### PR TITLE
fix(config): remove self-referencing attribution-driven expression

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -211,7 +211,9 @@ feature:
   # flip to false only as an emergency rollback.
   invoicing:
     internal:
-      attribution-driven: ${feature.invoicing.internal.attribution-driven:true}
+      # Override via env var FEATURE_INVOICING_INTERNAL_ATTRIBUTION_DRIVEN or
+      # the Quarkus config key `feature.invoicing.internal.attribution-driven`.
+      attribution-driven: true
   # Contract Rule Override System feature flags
   contract:
     overrides:


### PR DESCRIPTION
## Root cause
After fixing the YAML indentation (#42), the staging canary rolled back a second time. New CloudWatch error:
```
Failed to load config value of type boolean for: feature.invoicing.internal.attribution-driven
```

The value was `${feature.invoicing.internal.attribution-driven:true}` — a placeholder referencing the same key it's defining. MP Config recurses infinitely.

## Fix
Plain value: `attribution-driven: true`. MP Config automatically honors env var (`FEATURE_INVOICING_INTERNAL_ATTRIBUTION_DRIVEN`) and property overrides without the `${...}` indirection.

## Test plan
- [ ] Staging deploy canary does NOT roll back
- [ ] Probe `/invoices/{uuid}/internal-preview` returns 401 (auth), not 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)