### PR TITLE
Promote staging → master: internal-invoice attribution hotfix

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -212,12 +212,6 @@ feature:
   invoicing:
     internal:
       attribution-driven: ${feature.invoicing.internal.attribution-driven:true}
-invoicing:
-  internal:
-    # Contact-person name stamped on generated internal invoices. Externalized so
-    # no individual's name is embedded in source code. Default is a generic label;
-    # override per-environment if a specific contact is desired.
-    default-contact-name: ${INVOICING_INTERNAL_DEFAULT_CONTACT_NAME:Trustworks Finance}
   # Contract Rule Override System feature flags
   contract:
     overrides:
@@ -243,6 +237,12 @@ invoicing:
       cache:
         ttl-seconds: 3600  # 1 hour cache (matching spec)
         max-size: 10000    # Max cached rule sets
+invoicing:
+  internal:
+    # Contact-person name stamped on generated internal invoices. Externalized so
+    # no individual's name is embedded in source code. Default is a generic label;
+    # override per-environment if a specific contact is desired.
+    default-contact-name: ${INVOICING_INTERNAL_DEFAULT_CONTACT_NAME:Trustworks Finance}
 slack:
   slackApi: https://slack.com/api
   motherSlackBotToken: ${MOTHERSLACKBOTTOKEN:xx}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -211,7 +211,9 @@ feature:
   # flip to false only as an emergency rollback.
   invoicing:
     internal:
-      attribution-driven: ${feature.invoicing.internal.attribution-driven:true}
+      # Override via env var FEATURE_INVOICING_INTERNAL_ATTRIBUTION_DRIVEN or
+      # the Quarkus config key `feature.invoicing.internal.attribution-driven`.
+      attribution-driven: true
   # Contract Rule Override System feature flags
   contract:
     overrides:


### PR DESCRIPTION
Promotes the two hotfix commits on staging to production.

## Commits included
- `cb4bd24 fix(config): remove self-referencing expression on attribution-driven flag (#43)`
- `adf9b7b fix(config): restore feature.contract.overrides under feature: in application.yml (#42)`

## Why
Production has been running the pre-feature image (`d4a271d`) since the internal-invoice-attribution merge, because two separate application.yml bugs caused ECS Express canary to roll back every attempt:
1. Indentation moved `feature.contract.overrides` under a new top-level `invoicing:` key
2. The new `attribution-driven` flag used a self-referencing `${...}` expression

Both are fixed. Staging canary now sticks, `/invoices/{uuid}/internal-preview` returns 401 (auth) instead of 404.

## Test plan
- [ ] Watch prod canary — should NOT roll back
- [ ] Probe `/invoices/00000000-0000-0000-0000-000000000000/internal-preview` on `api.trustworks.dk` — expect 401
- [ ] User retries "Create internal invoice" in the UI — should now load the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)