### PR TITLE
Add conference text fields

### DIFF
--- a/docs/conference-fields.md
+++ b/docs/conference-fields.md
@@ -1,0 +1,12 @@
+# Conference Data Fields
+
+The `Conference` entity now exposes additional metadata fields. These values are stored in the database and returned by the `/knowledge/conferences` API.
+
+| Field | Description |
+|-------|-------------|
+| `description` | Optional description of the conference. |
+| `noteText` | Text shown on the registration form as a note. |
+| `consentText` | Text describing the consent given by the participant. |
+| `thanksText` | Text shown after successfully registering. |
+
+Database migrations are provided via Flyway to add these columns.

--- a/src/main/java/dk/trustworks/intranet/aggregates/conference/services/ConferenceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/conference/services/ConferenceService.java
@@ -20,15 +20,18 @@ public class ConferenceService {
     MailResource mailResource;
 
     public List<Conference> findAllConferences() {
+        log.debug("ConferenceService.findAllConferences");
         return Conference.listAll();
     }
 
     public Conference findConferenceBySlug(String slug) {
+        log.debug("ConferenceService.findConferenceBySlug: {}", slug);
         return Conference.<Conference>find("slug", slug).stream().findAny().orElse(null);
     }
 
     @Transactional
     public void createConference(Conference conference) {
+        log.info("ConferenceService.createConference: {}", conference.getName());
         conference.persist();
     }
 

--- a/src/main/java/dk/trustworks/intranet/aggregates/conference/services/ConferenceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/conference/services/ConferenceService.java
@@ -20,18 +20,18 @@ public class ConferenceService {
     MailResource mailResource;
 
     public List<Conference> findAllConferences() {
-        log.debug("ConferenceService.findAllConferences");
+        log.debugf("ConferenceService.findAllConferences");
         return Conference.listAll();
     }
 
     public Conference findConferenceBySlug(String slug) {
-        log.debug("ConferenceService.findConferenceBySlug: {}", slug);
+        log.debugf("ConferenceService.findConferenceBySlug: {}", slug);
         return Conference.<Conference>find("slug", slug).stream().findAny().orElse(null);
     }
 
     @Transactional
     public void createConference(Conference conference) {
-        log.info("ConferenceService.createConference: {}", conference.getName());
+        log.infof("ConferenceService.createConference: {}", conference.getName());
         conference.persist();
     }
 

--- a/src/main/java/dk/trustworks/intranet/knowledgeservice/model/Conference.java
+++ b/src/main/java/dk/trustworks/intranet/knowledgeservice/model/Conference.java
@@ -15,6 +15,13 @@ public class Conference extends PanacheEntityBase {
     private String name;
     private String slug;
     private boolean active;
+    private String description;
+    @Column(name = "note_text")
+    private String noteText;
+    @Column(name = "consent_text")
+    private String consentText;
+    @Column(name = "thanks_text")
+    private String thanksText;
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @JoinColumn(name = "conferenceuuid")
     private List<ConferencePhase> phases;

--- a/src/main/resources/db/migration/V65__Conference_add_text_fields.sql
+++ b/src/main/resources/db/migration/V65__Conference_add_text_fields.sql
@@ -1,6 +1,6 @@
 -- Add description and text columns to conferences table
 ALTER TABLE conferences
-    ADD COLUMN description VARCHAR(255) NULL AFTER active,
-    ADD COLUMN note_text VARCHAR(255) NULL AFTER description,
-    ADD COLUMN consent_text VARCHAR(255) NULL AFTER note_text,
-    ADD COLUMN thanks_text VARCHAR(255) NULL AFTER consent_text;
+    ADD COLUMN description TEXT NULL AFTER active,
+    ADD COLUMN note_text TEXT NULL AFTER description,
+    ADD COLUMN consent_text TEXT NULL AFTER note_text,
+    ADD COLUMN thanks_text TEXT NULL AFTER consent_text;

--- a/src/main/resources/db/migration/V65__Conference_add_text_fields.sql
+++ b/src/main/resources/db/migration/V65__Conference_add_text_fields.sql
@@ -1,0 +1,6 @@
+-- Add description and text columns to conferences table
+ALTER TABLE conferences
+    ADD COLUMN description VARCHAR(255) NULL AFTER active,
+    ADD COLUMN note_text VARCHAR(255) NULL AFTER description,
+    ADD COLUMN consent_text VARCHAR(255) NULL AFTER note_text,
+    ADD COLUMN thanks_text VARCHAR(255) NULL AFTER consent_text;


### PR DESCRIPTION
## Summary
- extend `Conference` entity with description and consent fields
- log activity in `ConferenceService`
- add flyway migration for new columns
- document new `Conference` fields

## Testing
- `./mvnw -q test` *(fails: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_b_68590fe4956083268d15d4bd327f3e34