### PR TITLE
feat: invoice-consultant revenue attribution

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/ConsultantInsightsService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/ConsultantInsightsService.java
@@ -422,21 +422,20 @@ public class ConsultantInsightsService {
             ) sal
             JOIN user u ON u.uuid = sal.useruuid
             LEFT JOIN (
-                SELECT ii.consultantuuid AS useruuid,
-                       SUM(ii.rate * ii.hours
+                SELECT iia.consultant_uuid AS useruuid,
+                       SUM(iia.attributed_amount
                            * CASE WHEN i.type = 'CREDIT_NOTE' THEN -1 ELSE 1 END
                            * CASE WHEN i.currency = 'DKK' THEN 1
                                   ELSE COALESCE(cur.conversion, 1) END) AS ttm_revenue
-                FROM invoiceitems ii
+                FROM invoice_item_attributions iia
+                JOIN invoiceitems ii ON iia.invoiceitem_uuid = ii.uuid
                 JOIN invoices i ON ii.invoiceuuid = i.uuid
                 LEFT JOIN currences cur ON cur.currency = i.currency
                     AND cur.month = DATE_FORMAT(i.invoicedate, '%Y%m')
                 WHERE i.status = 'CREATED'
                   AND i.type IN ('INVOICE', 'PHANTOM', 'CREDIT_NOTE')
-                  AND ii.rate IS NOT NULL AND ii.hours IS NOT NULL
-                  AND ii.consultantuuid IS NOT NULL
                   AND i.invoicedate >= :periodFrom AND i.invoicedate < :periodTo
-                GROUP BY ii.consultantuuid
+                GROUP BY iia.consultant_uuid
             ) rev ON rev.useruuid = sal.useruuid
             WHERE u.practice IN (:practices)
               AND EXISTS (

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/InvoiceGenerator.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/InvoiceGenerator.java
@@ -21,6 +21,7 @@ import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
 import dk.trustworks.intranet.aggregates.invoice.model.InvoiceItem;
 import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceStatus;
 import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceType;
+import dk.trustworks.intranet.aggregates.invoice.services.InvoiceAttributionService;
 import dk.trustworks.intranet.aggregates.invoice.services.InvoiceService;
 import dk.trustworks.intranet.domain.user.entity.User;
 import dk.trustworks.intranet.utils.DateUtils;
@@ -62,6 +63,9 @@ public class InvoiceGenerator {
 
     @Inject
     TaskService taskService;
+
+    @Inject
+    InvoiceAttributionService invoiceAttributionService;
 
     @Inject
     WorkService workService;
@@ -298,6 +302,7 @@ public class InvoiceGenerator {
         // Invoke pricing to add CALCULATED lines immediately
         Invoice priced = invoiceService.updateDraftInvoice(created);
         log.info("Priced draft invoice: " + priced.getUuid());
+        invoiceAttributionService.computeAttributions(priced.uuid);
         return created;
     }
 

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/InvoiceItemAttribution.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/InvoiceItemAttribution.java
@@ -1,0 +1,79 @@
+package dk.trustworks.intranet.aggregates.invoice.model;
+
+import dk.trustworks.intranet.aggregates.invoice.model.enums.AttributionSource;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "invoice_item_attributions")
+public class InvoiceItemAttribution extends PanacheEntityBase {
+
+    @Id
+    public String uuid;
+
+    @Column(name = "invoiceitem_uuid")
+    public String invoiceitemUuid;
+
+    @Column(name = "consultant_uuid")
+    public String consultantUuid;
+
+    @Column(name = "share_pct")
+    public BigDecimal sharePct;
+
+    @Column(name = "attributed_amount")
+    public BigDecimal attributedAmount;
+
+    @Column(name = "original_hours")
+    public BigDecimal originalHours;
+
+    @Enumerated(EnumType.STRING)
+    public AttributionSource source;
+
+    @Column(name = "created_at", updatable = false)
+    public LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    public LocalDateTime updatedAt;
+
+    public InvoiceItemAttribution() {
+    }
+
+    public InvoiceItemAttribution(String invoiceitemUuid,
+                                  String consultantUuid,
+                                  BigDecimal sharePct,
+                                  BigDecimal attributedAmount,
+                                  BigDecimal originalHours,
+                                  AttributionSource source) {
+        this.uuid = UUID.randomUUID().toString();
+        this.invoiceitemUuid = invoiceitemUuid;
+        this.consultantUuid = consultantUuid;
+        this.sharePct = sharePct;
+        this.attributedAmount = attributedAmount;
+        this.originalHours = originalHours;
+        this.source = source;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * Recalculates attributedAmount as sharePct% of itemTotal.
+     * Uses HALF_UP rounding, scale 2.
+     *
+     * @param itemTotal the total value of the invoice item
+     */
+    public void recalculateAmount(double itemTotal) {
+        BigDecimal total = BigDecimal.valueOf(itemTotal);
+        this.attributedAmount = sharePct
+                .multiply(total)
+                .divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/enums/AttributionSource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/enums/AttributionSource.java
@@ -1,0 +1,6 @@
+package dk.trustworks.intranet.aggregates.invoice.model.enums;
+
+public enum AttributionSource {
+    AUTO,
+    MANUAL
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/resources/InvoiceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/resources/InvoiceResource.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import dk.trustworks.intranet.aggregates.invoice.InvoiceGenerator;
 import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
 import dk.trustworks.intranet.aggregates.invoice.model.InvoiceControlHistory;
+import dk.trustworks.intranet.aggregates.invoice.model.InvoiceItemAttribution;
 import dk.trustworks.intranet.aggregates.invoice.model.InvoiceNote;
 import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceStatus;
 import dk.trustworks.intranet.aggregates.invoice.resources.dto.*;
+import dk.trustworks.intranet.aggregates.invoice.services.InvoiceAttributionService;
 import dk.trustworks.intranet.aggregates.invoice.services.InternalInvoiceControllingService;
 import dk.trustworks.intranet.aggregates.invoice.services.InvoiceLedgerService;
 import dk.trustworks.intranet.security.ScopeContext;
@@ -71,6 +73,9 @@ public class InvoiceResource {
 
     @Inject
     ScopeContext scopeContext;
+
+    @Inject
+    InvoiceAttributionService invoiceAttributionService;
 
     @GET
     public List<Invoice> list(@QueryParam("fromdate") String fromdate,
@@ -973,6 +978,64 @@ public class InvoiceResource {
                 "uuid", invoice.uuid,
                 "internalInvoiceSkip", false
         )).build();
+    }
+
+    // ── Attribution endpoints ─────────────────────────────────────────────
+
+    @GET
+    @Path("/{invoiceuuid}/attributions")
+    public List<InvoiceItemAttribution> getInvoiceAttributions(@PathParam("invoiceuuid") String invoiceuuid) {
+        return invoiceAttributionService.getInvoiceAttributions(invoiceuuid);
+    }
+
+    @GET
+    @Path("/{invoiceuuid}/items/{itemuuid}/attributions")
+    public List<InvoiceItemAttribution> getItemAttributions(
+            @PathParam("invoiceuuid") String invoiceuuid,
+            @PathParam("itemuuid") String itemuuid) {
+        return invoiceAttributionService.getAttributions(itemuuid);
+    }
+
+    @PUT
+    @Path("/{invoiceuuid}/items/{itemuuid}/attributions")
+    @RolesAllowed({"invoices:write"})
+    public void setItemAttributions(
+            @PathParam("invoiceuuid") String invoiceuuid,
+            @PathParam("itemuuid") String itemuuid,
+            List<InvoiceAttributionService.ManualAttributionInput> attributions) {
+        invoiceAttributionService.setManualAttribution(itemuuid, attributions);
+    }
+
+    @POST
+    @Path("/{invoiceuuid}/items/{itemuuid}/attributions/reset")
+    @RolesAllowed({"invoices:write"})
+    public void resetItemAttributions(
+            @PathParam("invoiceuuid") String invoiceuuid,
+            @PathParam("itemuuid") String itemuuid) {
+        invoiceAttributionService.resetToAuto(itemuuid);
+    }
+
+    @POST
+    @Path("/attributions/backfill")
+    @RolesAllowed({"admin:full"})
+    public Map<String, Object> backfillAttributions(
+            @QueryParam("from") String from,
+            @QueryParam("to") String to) {
+        LocalDate fromDate = LocalDate.parse(from);
+        LocalDate toDate = LocalDate.parse(to);
+        int count = invoiceAttributionService.backfillRange(fromDate, toDate);
+        return Map.of("processed", count);
+    }
+
+    @GET
+    @Path("/attributions/unattributed")
+    @RolesAllowed({"invoices:read"})
+    public List<Map<String, Object>> getUnattributedItems(
+            @QueryParam("from") String from,
+            @QueryParam("to") String to) {
+        LocalDate fromDate = LocalDate.parse(from);
+        LocalDate toDate = LocalDate.parse(to);
+        return invoiceAttributionService.findUnattributedItems(fromDate, toDate);
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceAttributionService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceAttributionService.java
@@ -1,0 +1,578 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
+import dk.trustworks.intranet.aggregates.invoice.model.InvoiceItem;
+import dk.trustworks.intranet.aggregates.invoice.model.InvoiceItemAttribution;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.AttributionSource;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceItemOrigin;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceStatus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import lombok.extern.jbosslog.JBossLog;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@JBossLog
+@ApplicationScoped
+public class InvoiceAttributionService {
+
+    private static final int PCT_SCALE = 4;
+    private static final int AMT_SCALE = 2;
+
+    @Inject
+    EntityManager em;
+
+    // ── Public query methods ──────────────────────────────────────────
+
+    public List<InvoiceItemAttribution> getAttributions(String invoiceItemUuid) {
+        return InvoiceItemAttribution.list("invoiceitemUuid", invoiceItemUuid);
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<InvoiceItemAttribution> getInvoiceAttributions(String invoiceUuid) {
+        return em.createNativeQuery("""
+                        SELECT iia.* FROM invoice_item_attributions iia
+                        JOIN invoiceitems ii ON iia.invoiceitem_uuid = ii.uuid
+                        WHERE ii.invoiceuuid = :invoiceUuid
+                        ORDER BY ii.position, iia.share_pct DESC
+                        """, InvoiceItemAttribution.class)
+                .setParameter("invoiceUuid", invoiceUuid)
+                .getResultList();
+    }
+
+    // ── Core attribution computation ──────────────────────────────────
+
+    @Transactional
+    public void computeAttributions(String invoiceUuid) {
+        Invoice invoice = Invoice.findById(invoiceUuid);
+        if (invoice == null) {
+            log.warnf("computeAttributions: invoice not found uuid=%s", invoiceUuid);
+            return;
+        }
+
+        List<InvoiceItem> baseItems = invoice.invoiceitems.stream()
+                .filter(ii -> ii.origin == InvoiceItemOrigin.BASE)
+                .toList();
+        List<InvoiceItem> calculatedItems = invoice.invoiceitems.stream()
+                .filter(ii -> ii.origin == InvoiceItemOrigin.CALCULATED)
+                .toList();
+
+        for (InvoiceItem item : baseItems) {
+            computeBaseItemAttribution(item, invoice);
+        }
+
+        if (!calculatedItems.isEmpty()) {
+            Map<String, BigDecimal> baseDistribution = computeBaseDistribution(invoiceUuid);
+            for (InvoiceItem item : calculatedItems) {
+                computeCalculatedItemAttribution(item, baseDistribution);
+            }
+        }
+
+        log.infof("computeAttributions: completed for invoice uuid=%s, items=%d",
+                invoiceUuid, invoice.invoiceitems.size());
+    }
+
+    // ── Recompute amounts from stable shares ──────────────────────────
+
+    @Transactional
+    public void recomputeItem(String invoiceItemUuid) {
+        InvoiceItem item = InvoiceItem.findById(invoiceItemUuid);
+        if (item == null) {
+            log.warnf("recomputeItem: item not found uuid=%s", invoiceItemUuid);
+            return;
+        }
+
+        double itemTotal = item.rate * item.hours;
+        List<InvoiceItemAttribution> attributions = getAttributions(invoiceItemUuid);
+        for (InvoiceItemAttribution attr : attributions) {
+            attr.recalculateAmount(itemTotal);
+            attr.updatedAt = java.time.LocalDateTime.now();
+        }
+
+        log.infof("recomputeItem: recalculated %d attributions for item uuid=%s, total=%.2f",
+                attributions.size(), invoiceItemUuid, itemTotal);
+    }
+
+    // ── Merge attributions ────────────────────────────────────────────
+
+    @Transactional
+    public void mergeAttributions(String targetItemUuid, String sourceItemUuid) {
+        InvoiceItem targetItem = InvoiceItem.findById(targetItemUuid);
+        if (targetItem == null) {
+            log.warnf("mergeAttributions: target item not found uuid=%s", targetItemUuid);
+            return;
+        }
+
+        List<InvoiceItemAttribution> targetAttrs = getAttributions(targetItemUuid);
+        List<InvoiceItemAttribution> sourceAttrs = getAttributions(sourceItemUuid);
+
+        Map<String, InvoiceItemAttribution> targetByConsultant = targetAttrs.stream()
+                .collect(Collectors.toMap(a -> a.consultantUuid, a -> a));
+
+        for (InvoiceItemAttribution sourceAttr : sourceAttrs) {
+            InvoiceItemAttribution existing = targetByConsultant.get(sourceAttr.consultantUuid);
+            if (existing != null) {
+                BigDecimal combinedHours = safeAdd(existing.originalHours, sourceAttr.originalHours);
+                existing.originalHours = combinedHours;
+            } else {
+                var merged = new InvoiceItemAttribution(
+                        targetItemUuid,
+                        sourceAttr.consultantUuid,
+                        BigDecimal.ZERO,
+                        BigDecimal.ZERO,
+                        sourceAttr.originalHours,
+                        AttributionSource.AUTO
+                );
+                merged.persist();
+                targetByConsultant.put(sourceAttr.consultantUuid, merged);
+            }
+        }
+
+        double itemTotal = targetItem.rate * targetItem.hours;
+        recalculateSharesFromHours(targetByConsultant.values(), itemTotal);
+
+        InvoiceItemAttribution.delete("invoiceitemUuid", sourceItemUuid);
+
+        log.infof("mergeAttributions: merged source=%s into target=%s, consultants=%d",
+                sourceItemUuid, targetItemUuid, targetByConsultant.size());
+    }
+
+    // ── Manual attribution override ───────────────────────────────────
+
+    public record ManualAttributionInput(String consultantUuid, BigDecimal sharePct) {}
+
+    @Transactional
+    public void setManualAttribution(String invoiceItemUuid, List<ManualAttributionInput> inputs) {
+        InvoiceItem item = InvoiceItem.findById(invoiceItemUuid);
+        if (item == null) {
+            log.warnf("setManualAttribution: item not found uuid=%s", invoiceItemUuid);
+            return;
+        }
+
+        InvoiceItemAttribution.delete("invoiceitemUuid", invoiceItemUuid);
+
+        double itemTotal = item.rate * item.hours;
+        for (ManualAttributionInput input : inputs) {
+            BigDecimal amount = input.sharePct()
+                    .multiply(BigDecimal.valueOf(itemTotal))
+                    .divide(BigDecimal.valueOf(100), AMT_SCALE, RoundingMode.HALF_UP);
+            var attribution = new InvoiceItemAttribution(
+                    invoiceItemUuid,
+                    input.consultantUuid(),
+                    input.sharePct().setScale(PCT_SCALE, RoundingMode.HALF_UP),
+                    amount,
+                    null,
+                    AttributionSource.MANUAL
+            );
+            attribution.persist();
+        }
+
+        log.infof("setManualAttribution: set %d manual attributions for item uuid=%s",
+                inputs.size(), invoiceItemUuid);
+    }
+
+    // ── Reset to auto ─────────────────────────────────────────────────
+
+    @Transactional
+    public void resetToAuto(String invoiceItemUuid) {
+        InvoiceItem item = InvoiceItem.findById(invoiceItemUuid);
+        if (item == null) {
+            log.warnf("resetToAuto: item not found uuid=%s", invoiceItemUuid);
+            return;
+        }
+
+        InvoiceItemAttribution.delete("invoiceitemUuid", invoiceItemUuid);
+
+        String invoiceUuid = item.invoiceuuid;
+        Invoice invoice = Invoice.findById(invoiceUuid);
+        if (invoice == null) {
+            log.warnf("resetToAuto: invoice not found uuid=%s", invoiceUuid);
+            return;
+        }
+
+        if (item.origin == InvoiceItemOrigin.BASE) {
+            computeBaseItemAttribution(item, invoice);
+        } else {
+            Map<String, BigDecimal> baseDistribution = computeBaseDistribution(invoiceUuid);
+            computeCalculatedItemAttribution(item, baseDistribution);
+        }
+
+        log.infof("resetToAuto: recomputed auto attributions for item uuid=%s", invoiceItemUuid);
+    }
+
+    // ── Batch backfill ────────────────────────────────────────────────
+
+    @Transactional
+    public int backfillRange(LocalDate from, LocalDate to) {
+        @SuppressWarnings("unchecked")
+        List<String> invoiceUuids = em.createNativeQuery("""
+                        SELECT i.uuid FROM invoices i
+                        WHERE i.status = :status
+                          AND i.invoicedate >= :fromDate
+                          AND i.invoicedate < :toDate
+                          AND NOT EXISTS (
+                            SELECT 1 FROM invoice_item_attributions iia
+                            JOIN invoiceitems ii ON iia.invoiceitem_uuid = ii.uuid
+                            WHERE ii.invoiceuuid = i.uuid
+                          )
+                        ORDER BY i.invoicedate
+                        """)
+                .setParameter("status", InvoiceStatus.CREATED.name())
+                .setParameter("fromDate", from)
+                .setParameter("toDate", to)
+                .getResultList();
+
+        int count = 0;
+        for (String invoiceUuid : invoiceUuids) {
+            computeAttributions(invoiceUuid);
+            count++;
+            if (count % 100 == 0) {
+                em.flush();
+                em.clear();
+                log.infof("backfillRange: processed %d/%d invoices", count, invoiceUuids.size());
+            }
+        }
+
+        log.infof("backfillRange: completed %d invoices for range %s to %s", count, from, to);
+        return count;
+    }
+
+    // ── Find unattributed items ───────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    public List<Map<String, Object>> findUnattributedItems(LocalDate from, LocalDate to) {
+        List<Object[]> rows = em.createNativeQuery("""
+                        SELECT ii.uuid AS item_uuid,
+                               ii.invoiceuuid AS invoice_uuid,
+                               i.invoicedate,
+                               i.clientname,
+                               ii.itemname,
+                               (ii.rate * ii.hours) AS amount
+                        FROM invoiceitems ii
+                        JOIN invoices i ON ii.invoiceuuid = i.uuid
+                        WHERE i.status = :status
+                          AND i.invoicedate >= :fromDate
+                          AND i.invoicedate < :toDate
+                          AND NOT EXISTS (
+                            SELECT 1 FROM invoice_item_attributions iia
+                            WHERE iia.invoiceitem_uuid = ii.uuid
+                          )
+                        ORDER BY i.invoicedate, ii.position
+                        """)
+                .setParameter("status", InvoiceStatus.CREATED.name())
+                .setParameter("fromDate", from)
+                .setParameter("toDate", to)
+                .getResultList();
+
+        return rows.stream()
+                .map(row -> {
+                    Map<String, Object> map = new LinkedHashMap<>();
+                    map.put("itemUuid", row[0]);
+                    map.put("invoiceUuid", row[1]);
+                    map.put("invoiceDate", row[2]);
+                    map.put("clientName", row[3]);
+                    map.put("itemName", row[4]);
+                    map.put("amount", row[5]);
+                    return map;
+                })
+                .toList();
+    }
+
+    // ── Private: BASE item attribution ────────────────────────────────
+
+    private void computeBaseItemAttribution(InvoiceItem item, Invoice invoice) {
+        List<InvoiceItemAttribution> existing = getAttributions(item.uuid);
+        boolean hasManual = existing.stream()
+                .anyMatch(a -> a.source == AttributionSource.MANUAL);
+
+        if (hasManual) {
+            double itemTotal = item.rate * item.hours;
+            for (InvoiceItemAttribution attr : existing) {
+                attr.recalculateAmount(itemTotal);
+                attr.updatedAt = java.time.LocalDateTime.now();
+            }
+            return;
+        }
+
+        InvoiceItemAttribution.delete(
+                "invoiceitemUuid = ?1 AND source = ?2",
+                item.uuid, AttributionSource.AUTO
+        );
+
+        double itemTotal = item.rate * item.hours;
+
+        if (item.consultantuuid != null && !item.consultantuuid.isBlank()) {
+            createSingleAttribution(item.uuid, item.consultantuuid, itemTotal);
+            return;
+        }
+
+        if (invoice.contractuuid == null || invoice.contractuuid.isBlank()) {
+            log.warnf("computeBaseItemAttribution: no contractuuid on invoice uuid=%s, skipping item uuid=%s",
+                    invoice.uuid, item.uuid);
+            return;
+        }
+
+        Map<String, BigDecimal> workShares = computeWorkShares(invoice.contractuuid, invoice.invoicedate);
+        if (!workShares.isEmpty()) {
+            createAttributionsFromShares(item.uuid, workShares, itemTotal, true);
+            return;
+        }
+
+        Map<String, BigDecimal> consultantShares = computeContractConsultantShares(
+                invoice.contractuuid, invoice.invoicedate);
+        if (!consultantShares.isEmpty()) {
+            createAttributionsFromShares(item.uuid, consultantShares, itemTotal, false);
+            return;
+        }
+
+        log.warnf("computeBaseItemAttribution: no work data or contract consultants for " +
+                        "contract=%s, invoice=%s, item=%s — item remains unattributed",
+                invoice.contractuuid, invoice.uuid, item.uuid);
+    }
+
+    // ── Private: CALCULATED item attribution ──────────────────────────
+
+    private void computeCalculatedItemAttribution(InvoiceItem item, Map<String, BigDecimal> baseDistribution) {
+        List<InvoiceItemAttribution> existing = getAttributions(item.uuid);
+        boolean hasManual = existing.stream()
+                .anyMatch(a -> a.source == AttributionSource.MANUAL);
+
+        if (hasManual) {
+            double itemTotal = item.rate * item.hours;
+            for (InvoiceItemAttribution attr : existing) {
+                attr.recalculateAmount(itemTotal);
+                attr.updatedAt = java.time.LocalDateTime.now();
+            }
+            return;
+        }
+
+        InvoiceItemAttribution.delete(
+                "invoiceitemUuid = ?1 AND source = ?2",
+                item.uuid, AttributionSource.AUTO
+        );
+
+        if (baseDistribution.isEmpty()) {
+            log.warnf("computeCalculatedItemAttribution: no base distribution for item uuid=%s", item.uuid);
+            return;
+        }
+
+        double itemTotal = item.rate * item.hours;
+        createAttributionsFromShares(item.uuid, baseDistribution, itemTotal, false);
+    }
+
+    // ── Private: work-based share computation ─────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private Map<String, BigDecimal> computeWorkShares(String contractUuid, LocalDate invoiceDate) {
+        LocalDate periodStart = invoiceDate.withDayOfMonth(1);
+        LocalDate periodEnd = periodStart.plusMonths(1);
+
+        List<Object[]> rows = em.createNativeQuery("""
+                        SELECT w.useruuid, SUM(w.workduration) AS total_hours
+                        FROM work w
+                        JOIN task t ON w.taskuuid = t.uuid
+                        JOIN contract_project cp ON t.projectuuid = cp.projectuuid
+                        WHERE cp.contractuuid = :contractUuid
+                          AND w.registered >= :periodStart
+                          AND w.registered < :periodEnd
+                          AND w.workduration > 0
+                        GROUP BY w.useruuid
+                        """)
+                .setParameter("contractUuid", contractUuid)
+                .setParameter("periodStart", periodStart)
+                .setParameter("periodEnd", periodEnd)
+                .getResultList();
+
+        if (rows.isEmpty()) {
+            return Map.of();
+        }
+
+        BigDecimal totalHours = BigDecimal.ZERO;
+        Map<String, BigDecimal> hoursByConsultant = new LinkedHashMap<>();
+        for (Object[] row : rows) {
+            String useruuid = (String) row[0];
+            BigDecimal hours = toBigDecimal(row[1]);
+            hoursByConsultant.put(useruuid, hours);
+            totalHours = totalHours.add(hours);
+        }
+
+        if (totalHours.compareTo(BigDecimal.ZERO) == 0) {
+            return Map.of();
+        }
+
+        Map<String, BigDecimal> shares = new LinkedHashMap<>();
+        for (var entry : hoursByConsultant.entrySet()) {
+            BigDecimal pct = entry.getValue()
+                    .multiply(BigDecimal.valueOf(100))
+                    .divide(totalHours, PCT_SCALE, RoundingMode.HALF_UP);
+            shares.put(entry.getKey(), pct);
+        }
+
+        return shares;
+    }
+
+    // ── Private: contract consultant fallback ─────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private Map<String, BigDecimal> computeContractConsultantShares(String contractUuid, LocalDate invoiceDate) {
+        LocalDate periodStart = invoiceDate.withDayOfMonth(1);
+        LocalDate periodEnd = periodStart.plusMonths(1).minusDays(1);
+
+        List<String> consultantUuids = em.createNativeQuery("""
+                        SELECT cc.useruuid
+                        FROM contract_consultants cc
+                        WHERE cc.contractuuid = :contractUuid
+                          AND cc.activefrom <= :periodEnd
+                          AND cc.activeto >= :periodStart
+                        """)
+                .setParameter("contractUuid", contractUuid)
+                .setParameter("periodStart", periodStart)
+                .setParameter("periodEnd", periodEnd)
+                .getResultList();
+
+        if (consultantUuids.isEmpty()) {
+            return Map.of();
+        }
+
+        BigDecimal equalShare = BigDecimal.valueOf(100)
+                .divide(BigDecimal.valueOf(consultantUuids.size()), PCT_SCALE, RoundingMode.HALF_UP);
+
+        Map<String, BigDecimal> shares = new LinkedHashMap<>();
+        for (String uuid : consultantUuids) {
+            shares.put(uuid, equalShare);
+        }
+
+        return shares;
+    }
+
+    // ── Private: base distribution across an invoice ──────────────────
+
+    @SuppressWarnings("unchecked")
+    private Map<String, BigDecimal> computeBaseDistribution(String invoiceUuid) {
+        List<Object[]> rows = em.createNativeQuery("""
+                        SELECT iia.consultant_uuid, SUM(iia.attributed_amount) AS total_amount
+                        FROM invoice_item_attributions iia
+                        JOIN invoiceitems ii ON iia.invoiceitem_uuid = ii.uuid
+                        WHERE ii.invoiceuuid = :invoiceUuid
+                          AND ii.origin = 'BASE'
+                        GROUP BY iia.consultant_uuid
+                        """)
+                .setParameter("invoiceUuid", invoiceUuid)
+                .getResultList();
+
+        if (rows.isEmpty()) {
+            return Map.of();
+        }
+
+        BigDecimal totalAmount = BigDecimal.ZERO;
+        Map<String, BigDecimal> amountByConsultant = new LinkedHashMap<>();
+        for (Object[] row : rows) {
+            String consultantUuid = (String) row[0];
+            BigDecimal amount = toBigDecimal(row[1]);
+            amountByConsultant.put(consultantUuid, amount);
+            totalAmount = totalAmount.add(amount);
+        }
+
+        if (totalAmount.compareTo(BigDecimal.ZERO) == 0) {
+            return Map.of();
+        }
+
+        Map<String, BigDecimal> distribution = new LinkedHashMap<>();
+        for (var entry : amountByConsultant.entrySet()) {
+            BigDecimal pct = entry.getValue()
+                    .multiply(BigDecimal.valueOf(100))
+                    .divide(totalAmount, PCT_SCALE, RoundingMode.HALF_UP);
+            distribution.put(entry.getKey(), pct);
+        }
+
+        return distribution;
+    }
+
+    // ── Private: attribution creation helpers ─────────────────────────
+
+    private void createSingleAttribution(String invoiceItemUuid, String consultantUuid, double itemTotal) {
+        var attribution = new InvoiceItemAttribution(
+                invoiceItemUuid,
+                consultantUuid,
+                BigDecimal.valueOf(100).setScale(PCT_SCALE, RoundingMode.HALF_UP),
+                BigDecimal.valueOf(itemTotal).setScale(AMT_SCALE, RoundingMode.HALF_UP),
+                null,
+                AttributionSource.AUTO
+        );
+        attribution.persist();
+    }
+
+    private void createAttributionsFromShares(
+            String invoiceItemUuid,
+            Map<String, BigDecimal> shares,
+            double itemTotal,
+            boolean includeHours) {
+        for (var entry : shares.entrySet()) {
+            BigDecimal amount = entry.getValue()
+                    .multiply(BigDecimal.valueOf(itemTotal))
+                    .divide(BigDecimal.valueOf(100), AMT_SCALE, RoundingMode.HALF_UP);
+
+            var attribution = new InvoiceItemAttribution(
+                    invoiceItemUuid,
+                    entry.getKey(),
+                    entry.getValue().setScale(PCT_SCALE, RoundingMode.HALF_UP),
+                    amount,
+                    null,
+                    AttributionSource.AUTO
+            );
+            attribution.persist();
+        }
+    }
+
+    // ── Private: recalculate from hours after merge ───────────────────
+
+    private void recalculateSharesFromHours(Collection<InvoiceItemAttribution> attributions, double itemTotal) {
+        BigDecimal totalHours = attributions.stream()
+                .map(a -> a.originalHours != null ? a.originalHours : BigDecimal.ZERO)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        if (totalHours.compareTo(BigDecimal.ZERO) == 0) {
+            BigDecimal equalShare = BigDecimal.valueOf(100)
+                    .divide(BigDecimal.valueOf(attributions.size()), PCT_SCALE, RoundingMode.HALF_UP);
+            for (InvoiceItemAttribution attr : attributions) {
+                attr.sharePct = equalShare;
+                attr.recalculateAmount(itemTotal);
+                attr.updatedAt = java.time.LocalDateTime.now();
+            }
+            return;
+        }
+
+        for (InvoiceItemAttribution attr : attributions) {
+            BigDecimal hours = attr.originalHours != null ? attr.originalHours : BigDecimal.ZERO;
+            attr.sharePct = hours
+                    .multiply(BigDecimal.valueOf(100))
+                    .divide(totalHours, PCT_SCALE, RoundingMode.HALF_UP);
+            attr.recalculateAmount(itemTotal);
+            attr.updatedAt = java.time.LocalDateTime.now();
+        }
+    }
+
+    // ── Private: type conversion ──────────────────────────────────────
+
+    private static BigDecimal toBigDecimal(Object value) {
+        if (value instanceof BigDecimal bd) {
+            return bd;
+        }
+        if (value instanceof Number n) {
+            return BigDecimal.valueOf(n.doubleValue());
+        }
+        return BigDecimal.ZERO;
+    }
+
+    private static BigDecimal safeAdd(BigDecimal a, BigDecimal b) {
+        BigDecimal left = a != null ? a : BigDecimal.ZERO;
+        BigDecimal right = b != null ? b : BigDecimal.ZERO;
+        return left.add(right);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceService.java
@@ -78,6 +78,9 @@ public class InvoiceService {
     @Inject IntercompanyCalcService calcService;
 
     @Inject
+    InvoiceAttributionService invoiceAttributionService;
+
+    @Inject
     PricingEngine pricingEngine;
 
     @Inject
@@ -381,6 +384,7 @@ public class InvoiceService {
         if (invoice.getType() != InvoiceType.INTERNAL) {
             bonusService.recalcForInvoice(invoice.getUuid());
         }
+        invoiceAttributionService.computeAttributions(invoice.getUuid());
         return invoice;
     }
 
@@ -962,6 +966,11 @@ public class InvoiceService {
 
     @Transactional
     public void deleteDraftInvoice(String invoiceuuid) {
+        // Clean up attribution rows for all items on this invoice
+        em.createNativeQuery("""
+                DELETE FROM invoice_item_attributions
+                WHERE invoiceitem_uuid IN (SELECT uuid FROM invoiceitems WHERE invoiceuuid = :uuid)
+                """).setParameter("uuid", invoiceuuid).executeUpdate();
         if(isDraftOrPhantom(invoiceuuid)) Invoice.deleteById(invoiceuuid);
     }
 

--- a/src/main/resources/db/migration/V281__Create_invoice_item_attributions.sql
+++ b/src/main/resources/db/migration/V281__Create_invoice_item_attributions.sql
@@ -1,0 +1,15 @@
+CREATE TABLE invoice_item_attributions (
+    uuid              VARCHAR(36)    NOT NULL,
+    invoiceitem_uuid  VARCHAR(40)    NOT NULL,
+    consultant_uuid   VARCHAR(36)    NOT NULL,
+    share_pct         DECIMAL(7,4)   NOT NULL,
+    attributed_amount DECIMAL(12,2)  NOT NULL,
+    original_hours    DECIMAL(8,2)   NULL,
+    source            VARCHAR(10)    NOT NULL DEFAULT 'AUTO',
+    created_at        DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        DATETIME       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (uuid),
+    INDEX idx_iia_item (invoiceitem_uuid),
+    INDEX idx_iia_consultant (consultant_uuid),
+    UNIQUE KEY uq_iia_item_consultant (invoiceitem_uuid, consultant_uuid)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceAttributionServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceAttributionServiceTest.java
@@ -19,14 +19,17 @@ class InvoiceAttributionServiceTest {
     /**
      * Test profile that disables S3/LocalStack dev services so that
      * @QuarkusTest can start without Docker being available.
+     * Also provides non-empty placeholder values for config properties that
+     * reject empty strings (cvtool credentials).
      * The datasource connects to the local/staging MariaDB via application.yml defaults.
      */
     public static class NoDevServicesProfile implements QuarkusTestProfile {
         @Override
         public Map<String, String> getConfigOverrides() {
             return Map.of(
-                    "quarkus.amazon.s3.devservices.enabled", "false",
-                    "quarkus.amazon.devservices.enabled", "false"
+                    "quarkus.s3.devservices.enabled", "false",
+                    "cvtool.username", "test-placeholder",
+                    "cvtool.password", "test-placeholder"
             );
         }
     }

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceAttributionServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceAttributionServiceTest.java
@@ -1,0 +1,83 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.model.InvoiceItemAttribution;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(InvoiceAttributionServiceTest.NoDevServicesProfile.class)
+class InvoiceAttributionServiceTest {
+
+    /**
+     * Test profile that disables S3/LocalStack dev services so that
+     * @QuarkusTest can start without Docker being available.
+     * The datasource connects to the local/staging MariaDB via application.yml defaults.
+     */
+    public static class NoDevServicesProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.amazon.s3.devservices.enabled", "false",
+                    "quarkus.amazon.devservices.enabled", "false"
+            );
+        }
+    }
+
+    @Inject
+    InvoiceAttributionService attributionService;
+
+    @Test
+    void computeAttributions_populatesAttributionsForInvoiceWithConsultantItems() {
+        // Find a known CREATED invoice with items that have consultantuuid set
+        @SuppressWarnings("unchecked")
+        List<String> invoices = InvoiceItemAttribution.getEntityManager().createNativeQuery("""
+                SELECT i.uuid FROM invoices i
+                JOIN invoiceitems ii ON ii.invoiceuuid = i.uuid
+                WHERE i.status = 'CREATED' AND i.type = 'INVOICE'
+                  AND ii.consultantuuid IS NOT NULL AND ii.origin = 'BASE'
+                LIMIT 1
+                """).getResultList();
+
+        if (invoices.isEmpty()) return; // No test data — skip gracefully
+
+        String invoiceUuid = invoices.get(0);
+
+        // Clean up any existing attributions for this invoice first
+        InvoiceItemAttribution.getEntityManager().createNativeQuery("""
+                DELETE FROM invoice_item_attributions
+                WHERE invoiceitem_uuid IN (SELECT uuid FROM invoiceitems WHERE invoiceuuid = :uuid)
+                """).setParameter("uuid", invoiceUuid).executeUpdate();
+
+        // Act
+        attributionService.computeAttributions(invoiceUuid);
+
+        // Assert
+        List<InvoiceItemAttribution> result = attributionService.getInvoiceAttributions(invoiceUuid);
+        assertFalse(result.isEmpty(), "Should create attribution rows");
+
+        for (InvoiceItemAttribution attr : result) {
+            assertNotNull(attr.consultantUuid, "consultant_uuid should be set");
+            assertNotNull(attr.sharePct, "share_pct should be set");
+            assertTrue(attr.sharePct.doubleValue() > 0, "share_pct should be positive");
+            assertNotNull(attr.attributedAmount, "attributed_amount should be set");
+        }
+    }
+
+    @Test
+    void findUnattributedItems_returnsItemsWithNoAttributions() {
+        var from = java.time.LocalDate.of(2025, 7, 1);
+        var to = java.time.LocalDate.now();
+
+        List<Map<String, Object>> unattributed = attributionService.findUnattributedItems(from, to);
+        assertNotNull(unattributed);
+        // Query executes without error — count is informational
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+# Disable S3/LocalStack dev services during tests — Docker is not required
+# The quarkus.s3.devservices.enabled key must be set at build time;
+# the test profile in the test class also disables it at runtime.
+quarkus.s3.devservices.enabled=false


### PR DESCRIPTION
## Summary

- Adds `invoice_item_attributions` bridge table (V281 migration) mapping invoice items to consultants with proportional revenue shares
- New `InvoiceAttributionService` computes shares from work data, supports manual overrides, merge operations, and batch backfill
- **Fixes profitability chart** — switches `ConsultantInsightsService` TTM query from `invoiceitems.consultantuuid` to the attribution table, fixing silent revenue drop for 40+ contracts
- REST endpoints for attribution CRUD, admin backfill trigger, and unattributed items monitoring
- Lifecycle integration: attributions computed on draft create, recomputed on edit, cleaned up on delete

## Context

Sarah Skipper's TTM profitability showed 18,613 DKK instead of ~370K+ because her main 700K DKK fixed-fee invoice had `consultantuuid = NULL`. This affected all contract-level invoicing — 40+ contracts in the TTM window.

## Companion PR

Frontend: trustworksdk/trustworks-intranet-v3 (feature/invoice-attribution)

## Test plan

- [ ] Run backfill: `POST /invoices/attributions/backfill?from=2021-07-01&to=2026-05-01`
- [ ] Verify Sarah Skipper's profitability revenue increases after backfill
- [ ] Check unattributed items: `GET /invoices/attributions/unattributed?from=2025-07-01&to=2026-05-01`
- [ ] Create a draft invoice — verify attributions are auto-computed
- [ ] Edit a draft invoice item — verify attributions recalculate
- [ ] Delete a draft — verify attribution rows are cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)