### PR TITLE
Implement app membership resource methods

### DIFF
--- a/docs/app-membership.md
+++ b/docs/app-membership.md
@@ -1,0 +1,28 @@
+# App Membership API
+
+The `/apps` resource now exposes endpoints for managing users in an application.
+All requests require authentication via the `Authorization` header.
+
+## Listing Apps with Paging
+
+```bash
+GET /apps?user=<userUuid>&page=0&size=50
+```
+
+Returns page `0` with up to `50` apps for the given user. Use
+`GET /apps/count?user=<userUuid>` to retrieve the total number of apps.
+
+## Managing Members
+
+```bash
+GET    /apps/{appUuid}/members
+POST   /apps/{appUuid}/members/{userUuid}
+PUT    /apps/{appUuid}/members/{userUuid}?role=APP_ADMIN
+DELETE /apps/{appUuid}/members/{userUuid}
+```
+
+These endpoints list, add, update and remove members. Roles are `APP_ADMIN` or
+`APP_MEMBER`.
+
+Debug and info log statements in `AppResource` and `AppService` describe each
+operation.

--- a/src/main/java/dk/trustworks/intranet/apigateway/resources/AppResource.java
+++ b/src/main/java/dk/trustworks/intranet/apigateway/resources/AppResource.java
@@ -1,6 +1,8 @@
 package dk.trustworks.intranet.apigateway.resources;
 
 import dk.trustworks.intranet.appplatform.model.App;
+import dk.trustworks.intranet.appplatform.model.AppMember;
+import dk.trustworks.intranet.appplatform.model.AppRole;
 import dk.trustworks.intranet.appplatform.services.AppService;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.enterprise.context.RequestScoped;
@@ -34,9 +36,21 @@ public class AppResource {
     }
 
     @GET
-    public List<App> listApps(@QueryParam("user") String userUuid) {
-        log.debug("Listing apps for user=" + userUuid);
+    public List<App> listApps(@QueryParam("user") String userUuid,
+                              @QueryParam("page") @DefaultValue("0") int page,
+                              @QueryParam("size") @DefaultValue("50") int size) {
+        log.debug("Listing apps for user=" + userUuid + " page=" + page + " size=" + size);
+        if(page >= 0 && size > 0) {
+            return appService.listAppsForUser(userUuid, page, size);
+        }
         return appService.listAppsForUser(userUuid);
+    }
+
+    @GET
+    @Path("/count")
+    public long countApps(@QueryParam("user") String userUuid) {
+        log.debug("Counting apps for user=" + userUuid);
+        return appService.countAppsForUser(userUuid);
     }
 
     @POST
@@ -56,5 +70,42 @@ public class AppResource {
     public void revoke(@PathParam("token") String tokenId) {
         log.info("Revoking token " + tokenId);
         appService.revokeToken(tokenId);
+    }
+
+    @GET
+    @Path("/{app}/members")
+    @RolesAllowed({"DEVELOPER","APP_ADMIN"})
+    public List<AppMember> listMembers(@PathParam("app") String appUuid) {
+        log.debug("Listing members for app=" + appUuid);
+        return appService.listMembers(appUuid);
+    }
+
+    @POST
+    @Path("/{app}/members/{user}")
+    @Transactional
+    @RolesAllowed({"DEVELOPER","APP_ADMIN"})
+    public void addMember(@PathParam("app") String appUuid, @PathParam("user") String userUuid) {
+        log.info("Adding member " + userUuid + " to app " + appUuid);
+        appService.addMember(appUuid, userUuid);
+    }
+
+    @PUT
+    @Path("/{app}/members/{user}")
+    @Transactional
+    @RolesAllowed({"DEVELOPER","APP_ADMIN"})
+    public void changeRole(@PathParam("app") String appUuid,
+                           @PathParam("user") String userUuid,
+                           @QueryParam("role") String role) {
+        log.info("Changing role for user=" + userUuid + " to " + role + " in app=" + appUuid);
+        appService.changeRole(appUuid, userUuid, AppRole.valueOf(role));
+    }
+
+    @DELETE
+    @Path("/{app}/members/{user}")
+    @Transactional
+    @RolesAllowed({"DEVELOPER","APP_ADMIN"})
+    public void removeMember(@PathParam("app") String appUuid, @PathParam("user") String userUuid) {
+        log.info("Removing member " + userUuid + " from app " + appUuid);
+        appService.removeMember(appUuid, userUuid);
     }
 }

--- a/src/main/java/dk/trustworks/intranet/appplatform/model/AppMember.java
+++ b/src/main/java/dk/trustworks/intranet/appplatform/model/AppMember.java
@@ -1,0 +1,19 @@
+package dk.trustworks.intranet.appplatform.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a user membership in an application.
+ */
+@Data
+@NoArgsConstructor
+public class AppMember {
+    private String userUuid;
+    private AppRole role;
+
+    public AppMember(String userUuid, AppRole role) {
+        this.userUuid = userUuid;
+        this.role = role;
+    }
+}


### PR DESCRIPTION
## Summary
- extend AppService with pagination, member management and counting
- update AppResource with new endpoints and logging
- add simple `AppMember` DTO
- document the app membership API

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6868298a5e108326a065449b3a0fa08d