### PR TITLE
Add BorrowedDevice management REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,20 @@ The Quarkus application configuration is located in `src/main/resources/applicat
 Easily start your Reactive RESTful Web Services
 
 [Related guide section...](https://quarkus.io/guides/getting-started-reactive#reactive-jax-rs-resources)
+
+## Borrowed Device API
+
+Manage devices borrowed by users.
+
+### Endpoints
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/users/{useruuid}/borroweddevices` | List borrowed devices for a user |
+| `POST` | `/users/{useruuid}/borroweddevices` | Create a borrowed device |
+| `PUT` | `/users/{useruuid}/borroweddevices` | Update an existing borrowed device |
+| `DELETE` | `/users/{useruuid}/borroweddevices/{uuid}` | Delete a borrowed device |
+
+### BorrowedDevice Fields
+
+`uuid`, `useruuid`, `type`, `description`, `serial`, `borrowedDate`, `returnedDate`

--- a/src/main/java/dk/trustworks/intranet/model/BorrowedDevice.java
+++ b/src/main/java/dk/trustworks/intranet/model/BorrowedDevice.java
@@ -1,0 +1,48 @@
+package dk.trustworks.intranet.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import dk.trustworks.intranet.model.enums.BorrowedDeviceType;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@Entity
+@Table(name = "borrowed_device")
+public class BorrowedDevice extends PanacheEntityBase {
+
+    @Id
+    private String uuid;
+
+    private String useruuid;
+
+    @Enumerated(EnumType.STRING)
+    private BorrowedDeviceType type;
+
+    private String description;
+
+    private String serial;
+
+    @Column(name = "borrowed_date")
+    @JsonSerialize(using = LocalDateSerializer.class)
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    private LocalDate borrowedDate;
+
+    @Column(name = "returned_date")
+    @JsonSerialize(using = LocalDateSerializer.class)
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    private LocalDate returnedDate;
+
+    @JsonIgnore
+    public boolean isReturned() {
+        return returnedDate != null;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/model/enums/BorrowedDeviceType.java
+++ b/src/main/java/dk/trustworks/intranet/model/enums/BorrowedDeviceType.java
@@ -1,0 +1,9 @@
+package dk.trustworks.intranet.model.enums;
+
+public enum BorrowedDeviceType {
+    LAPTOP,
+    PHONE,
+    ACCESS_CARD,
+    MFA_DEVICE,
+    OTHER
+}

--- a/src/main/java/dk/trustworks/intranet/resources/BorrowedDeviceResource.java
+++ b/src/main/java/dk/trustworks/intranet/resources/BorrowedDeviceResource.java
@@ -1,0 +1,54 @@
+package dk.trustworks.intranet.resources;
+
+import dk.trustworks.intranet.model.BorrowedDevice;
+import dk.trustworks.intranet.services.BorrowedDeviceService;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import lombok.extern.jbosslog.JBossLog;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+
+import java.util.List;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@JBossLog
+@ApplicationScoped
+@Path("/users/{useruuid}/borroweddevices")
+@RolesAllowed({"SYSTEM"})
+@SecurityRequirement(name = "jwt")
+@Produces(APPLICATION_JSON)
+@Consumes(APPLICATION_JSON)
+public class BorrowedDeviceResource {
+
+    @Inject
+    BorrowedDeviceService service;
+
+    @GET
+    public List<BorrowedDevice> list(@PathParam("useruuid") String useruuid) {
+        log.debugf("Listing borrowed devices for user %s", useruuid);
+        return service.findBorrowedDevices(useruuid);
+    }
+
+    @POST
+    public void create(@PathParam("useruuid") String useruuid, BorrowedDevice device) {
+        device.setUseruuid(useruuid);
+        log.debugf("Creating borrowed device %s", device);
+        service.save(device);
+    }
+
+    @PUT
+    public void update(@PathParam("useruuid") String useruuid, BorrowedDevice device) {
+        device.setUseruuid(useruuid);
+        log.debugf("Updating borrowed device %s", device);
+        service.update(device);
+    }
+
+    @DELETE
+    @Path("/{uuid}")
+    public void delete(@PathParam("uuid") String uuid) {
+        log.debugf("Deleting borrowed device %s", uuid);
+        service.delete(uuid);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/services/BorrowedDeviceService.java
+++ b/src/main/java/dk/trustworks/intranet/services/BorrowedDeviceService.java
@@ -1,0 +1,44 @@
+package dk.trustworks.intranet.services;
+
+import dk.trustworks.intranet.model.BorrowedDevice;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.jbosslog.JBossLog;
+
+@JBossLog
+@ApplicationScoped
+public class BorrowedDeviceService {
+
+    public List<BorrowedDevice> findBorrowedDevices(String useruuid) {
+        log.debugf("Fetching borrowed devices for user %s", useruuid);
+        return BorrowedDevice.find("useruuid", useruuid).list();
+    }
+
+    @Transactional
+    public void save(BorrowedDevice device) {
+        if (device.getUuid() == null) {
+            device.setUuid(UUID.randomUUID().toString());
+            log.debugf("Persisting new borrowed device %s", device);
+            BorrowedDevice.persist(device);
+        } else {
+            log.debugf("Device exists, updating %s", device);
+            update(device);
+        }
+    }
+
+    @Transactional
+    public void update(BorrowedDevice device) {
+        log.debugf("Updating borrowed device %s", device);
+        BorrowedDevice.update("useruuid = ?1, type = ?2, description = ?3, serial = ?4, borrowedDate = ?5, returnedDate = ?6 where uuid = ?7",
+                device.getUseruuid(), device.getType(), device.getDescription(), device.getSerial(),
+                device.getBorrowedDate(), device.getReturnedDate(), device.getUuid());
+    }
+
+    @Transactional
+    public void delete(String uuid) {
+        log.debugf("Deleting borrowed device %s", uuid);
+        BorrowedDevice.delete("uuid", uuid);
+    }
+}

--- a/src/main/resources/db/migration/V63__Create_borrowed_device_table.sql
+++ b/src/main/resources/db/migration/V63__Create_borrowed_device_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE borrowed_device (
+    uuid          VARCHAR(36)  NOT NULL PRIMARY KEY,
+    useruuid      VARCHAR(36)  NOT NULL,
+    type          VARCHAR(50)  NOT NULL,
+    description   VARCHAR(255) NULL,
+    serial        VARCHAR(255) NULL,
+    borrowed_date DATE         NOT NULL,
+    returned_date DATE         NULL,
+    CONSTRAINT borrowed_device_user_fk FOREIGN KEY (useruuid) REFERENCES user (uuid)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- add `BorrowedDevice` JPA entity and enum
- expose CRUD endpoints in `BorrowedDeviceResource`
- implement `BorrowedDeviceService`
- create Flyway migration to add new table
- document Borrowed Device API and add debug logging

## Testing
- `./mvnw -q test` *(fails: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain)*