### PR TITLE
Handle company-specific fiscal year naming

### DIFF
--- a/docs/accounting-year-naming.md
+++ b/docs/accounting-year-naming.md
@@ -1,9 +1,12 @@
 # Handling Custom Accounting Year Names
 
 E‑conomics occasionally uses custom names for accounting years. In 2025/2026 the
-accountant created the year as `2025/2026a`. The expense and invoice services
-now derive the year label using `DateUtils.getFiscalYearName`, which applies
-configured overrides before posting vouchers.
+accountant created the year as `2025/2026a` for the company with UUID
+`d8894494-2fb4-4f72-9e05-e6032e6dd691`. The expense and invoice services now
+derive the year label using `DateUtils.getFiscalYearName`, which applies
+company‑specific overrides before posting vouchers.
 
-The default name is `YYYY/YYYY+1`, but the method maps `2025/2026` to
-`2025/2026a`. Future years follow the original naming convention.
+The default name is `YYYY/YYYY+1`. For the company mentioned above the method
+maps `2025/2026` to `2025/2026a`, while all other companies use the default.
+Future years follow the original naming convention unless new overrides are
+added.

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -112,9 +112,11 @@ public class EconomicsInvoiceService {
         log.debug("contraAccount = " + contraAccount.getAccountNumber());
         ExpenseAccount account = new ExpenseAccount(integrationKeyValue.invoiceAccountNumber());
         log.debug("account = " + account.getAccountNumber());
-        String fiscalYearName = DateUtils.getFiscalYearName(DateUtils.getFiscalStartDateBasedOnDate(invoice.getInvoicedate()));
+        String fiscalYearName = DateUtils.getFiscalYearName(
+                DateUtils.getFiscalStartDateBasedOnDate(invoice.getInvoicedate()),
+                invoice.getCompany().getUuid());
         AccountingYear accountingYear = new AccountingYear(fiscalYearName);
-        log.debug("Using accounting year " + accountingYear.getYear());
+        log.debug("Using accounting year " + accountingYear.getYear() + " for company " + invoice.getCompany().getUuid());
 
         String date = DateUtils.stringIt(invoice.getInvoicedate());
 

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
@@ -141,9 +141,10 @@ public class  EconomicsService {
 
         ContraAccount contraAccount = new ContraAccount(userAccount.getEconomics());
         ExpenseAccount expenseaccount = new ExpenseAccount(Integer.parseInt(expense.getAccount()));
-        String fiscalYearName = DateUtils.getFiscalYearName(DateUtils.getCurrentFiscalStartDate());
+        Company company = getCompanyFromExpense(expense);
+        String fiscalYearName = DateUtils.getFiscalYearName(DateUtils.getCurrentFiscalStartDate(), company.getUuid());
         AccountingYear accountingYear = new AccountingYear(fiscalYearName);
-        log.debug("Using accounting year " + fiscalYearName);
+        log.debug("Using accounting year " + fiscalYearName + " for company " + company.getUuid());
 
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         String date = dateFormat.format(new Date());


### PR DESCRIPTION
## Summary
- support per-company overrides for fiscal year labels
- use company-aware fiscal year naming for expenses and invoices
- document e-conomic accounting year override

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_689231da837483269a197f10944be2fd