### PR TITLE
Handle company-specific accounting year naming

### DIFF
--- a/docs/accounting-year-naming.md
+++ b/docs/accounting-year-naming.md
@@ -1,9 +1,11 @@
 # Handling Custom Accounting Year Names
 
 E‑conomics occasionally uses custom names for accounting years. In 2025/2026 the
-accountant created the year as `2025/2026a`. The expense and invoice services
-now derive the year label using `DateUtils.getFiscalYearName`, which applies
-configured overrides before posting vouchers.
+accountant created the year as `2025/2026a` for the Trustworks company
+(`d8894494-2fb4-4f72-9e05-e6032e6dd691`). The expense and invoice services now
+derive the year label using `DateUtils.getFiscalYearName(startDate, companyUuid)`,
+which applies company-specific overrides before posting vouchers.
 
-The default name is `YYYY/YYYY+1`, but the method maps `2025/2026` to
-`2025/2026a`. Future years follow the original naming convention.
+The default name is `YYYY/YYYY+1`. Only the Trustworks company maps `2025/2026`
+to `2025/2026a`. All other companies use the default name and future years
+follow the original naming convention.

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -9,6 +9,7 @@ import dk.trustworks.intranet.financeservice.remote.EconomicsDynamicHeaderFilter
 import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
 import dk.trustworks.intranet.aggregates.invoice.utils.StringUtils;
 import dk.trustworks.intranet.utils.DateUtils;
+import dk.trustworks.intranet.model.Company;
 import lombok.extern.jbosslog.JBossLog;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;
@@ -112,9 +113,12 @@ public class EconomicsInvoiceService {
         log.debug("contraAccount = " + contraAccount.getAccountNumber());
         ExpenseAccount account = new ExpenseAccount(integrationKeyValue.invoiceAccountNumber());
         log.debug("account = " + account.getAccountNumber());
-        String fiscalYearName = DateUtils.getFiscalYearName(DateUtils.getFiscalStartDateBasedOnDate(invoice.getInvoicedate()));
+        Company company = invoice.getCompany();
+        String fiscalYearName = DateUtils.getFiscalYearName(
+                DateUtils.getFiscalStartDateBasedOnDate(invoice.getInvoicedate()),
+                company.getUuid());
         AccountingYear accountingYear = new AccountingYear(fiscalYearName);
-        log.debug("Using accounting year " + accountingYear.getYear());
+        log.debug("Using accounting year " + accountingYear.getYear() + " for company " + company.getUuid());
 
         String date = DateUtils.stringIt(invoice.getInvoicedate());
 

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
@@ -141,9 +141,10 @@ public class  EconomicsService {
 
         ContraAccount contraAccount = new ContraAccount(userAccount.getEconomics());
         ExpenseAccount expenseaccount = new ExpenseAccount(Integer.parseInt(expense.getAccount()));
-        String fiscalYearName = DateUtils.getFiscalYearName(DateUtils.getCurrentFiscalStartDate());
+        Company company = getCompanyFromExpense(expense);
+        String fiscalYearName = DateUtils.getFiscalYearName(DateUtils.getCurrentFiscalStartDate(), company.getUuid());
         AccountingYear accountingYear = new AccountingYear(fiscalYearName);
-        log.debug("Using accounting year " + fiscalYearName);
+        log.debug("Using accounting year " + fiscalYearName + " for company " + company.getUuid());
 
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         String date = dateFormat.format(new Date());


### PR DESCRIPTION
## Summary
- support company-specific fiscal year overrides so Trustworks uses `2025/2026a`
- use company-specific fiscal year when building expense and invoice vouchers
- document how accounting year overrides are applied

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6891ed76d7b88326907afbe1b7ac8867