### PR TITLE
Fix accounting year naming

### DIFF
--- a/docs/accounting-year-naming.md
+++ b/docs/accounting-year-naming.md
@@ -1,0 +1,9 @@
+# Handling Custom Accounting Year Names
+
+E‑conomics occasionally uses custom names for accounting years. In 2025/2026 the
+accountant created the year as `2025/2026a`. The expense and invoice services
+now derive the year label using `DateUtils.getFiscalYearName`, which applies
+configured overrides before posting vouchers.
+
+The default name is `YYYY/YYYY+1`, but the method maps `2025/2026` to
+`2025/2026a`. Future years follow the original naming convention.

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -112,10 +112,9 @@ public class EconomicsInvoiceService {
         log.debug("contraAccount = " + contraAccount.getAccountNumber());
         ExpenseAccount account = new ExpenseAccount(integrationKeyValue.invoiceAccountNumber());
         log.debug("account = " + account.getAccountNumber());
-        String s = DateUtils.getFiscalStartDateBasedOnDate(invoice.getInvoicedate()).getYear() + "/" + DateUtils.getFiscalStartDateBasedOnDate(invoice.getInvoicedate()).plusYears(1).getYear();
-        log.debug("s = " + s);
-        AccountingYear accountingYear = new AccountingYear(s);//new AccountingYear(DateUtils.getCurrentFiscalStartDate().getYear()+"/"+DateUtils.getCurrentFiscalStartDate().plusYears(1).getYear());
-        log.debug("accountingYear = " + accountingYear.getYear());
+        String fiscalYearName = DateUtils.getFiscalYearName(DateUtils.getFiscalStartDateBasedOnDate(invoice.getInvoicedate()));
+        AccountingYear accountingYear = new AccountingYear(fiscalYearName);
+        log.debug("Using accounting year " + accountingYear.getYear());
 
         String date = DateUtils.stringIt(invoice.getInvoicedate());
 

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
@@ -141,7 +141,9 @@ public class  EconomicsService {
 
         ContraAccount contraAccount = new ContraAccount(userAccount.getEconomics());
         ExpenseAccount expenseaccount = new ExpenseAccount(Integer.parseInt(expense.getAccount()));
-        AccountingYear accountingYear = new AccountingYear(DateUtils.getCurrentFiscalStartDate().getYear()+"/"+DateUtils.getCurrentFiscalStartDate().plusYears(1).getYear());
+        String fiscalYearName = DateUtils.getFiscalYearName(DateUtils.getCurrentFiscalStartDate());
+        AccountingYear accountingYear = new AccountingYear(fiscalYearName);
+        log.debug("Using accounting year " + fiscalYearName);
 
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         String date = dateFormat.format(new Date());

--- a/src/main/java/dk/trustworks/intranet/utils/DateUtils.java
+++ b/src/main/java/dk/trustworks/intranet/utils/DateUtils.java
@@ -9,11 +9,29 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.HashMap;
+
+import org.jboss.logging.Logger;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.time.temporal.ChronoUnit.MONTHS;
 
 public final class DateUtils {
+
+    private static final Logger log = Logger.getLogger(DateUtils.class);
+
+    /**
+     * Overrides for fiscal year names when e-conomic uses custom labels.
+     * Key is the default fiscal year string (e.g. "2025/2026") and value is the
+     * actual name in e-conomic (e.g. "2025/2026a").
+     */
+    private static final Map<String, String> FISCAL_YEAR_OVERRIDES = new HashMap<>();
+
+    static {
+        FISCAL_YEAR_OVERRIDES.put("2025/2026", "2025/2026a");
+    }
+
 
     private DateUtils() {
     }
@@ -272,6 +290,21 @@ public final class DateUtils {
 
     public static LocalDate getFiscalStartDateBasedOnDate(LocalDate date) {
         return (date.getMonthValue()>6 && date.getMonthValue()<13)?date.withMonth(7).withDayOfMonth(1):date.minusYears(1).withMonth(7).withDayOfMonth(1);
+    }
+
+    /**
+     * Returns the accounting year label used in e-conomic for the given fiscal
+     * start date. Normally this is "YYYY/YYYY+1", but certain years may have
+     * custom suffixes.
+     *
+     * @param fiscalStartDate start of the fiscal year
+     * @return formatted accounting year string
+     */
+    public static String getFiscalYearName(LocalDate fiscalStartDate) {
+        String base = fiscalStartDate.getYear() + "/" + fiscalStartDate.plusYears(1).getYear();
+        String result = FISCAL_YEAR_OVERRIDES.getOrDefault(base, base);
+        log.debug("Mapping fiscal year '" + base + "' to '" + result + "'");
+        return result;
     }
 
     public static LocalDate getTwentieth(LocalDate date) {


### PR DESCRIPTION
## Summary
- handle custom accounting year names via DateUtils
- use new fiscal year name helper in expense and invoice services
- document accounting year naming workaround

## Testing
- `mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_688ca17325548326b3115ee9c81a759f