### PR TITLE
Improve voucher error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,8 @@ The centralized request logging and the `/api-usage-logs` endpoint are described
 in [docs/api-usage-logging.md](docs/api-usage-logging.md). Client developers can
 learn how to query the log API in
 [docs/api-usage-log-client-guide.md](docs/api-usage-log-client-guide.md).
+
+## Voucher Upload Errors
+
+Information about the new voucher upload error logging can be found in
+[docs/voucher-upload-error-logging.md](docs/voucher-upload-error-logging.md).

--- a/docs/voucher-upload-error-logging.md
+++ b/docs/voucher-upload-error-logging.md
@@ -1,0 +1,8 @@
+# Voucher Upload Error Logging
+
+Errors returned by the e-conomics API when posting an invoice voucher are now
+logged with additional detail.
+
+`EconomicsInvoiceService.sendVoucher` writes the HTTP status code and response
+body if the call fails. The stack trace is preserved using
+`log.error("Failed to send voucher", e)`.

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -62,11 +62,12 @@ public class EconomicsInvoiceService {
                 log.info("voucher posted successfully to e-conomics. Invoiceuuid: " + invoice.getUuid() + ", voucher: " + voucher + ", voucherNumber: " + voucherNumber);
                 return sendFile(invoice, voucher, voucherNumber);
             } else {
-                log.error("voucher not posted successfully to e-conomics. Invoiceuuid: " + invoice.getUuid() + ", voucher: " + voucher + ", response: " + response);
+                String errorBody = response.readEntity(String.class);
+                log.error("voucher not posted successfully to e-conomics. Invoiceuuid: " + invoice.getUuid() + ", voucher: " + voucher + ", status: " + response.getStatus() + ", body: " + errorBody);
                 return response;
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Failed to send voucher", e);
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
## Summary
- log failed voucher posting responses including status code and body
- log exceptions using JBoss logger
- document voucher upload error logging
- link new doc from README

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6864271cad288326a4938f3527db5edc