### PR TITLE
fix(config): restore feature.contract.overrides indentation

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -212,12 +212,6 @@ feature:
   invoicing:
     internal:
       attribution-driven: ${feature.invoicing.internal.attribution-driven:true}
-invoicing:
-  internal:
-    # Contact-person name stamped on generated internal invoices. Externalized so
-    # no individual's name is embedded in source code. Default is a generic label;
-    # override per-environment if a specific contact is desired.
-    default-contact-name: ${INVOICING_INTERNAL_DEFAULT_CONTACT_NAME:Trustworks Finance}
   # Contract Rule Override System feature flags
   contract:
     overrides:
@@ -243,6 +237,12 @@ invoicing:
       cache:
         ttl-seconds: 3600  # 1 hour cache (matching spec)
         max-size: 10000    # Max cached rule sets
+invoicing:
+  internal:
+    # Contact-person name stamped on generated internal invoices. Externalized so
+    # no individual's name is embedded in source code. Default is a generic label;
+    # override per-environment if a specific contact is desired.
+    default-contact-name: ${INVOICING_INTERNAL_DEFAULT_CONTACT_NAME:Trustworks Finance}
 slack:
   slackApi: https://slack.com/api
   motherSlackBotToken: ${MOTHERSLACKBOTTOKEN:xx}


### PR DESCRIPTION
## Root cause
ECS Express canary deployments on both staging and production have been rolling back since the internal-invoice-attribution PR landed. The running tasks are still on the pre-feature commit `d4a271d`.

CloudWatch logs on the failed canary show:
```
Configuration validation failed:
java.util.NoSuchElementException: SRCFG00014: The config property feature.contract.overrides.rollout.whitelist is required but it could not be found in any config source
```

The `contract:` block ended up under a new top-level `invoicing:` key instead of under `feature:` after the earlier merge, so `@ConfigProperty("feature.contract.overrides.rollout.whitelist")` resolved to missing and Quarkus failed to start.

## Fix
Move `contract:` back under `feature:` in `application.yml`. Keep `invoicing.internal.default-contact-name` as a top-level `invoicing:` key (matches the `INVOICING_INTERNAL_DEFAULT_CONTACT_NAME` env-var convention).

`application-dev.yaml` was already correct — only `application.yml` needed the fix.

## Verification
- `python3 -c "import yaml; print(yaml.safe_load(open('…/application.yml')))"` — keys match the expected structure
- `feature.contract.overrides.rollout.whitelist` resolves to the 3 pilot UUIDs
- `feature.invoicing.internal.attribution-driven` preserved
- `invoicing.internal.default-contact-name` preserved

## Test plan
- [ ] After merge to staging, confirm the ECS Express deploy does NOT roll back (stream canary events)
- [ ] Probe `GET /invoices/00000000-0000-0000-0000-000000000000/internal-preview` on staging — should now return 401 (auth) instead of 404 (missing method)
- [ ] Promote staging → master once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)