### PR TITLE
Add Slack ID sync job

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,7 @@ The sorting options for invoices are documented in [docs/invoice-sorting.md](doc
 ## Guest Registration
 
 The guest registration endpoints are documented in [docs/guest-registration.md](docs/guest-registration.md).
+
+## Slack User Sync
+
+Slack user ids are synchronized nightly. Details in [docs/slack-user-sync.md](docs/slack-user-sync.md).

--- a/docs/slack-user-sync.md
+++ b/docs/slack-user-sync.md
@@ -1,0 +1,11 @@
+# Slack User Synchronization
+
+The `SlackUserSyncJob` links intranet users with their Slack accounts.
+It runs every night at 02:30 and performs the following steps:
+
+1. Look up all users where `slackusername` is empty.
+2. For each user, call Slack's `users.lookupByEmail` API using the admin bot token.
+3. If a Slack user is found the `slackusername` column is updated with the returned id.
+4. Users without a corresponding Slack account are skipped.
+
+Detailed logging is added to track how many users are processed and any lookup errors.

--- a/src/main/java/dk/trustworks/intranet/communicationsservice/services/SlackService.java
+++ b/src/main/java/dk/trustworks/intranet/communicationsservice/services/SlackService.java
@@ -4,6 +4,7 @@ import com.slack.api.Slack;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.response.chat.ChatPostMessageResponse;
 import com.slack.api.methods.response.conversations.*;
+import com.slack.api.methods.response.users.UsersLookupByEmailResponse;
 import dk.trustworks.intranet.userservice.model.User;
 import lombok.extern.jbosslog.JBossLog;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -97,6 +98,18 @@ public class SlackService {
         }
 
         return response.isOk();
+    }
+
+    public String findUserIdByEmail(String email) throws IOException, SlackApiException {
+        Slack slack = Slack.getInstance();
+        log.info("Looking up Slack user for email " + email);
+        UsersLookupByEmailResponse response = slack.methods(adminSlackBotToken)
+                .usersLookupByEmail(r -> r.email(email));
+        if (!response.isOk()) {
+            log.warn("Slack lookup failed for " + email + ": " + response.getError());
+            return null;
+        }
+        return response.getUser() != null ? response.getUser().getId() : null;
     }
 
 }

--- a/src/main/java/dk/trustworks/intranet/jobs/SlackUserSyncJob.java
+++ b/src/main/java/dk/trustworks/intranet/jobs/SlackUserSyncJob.java
@@ -1,0 +1,43 @@
+package dk.trustworks.intranet.jobs;
+
+import dk.trustworks.intranet.communicationsservice.services.SlackService;
+import dk.trustworks.intranet.userservice.model.User;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import lombok.extern.jbosslog.JBossLog;
+
+import java.util.List;
+
+@JBossLog
+@ApplicationScoped
+public class SlackUserSyncJob {
+
+    @Inject
+    SlackService slackService;
+
+    @Transactional
+    @Scheduled(cron = "0 30 2 * * ?")
+    public void syncSlackUserIds() {
+        log.info("Starting Slack user synchronization job");
+        List<User> users = User.list("slackusername is null or slackusername = ''");
+        log.info("Users missing Slack ID: " + users.size());
+        for (User user : users) {
+            try {
+                String slackId = slackService.findUserIdByEmail(user.getEmail());
+                if (slackId == null) {
+                    log.warn("No Slack account found for " + user.getEmail());
+                    continue;
+                }
+                QuarkusTransaction.requiringNew().run(() -> {
+                    User.update("slackusername = ?1 where uuid = ?2", slackId, user.uuid);
+                });
+                log.info("Updated Slack ID for " + user.getEmail() + " -> " + slackId);
+            } catch (Exception e) {
+                log.error("Failed syncing user " + user.getEmail() + ": " + e.getMessage(), e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add scheduled job to sync Slack user ids from email
- expand SlackService with email lookup helper
- document Slack user synchronization flow
- mention new job in README

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_685c3c7c4b8083268c32f440f6604ad5