### PR TITLE
Implement photo caching and resizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,7 @@ The guest registration endpoints are documented in [docs/guest-registration.md](
 ## Slack User Sync
 
 Slack user ids are synchronized nightly. Details in [docs/slack-user-sync.md](docs/slack-user-sync.md).
+
+## Photo Service
+
+Caching behaviour, S3 storage layout and dynamic resizing are described in [docs/photo-service.md](docs/photo-service.md).

--- a/docs/photo-service.md
+++ b/docs/photo-service.md
@@ -1,0 +1,7 @@
+# Photo Service Optimization
+
+Images are cached after the first retrieval from S3. Subsequent requests for the same UUID avoid an S3 round-trip.
+
+The `/files/photos/{uuid}/jpg` endpoint accepts an optional `width` query parameter. When provided the photo is resized using Claid before being returned.
+
+Resized images are looked up in S3 using the key `resized/{width}/{uuid}`. If not present a new one is generated, returned to the caller and stored asynchronously back to S3. Both original and resized images are cached in memory for fast repeated access.

--- a/src/main/java/dk/trustworks/intranet/apigateway/resources/FileResource.java
+++ b/src/main/java/dk/trustworks/intranet/apigateway/resources/FileResource.java
@@ -9,6 +9,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Response;
+import lombok.extern.jbosslog.JBossLog;
 
 import java.io.IOException;
 import java.util.List;
@@ -20,6 +21,7 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 @Produces(APPLICATION_JSON)
 @Consumes(APPLICATION_JSON)
 @RolesAllowed({"SYSTEM"})
+@JBossLog
 public class FileResource {
 
     @Inject
@@ -40,8 +42,14 @@ public class FileResource {
     @GET
     @Path("/photos/{relateduuid}/jpg")
     @Produces("image/webp")
-    public Response getImage(@PathParam("relateduuid") String relateduuid) {
-        byte[] imageBytes = photoService.findPhotoByRelatedUUID(relateduuid).getFile(); // get the byte array for the image
+    public Response getImage(@PathParam("relateduuid") String relateduuid, @QueryParam("width") Integer width) {
+        log.debug("Fetching photo " + relateduuid + (width != null ? " width=" + width : ""));
+        byte[] imageBytes;
+        if(width != null) {
+            imageBytes = photoService.getResizedPhoto(relateduuid, width);
+        } else {
+            imageBytes = photoService.findPhotoByRelatedUUID(relateduuid).getFile();
+        }
         return Response.ok(imageBytes).build();
     }
 


### PR DESCRIPTION
## Summary
- cache loaded photos to speed up S3 access
- add optional width parameter for photo download and resize using Claid
- log retrieval and resizing actions
- document photo service behaviour
- persist resized images in S3 with prefix and save them asynchronously

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_685e47c1a22483269161173b7ab0fe8d