### PR TITLE
Fix username logging bug

### DIFF
--- a/docs/api-usage-logging.md
+++ b/docs/api-usage-logging.md
@@ -1,6 +1,7 @@
 # API Usage Logging
 
 The `ApiUsageLoggingFilter` records every REST request. It logs the HTTP method, the request path and the username resolved by `HeaderInterceptor`.
+When neither an `X-Requested-By` header nor a JWT token is present, the interceptor attempts to read a `username` query parameter. If no identifier can be found, the username `anonymous` is used.
 
 To correlate multiple requests used to build the same page, the filter also logs the `Referer` header when present. Frontend clients may instead send an `X-View-Id` header to explicitly group requests belonging to a single view.
 

--- a/src/main/java/dk/trustworks/intranet/logging/ApiUsageLogService.java
+++ b/src/main/java/dk/trustworks/intranet/logging/ApiUsageLogService.java
@@ -19,6 +19,10 @@ public class ApiUsageLogService {
 
     @Transactional
     public void record(String username, String method, String path, String viewId, long duration) {
+        if (username == null || username.isEmpty()) {
+            log.debug("Username missing when recording API usage; defaulting to anonymous");
+            username = "anonymous";
+        }
         log.debugf("record user=%s method=%s path=%s viewId=%s duration=%dms", username, method, path, viewId, duration);
         ApiUsageLog logEntry = new ApiUsageLog();
         logEntry.setTimestamp(LocalDateTime.now());

--- a/src/main/java/dk/trustworks/intranet/security/HeaderInterceptor.java
+++ b/src/main/java/dk/trustworks/intranet/security/HeaderInterceptor.java
@@ -1,20 +1,26 @@
 package dk.trustworks.intranet.security;
 
 import org.eclipse.microprofile.jwt.JsonWebToken;
+import lombok.extern.jbosslog.JBossLog;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.Provider;
 import java.io.IOException;
 
+@JBossLog
 @Provider
 public class HeaderInterceptor implements ContainerRequestFilter {
 
     @Context
     HttpHeaders headers;
+
+    @Context
+    UriInfo uriInfo;
 
     @Inject
     JsonWebToken jwt;
@@ -25,11 +31,20 @@ public class HeaderInterceptor implements ContainerRequestFilter {
     @Override
     public void filter(ContainerRequestContext context) throws IOException {
         String requestedBy = context.getHeaders().getFirst("X-Requested-By");
-
         if (requestedBy == null || requestedBy.isEmpty()) {
             requestedBy = jwt.getClaim("preferred_username");
+            if (requestedBy != null) log.debugf("Username resolved from JWT: %s", requestedBy);
+        }
+        if (requestedBy == null || requestedBy.isEmpty()) {
+            requestedBy = uriInfo.getQueryParameters().getFirst("username");
+            if (requestedBy != null) log.debugf("Username resolved from query param: %s", requestedBy);
+        }
+        if (requestedBy == null || requestedBy.isEmpty()) {
+            requestedBy = "anonymous";
+            log.debug("Username not found in request; defaulting to anonymous");
         }
 
         requestHeaderHolder.setUsername(requestedBy);
+        log.debugf("Request username set to %s", requestedBy);
     }
 }


### PR DESCRIPTION
## Summary
- default username to `anonymous` when header, JWT and query parameter are missing
- log username resolution steps in `HeaderInterceptor`
- guard against empty username in `ApiUsageLogService`
- document anonymous fallback in API usage logging docs

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68654c37a48c8326b154184b5fd51f72