### PR TITLE
Improve expense upload robustness and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@ Easily start your Reactive RESTful Web Services
 ## Borrowed Device API
 
 The `BorrowedDevice` endpoints manage devices lent to users. A new `clientuuid` field links a device to a client. Developers should include this property when creating or updating devices. See `docs/borroweddevice-client-update.md` for migration details.
+
+## Expense Processing
+
+The expense upload flow is documented in [docs/expense-processing.md](docs/expense-processing.md).

--- a/docs/expense-processing.md
+++ b/docs/expense-processing.md
@@ -1,0 +1,23 @@
+# Expense Processing Flow
+
+The expense service periodically scans the database for new receipts and uploads them to e‑conomics.
+This happens in the `ExpenseService.consumeCreate` scheduled job.
+
+## Status values
+
+Expenses move through a number of states while being processed.
+
+| Status | Meaning |
+|--------|---------|
+| `CREATED` | The expense has been received and stored. |
+| `PROCESSING` | The scheduled job has picked up the expense and is uploading it. |
+| `PROCESSED` | The upload succeeded and a voucher number is assigned. |
+| `NO_FILE` | No file was found in S3 for the expense. |
+| `NO_USER` | A user account in e‑conomics could not be found. |
+| `UP_FAILED` | Uploading to e‑conomics failed. |
+
+## Scheduled job
+
+Every five seconds the job looks for expenses with status `CREATED` that are older than two days and have a positive amount. Each expense is marked as `PROCESSING` before any remote calls are made. If an error occurs the status is updated accordingly so the row is not processed again automatically.
+
+Detailed logging has been added to `ExpenseService`, `ExpenseFileService` and `EconomicsService` to aid debugging of failed uploads.

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
@@ -41,6 +41,7 @@ public class  EconomicsService {
     UserService userService;
 
     public Response sendVoucher(Expense expense, ExpenseFile expensefile, UserAccount userAccount) throws IOException {
+        log.info("Sending voucher for expense " + expense.getUuid());
 
         IntegrationKey.IntegrationKeyValue result = getIntegrationKey(expense);
         log.info("Voucher target = " + result);
@@ -86,7 +87,7 @@ public class  EconomicsService {
     }
 
     public Response sendFile(Expense expense, ExpenseFile expensefile, Voucher voucher) throws IOException {
-        System.out.println("EconomicsService.sendFile");
+        log.info("Uploading file for expense " + expense.getUuid());
         // format accountingYear to URL output
         String year = voucher.getAccountingYear().getYear();
         String[] arrOfStr = year.split("/", 2);
@@ -102,7 +103,7 @@ public class  EconomicsService {
 
         // call e-conomics endpoint
         IntegrationKey.IntegrationKeyValue result = getIntegrationKey(expense);
-        System.out.println("File upload data = " + result);
+        log.info("File upload target = " + result);
         EconomicsAPI remoteApi = getEconomicsAPI(result);
 
         Response fileResponse = null;

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseFileService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseFileService.java
@@ -33,18 +33,25 @@ public class ExpenseFileService {
     S3Client s3 = S3Client.builder().region(regionNew).httpClientBuilder(httpClientBuilder).build();
 
     public PutObjectResponse saveFile(ExpenseFile expenseFile) {
-        return s3.putObject(PutObjectRequest.builder().bucket(bucketName).key(expenseFile.getUuid()).build(),
+        log.info("Uploading expense file to S3: " + expenseFile.getUuid());
+        PutObjectResponse response = s3.putObject(
+                PutObjectRequest.builder().bucket(bucketName).key(expenseFile.getUuid()).build(),
                 RequestBody.fromString(expenseFile.getExpensefile()));
+        log.info("S3 upload response: " + response);
+        return response;
     }
 
     public ExpenseFile getFileById(String uuid) throws S3Exception {
         ExpenseFile file = new ExpenseFile(uuid,"");
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try{
+            log.info("Downloading expense file from S3: " + uuid);
             s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(uuid).build(), ResponseTransformer.toOutputStream(baos));
 
             String str = baos.toString(StandardCharsets.UTF_8);
             file.setExpensefile(str);
+
+            log.info("Loaded expense file from S3: " + uuid);
 
         }  catch (S3Exception e) {
             log.error("Could not load file from S3", e.fillInStackTrace());

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseService.java
@@ -137,11 +137,12 @@ public class ExpenseService {
         }
     }
 
-    @Transactional(Transactional.TxType.REQUIRES_NEW)
     private void updateStatus(Expense expense, String status) {
-        expense.setStatus(status);
-        Expense.update("status = ?1, " + "vouchernumber = ?2 " + "WHERE uuid like ?3 ", expense.getStatus(), expense.getVouchernumber(), expense.getUuid());
-        log.info("Updated expense " + expense);
+        QuarkusTransaction.requiringNew().run(() -> {
+            expense.setStatus(status);
+            Expense.update("status = ?1, " + "vouchernumber = ?2 " + "WHERE uuid like ?3 ", expense.getStatus(), expense.getVouchernumber(), expense.getUuid());
+            log.info("Updated expense " + expense);
+        });
     }
 
     @Transactional


### PR DESCRIPTION
## Summary
- add documentation about expense processing
- document new expense status flow in README
- improve logging around AWS and e-conomics calls
- mark expenses as PROCESSING while uploading
- update status in its own transaction

## Testing
- `./mvnw -q test` *(fails: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain)*