### PR TITLE
feat(cxo): migrate Finance + Clients direct-DB to backend (Phase 1/5)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/CostToRevenueDataPointDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/CostToRevenueDataPointDTO.java
@@ -1,0 +1,16 @@
+package dk.trustworks.intranet.aggregates.finance.dto.cxo;
+
+/**
+ * One month of cost-to-revenue data for the CXO Command Center.
+ * Field names use Java camelCase; Jackson default serialization produces matching JSON keys.
+ */
+public record CostToRevenueDataPointDTO(
+        String monthKey,
+        int year,
+        int monthNumber,
+        String monthLabel,
+        double revenueDkk,
+        double deliveryCostDkk,
+        double opexDkk,
+        Double costToRevenueRatioPct  // boxed: nullable when revenue == 0
+) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/CostToRevenueDataPointDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/CostToRevenueDataPointDTO.java
@@ -13,4 +13,13 @@ public record CostToRevenueDataPointDTO(
         double deliveryCostDkk,
         double opexDkk,
         Double costToRevenueRatioPct  // boxed: nullable when revenue == 0
-) {}
+) {
+    public CostToRevenueDataPointDTO {
+        if (monthKey == null || !monthKey.matches("\\d{6}"))
+            throw new IllegalArgumentException("monthKey must be YYYYMM, was " + monthKey);
+        if (monthNumber < 1 || monthNumber > 12)
+            throw new IllegalArgumentException("monthNumber out of range: " + monthNumber);
+        if (year < 2000 || year > 2100)
+            throw new IllegalArgumentException("year out of range: " + year);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/CreditNoteRateDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/CreditNoteRateDTO.java
@@ -1,6 +1,7 @@
 package dk.trustworks.intranet.aggregates.finance.dto.cxo;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Wrapper response for GET /clients/cxo/credit-note-rate.
@@ -12,4 +13,9 @@ import java.util.List;
 public record CreditNoteRateDTO(
         List<MonthlyCreditNoteDTO> monthly,
         List<CreditNoteTopClientDTO> topClients
-) {}
+) {
+    public CreditNoteRateDTO {
+        Objects.requireNonNull(monthly, "monthly");
+        Objects.requireNonNull(topClients, "topClients");
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/CreditNoteRateDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/CreditNoteRateDTO.java
@@ -1,0 +1,15 @@
+package dk.trustworks.intranet.aggregates.finance.dto.cxo;
+
+import java.util.List;
+
+/**
+ * Wrapper response for GET /clients/cxo/credit-note-rate.
+ *
+ * <p>{@code monthly} is the time-ordered (ascending {@code monthKey}) series of
+ * monthly invoice vs credit-note volumes plus the derived rate. {@code topClients}
+ * is the top-5 clients by absolute credit-note amount in the same window.</p>
+ */
+public record CreditNoteRateDTO(
+        List<MonthlyCreditNoteDTO> monthly,
+        List<CreditNoteTopClientDTO> topClients
+) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/CreditNoteTopClientDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/CreditNoteTopClientDTO.java
@@ -1,0 +1,15 @@
+package dk.trustworks.intranet.aggregates.finance.dto.cxo;
+
+/**
+ * One row in the "top clients by credit-note volume" table on the
+ * GET /clients/cxo/credit-note-rate dashboard, capped at 5 entries.
+ *
+ * <p>{@code creditNoteCount} is the number of distinct credit-note invoices for this
+ * client in the date window — backed by {@code COUNT(DISTINCT i.uuid)} which returns
+ * BIGINT in MariaDB, hence {@code long} on the Java side.</p>
+ */
+public record CreditNoteTopClientDTO(
+        String clientName,
+        double creditNoteAmountDkk,
+        long creditNoteCount
+) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/GrossMarginTrendDataPointDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/GrossMarginTrendDataPointDTO.java
@@ -11,5 +11,14 @@ public record GrossMarginTrendDataPointDTO(
         String monthLabel,
         double totalRevenueDkk,
         double totalCostDkk,
-        Double grossMarginPct  // boxed: nullable per frontend contract (`number | null`)
-) {}
+        Double grossMarginPct  // boxed: nullable per frontend contract; HAVING clause currently filters zero-revenue months so production responses always have a value, but defensive null-safety is preserved
+) {
+    public GrossMarginTrendDataPointDTO {
+        if (monthKey == null || !monthKey.matches("\\d{6}"))
+            throw new IllegalArgumentException("monthKey must be YYYYMM, was " + monthKey);
+        if (monthNumber < 1 || monthNumber > 12)
+            throw new IllegalArgumentException("monthNumber out of range: " + monthNumber);
+        if (year < 2000 || year > 2100)
+            throw new IllegalArgumentException("year out of range: " + year);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/GrossMarginTrendDataPointDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/GrossMarginTrendDataPointDTO.java
@@ -1,0 +1,15 @@
+package dk.trustworks.intranet.aggregates.finance.dto.cxo;
+
+/**
+ * One month of gross margin data for the CXO Command Center.
+ * Only months with positive revenue are returned (filter applied SQL-side via HAVING).
+ */
+public record GrossMarginTrendDataPointDTO(
+        String monthKey,
+        int year,
+        int monthNumber,
+        String monthLabel,
+        double totalRevenueDkk,
+        double totalCostDkk,
+        Double grossMarginPct  // boxed: nullable per frontend contract (`number | null`)
+) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/MonthlyCreditNoteDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/MonthlyCreditNoteDTO.java
@@ -1,0 +1,20 @@
+package dk.trustworks.intranet.aggregates.finance.dto.cxo;
+
+/**
+ * One month in the credit-note-rate series for GET /clients/cxo/credit-note-rate.
+ *
+ * <p>{@code monthKey} is the {@code YYYYMM} key produced by {@code DATE_FORMAT(invoicedate, '%Y%m')}.
+ * {@code creditNoteRatePct} is the percentage of total billed value that was credited
+ * back, computed as {@code creditNoteAmountDkk / (invoiceAmountDkk + creditNoteAmountDkk) * 100}
+ * rounded to two decimals. When the denominator is zero the BFF returns {@code 0.0}, so this
+ * field is a primitive {@code double} (never null).</p>
+ */
+public record MonthlyCreditNoteDTO(
+        String monthKey,
+        int year,
+        int monthNumber,
+        String monthLabel,
+        double invoiceAmountDkk,
+        double creditNoteAmountDkk,
+        double creditNoteRatePct
+) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/MonthlyCreditNoteDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/MonthlyCreditNoteDTO.java
@@ -17,4 +17,13 @@ public record MonthlyCreditNoteDTO(
         double invoiceAmountDkk,
         double creditNoteAmountDkk,
         double creditNoteRatePct
-) {}
+) {
+    public MonthlyCreditNoteDTO {
+        if (monthKey == null || !monthKey.matches("\\d{6}"))
+            throw new IllegalArgumentException("monthKey must be YYYYMM, was " + monthKey);
+        if (monthNumber < 1 || monthNumber > 12)
+            throw new IllegalArgumentException("monthNumber out of range: " + monthNumber);
+        if (year < 2000 || year > 2100)
+            throw new IllegalArgumentException("year out of range: " + year);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/MonthlyRevenuePracticeDataPoint.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/MonthlyRevenuePracticeDataPoint.java
@@ -1,5 +1,7 @@
 package dk.trustworks.intranet.aggregates.finance.dto.cxo;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -13,6 +15,11 @@ import java.util.Map;
  *
  * <p>{@link #marginPercent} is {@code null} for months with no positive revenue;
  * otherwise it is rounded to two decimal places.</p>
+ *
+ * <p>The compact constructor wraps {@code practiceRevenue} in an unmodifiable
+ * {@link LinkedHashMap} copy to preserve the caller's insertion order (the service
+ * builds it ordered to match the {@code practices} list) while preventing external
+ * mutation of the DTO's internal state.</p>
  */
 public record MonthlyRevenuePracticeDataPoint(
         String monthKey,
@@ -23,4 +30,20 @@ public record MonthlyRevenuePracticeDataPoint(
         double totalRevenueDkk,
         double totalCostDkk,
         Double marginPercent
-) {}
+) {
+    public MonthlyRevenuePracticeDataPoint {
+        if (monthKey == null || !monthKey.matches("\\d{6}"))
+            throw new IllegalArgumentException("monthKey must be YYYYMM, was " + monthKey);
+        if (monthNumber < 1 || monthNumber > 12)
+            throw new IllegalArgumentException("monthNumber out of range: " + monthNumber);
+        if (year < 2000 || year > 2100)
+            throw new IllegalArgumentException("year out of range: " + year);
+        // Defensive copy preserves insertion order (LinkedHashMap) while preventing
+        // external mutation. Map.copyOf would lose ordering and reject null values
+        // (the service uses 0.0 for missing practices, never null, so order is the
+        // only practical concern).
+        practiceRevenue = practiceRevenue == null
+                ? Map.of()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(practiceRevenue));
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/MonthlyRevenuePracticeDataPoint.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/MonthlyRevenuePracticeDataPoint.java
@@ -1,0 +1,26 @@
+package dk.trustworks.intranet.aggregates.finance.dto.cxo;
+
+import java.util.Map;
+
+/**
+ * One month of consultant-level invoiced revenue broken down by practice (service line).
+ *
+ * <p>The {@link #practiceRevenue} map serializes as a JSON object whose keys are
+ * the practice ids present in the parent {@link RevenuePracticeDTO#practices()} list,
+ * each value being the DKK revenue for that practice in this month. Missing
+ * practices are explicitly populated with {@code 0.0} so the frontend can rely
+ * on key parity across all months.</p>
+ *
+ * <p>{@link #marginPercent} is {@code null} for months with no positive revenue;
+ * otherwise it is rounded to two decimal places.</p>
+ */
+public record MonthlyRevenuePracticeDataPoint(
+        String monthKey,
+        int year,
+        int monthNumber,
+        String monthLabel,
+        Map<String, Double> practiceRevenue,
+        double totalRevenueDkk,
+        double totalCostDkk,
+        Double marginPercent
+) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/NewVsRepeatClientRevenueDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/NewVsRepeatClientRevenueDTO.java
@@ -1,0 +1,15 @@
+package dk.trustworks.intranet.aggregates.finance.dto.cxo;
+
+import java.util.List;
+
+/**
+ * Wrapper response for GET /clients/cxo/new-vs-repeat-revenue.
+ *
+ * <p>{@link #quarters} is the time-ordered (ascending year then quarter) series
+ * of quarterly buckets, each split into NEW vs REPEAT revenue. A project's
+ * revenue counts as NEW for the quarter that contains the project's first-ever
+ * invoice; otherwise the same project's revenue is REPEAT.</p>
+ */
+public record NewVsRepeatClientRevenueDTO(
+        List<QuarterlyNewVsRepeatDTO> quarters
+) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/NewVsRepeatClientRevenueDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/NewVsRepeatClientRevenueDTO.java
@@ -1,6 +1,7 @@
 package dk.trustworks.intranet.aggregates.finance.dto.cxo;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Wrapper response for GET /clients/cxo/new-vs-repeat-revenue.
@@ -12,4 +13,8 @@ import java.util.List;
  */
 public record NewVsRepeatClientRevenueDTO(
         List<QuarterlyNewVsRepeatDTO> quarters
-) {}
+) {
+    public NewVsRepeatClientRevenueDTO {
+        Objects.requireNonNull(quarters, "quarters");
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/QuarterlyNewVsRepeatDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/QuarterlyNewVsRepeatDTO.java
@@ -18,4 +18,11 @@ public record QuarterlyNewVsRepeatDTO(
         double repeatRevenueDkk,
         double totalRevenueDkk,
         Double repeatSharePercent
-) {}
+) {
+    public QuarterlyNewVsRepeatDTO {
+        if (quarter < 1 || quarter > 4)
+            throw new IllegalArgumentException("quarter out of range: " + quarter);
+        if (year < 2000 || year > 2100)
+            throw new IllegalArgumentException("year out of range: " + year);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/QuarterlyNewVsRepeatDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/QuarterlyNewVsRepeatDTO.java
@@ -1,0 +1,21 @@
+package dk.trustworks.intranet.aggregates.finance.dto.cxo;
+
+/**
+ * One quarter row in the New vs Repeat client revenue series.
+ *
+ * <p>{@code repeatSharePercent} is boxed because total revenue can be zero in
+ * empty quarters; the BFF contract returns {@code null} in that case rather
+ * than {@code 0.0} so the UI can render an N/A indicator.</p>
+ *
+ * <p>Field names match the frontend {@code QuarterlyNewVsRepeatDTO} (camelCase),
+ * so no {@code @JsonProperty} annotations are needed.</p>
+ */
+public record QuarterlyNewVsRepeatDTO(
+        int year,
+        int quarter,
+        String quarterLabel,
+        double newRevenueDkk,
+        double repeatRevenueDkk,
+        double totalRevenueDkk,
+        Double repeatSharePercent
+) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/RevenuePracticeDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/RevenuePracticeDTO.java
@@ -1,6 +1,7 @@
 package dk.trustworks.intranet.aggregates.finance.dto.cxo;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Wrapper response for GET /finance/cxo/revenue-by-practice.
@@ -14,4 +15,9 @@ import java.util.List;
 public record RevenuePracticeDTO(
         List<MonthlyRevenuePracticeDataPoint> months,
         List<String> practices
-) {}
+) {
+    public RevenuePracticeDTO {
+        Objects.requireNonNull(months, "months");
+        Objects.requireNonNull(practices, "practices");
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/RevenuePracticeDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/RevenuePracticeDTO.java
@@ -1,0 +1,17 @@
+package dk.trustworks.intranet.aggregates.finance.dto.cxo;
+
+import java.util.List;
+
+/**
+ * Wrapper response for GET /finance/cxo/revenue-by-practice.
+ *
+ * <p>{@link #months} is the time-ordered (ascending {@code monthKey}) series of
+ * monthly data points. {@link #practices} is the ordered list of practice ids
+ * that have at least one non-zero entry across the full series; the canonical
+ * order is {@code [PM, SA, BA, DEV, CYB]} with {@code OTHER} appended last when
+ * present.</p>
+ */
+public record RevenuePracticeDTO(
+        List<MonthlyRevenuePracticeDataPoint> months,
+        List<String> practices
+) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoClientResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoClientResource.java
@@ -699,7 +699,6 @@ public class CxoClientResource {
      */
     @GET
     @Path("/new-vs-repeat-revenue")
-    @RolesAllowed({"clients:read"})
     public NewVsRepeatClientRevenueDTO newVsRepeatRevenue(
             @QueryParam("fromDate") String fromDate,
             @QueryParam("toDate") String toDate,

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoClientResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoClientResource.java
@@ -56,6 +56,21 @@ public class CxoClientResource {
     jakarta.persistence.EntityManager em;
 
     /**
+     * Splits a comma-separated UUID list query param into a Set; returns null for blank input.
+     * Null means "no company filter" — services bind null to a SQL parameter and the WHERE clause
+     * `(:companyIds IS NULL OR fact.company_id IN (:companyIds))` short-circuits.
+     */
+    private static Set<String> parseCompanyIds(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        Set<String> out = new HashSet<>();
+        for (String s : raw.split(",")) {
+            String trimmed = s.trim();
+            if (!trimmed.isEmpty()) out.add(trimmed);
+        }
+        return out.isEmpty() ? null : out;
+    }
+
+    /**
      * Gets Active Clients (TTM) KPI data.
      * Returns the count of distinct clients with revenue in a trailing 12-month window,
      * along with year-over-year comparison and monthly sparkline trend.

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoClientResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoClientResource.java
@@ -678,7 +678,7 @@ public class CxoClientResource {
      * The result is the time-ordered series of quarters with absolute DKK amounts and
      * a repeat-share percentage.</p>
      *
-     * @param fromDate ISO-8601 start date (optional, defaults to 2 years before today, day 1)
+     * @param fromDate ISO-8601 start date (optional, defaults to the 1st of the calendar month two years ago)
      * @param toDate   ISO-8601 end date (optional, defaults to today)
      * @param companyIds comma-separated company UUIDs (optional)
      * @return NewVsRepeatClientRevenueDTO with the quarter series
@@ -686,16 +686,14 @@ public class CxoClientResource {
     @GET
     @Path("/new-vs-repeat-revenue")
     public NewVsRepeatClientRevenueDTO newVsRepeatRevenue(
-            @QueryParam("fromDate") String fromDate,
-            @QueryParam("toDate") String toDate,
+            @QueryParam("fromDate") LocalDate fromDate,
+            @QueryParam("toDate") LocalDate toDate,
             @QueryParam("companyIds") String companyIds) {
 
         log.debugf("GET /clients/cxo/new-vs-repeat-revenue: fromDate=%s, toDate=%s, companyIds=%s",
                 fromDate, toDate, companyIds);
 
-        LocalDate from = (fromDate == null || fromDate.isBlank()) ? null : LocalDate.parse(fromDate);
-        LocalDate to = (toDate == null || toDate.isBlank()) ? null : LocalDate.parse(toDate);
-        return cxoClientService.newVsRepeatRevenue(from, to, parseCommaSeparated(companyIds));
+        return cxoClientService.newVsRepeatRevenue(fromDate, toDate, parseCommaSeparated(companyIds));
     }
 
     /**
@@ -714,15 +712,13 @@ public class CxoClientResource {
     @GET
     @Path("/credit-note-rate")
     public CreditNoteRateDTO creditNoteRate(
-            @QueryParam("fromDate") String fromDate,
-            @QueryParam("toDate") String toDate,
+            @QueryParam("fromDate") LocalDate fromDate,
+            @QueryParam("toDate") LocalDate toDate,
             @QueryParam("companyIds") String companyIds) {
 
         log.debugf("GET /clients/cxo/credit-note-rate: fromDate=%s, toDate=%s, companyIds=%s",
                 fromDate, toDate, companyIds);
 
-        LocalDate from = (fromDate == null || fromDate.isBlank()) ? null : LocalDate.parse(fromDate);
-        LocalDate to = (toDate == null || toDate.isBlank()) ? null : LocalDate.parse(toDate);
-        return cxoClientService.creditNoteRate(from, to, parseCommaSeparated(companyIds));
+        return cxoClientService.creditNoteRate(fromDate, toDate, parseCommaSeparated(companyIds));
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoClientResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoClientResource.java
@@ -14,6 +14,7 @@ import dk.trustworks.intranet.aggregates.finance.dto.EngagementByCompanyDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.FactFreshnessDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.IndustryDistributionDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.ServiceLinePenetrationDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.NewVsRepeatClientRevenueDTO;
 import dk.trustworks.intranet.aggregates.finance.services.CxoClientService;
 import dk.trustworks.intranet.aggregates.finance.services.analytics.ClientProfitabilityProvider;
 import jakarta.annotation.security.RolesAllowed;
@@ -681,5 +682,34 @@ public class CxoClientResource {
                 Integer.valueOf(result.getSegments().size()), Integer.valueOf(result.getTotalClients()), Double.valueOf(result.getTotalRevenueM()));
 
         return Response.ok(result).build();
+    }
+
+    /**
+     * Gets quarterly New vs Repeat client revenue.
+     *
+     * <p>Each quarter's revenue is split into "NEW" (project's first-ever invoice falls
+     * within that quarter) and "REPEAT" (subsequent quarters for the same project).
+     * The result is the time-ordered series of quarters with absolute DKK amounts and
+     * a repeat-share percentage.</p>
+     *
+     * @param fromDate ISO-8601 start date (optional, defaults to 2 years before today, day 1)
+     * @param toDate   ISO-8601 end date (optional, defaults to today)
+     * @param companyIds comma-separated company UUIDs (optional)
+     * @return NewVsRepeatClientRevenueDTO with the quarter series
+     */
+    @GET
+    @Path("/new-vs-repeat-revenue")
+    @RolesAllowed({"clients:read"})
+    public NewVsRepeatClientRevenueDTO newVsRepeatRevenue(
+            @QueryParam("fromDate") String fromDate,
+            @QueryParam("toDate") String toDate,
+            @QueryParam("companyIds") String companyIds) {
+
+        log.debugf("GET /clients/cxo/new-vs-repeat-revenue: fromDate=%s, toDate=%s, companyIds=%s",
+                fromDate, toDate, companyIds);
+
+        LocalDate from = (fromDate == null || fromDate.isBlank()) ? null : LocalDate.parse(fromDate);
+        LocalDate to = (toDate == null || toDate.isBlank()) ? null : LocalDate.parse(toDate);
+        return cxoClientService.newVsRepeatRevenue(from, to, parseCompanyIds(companyIds));
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoClientResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoClientResource.java
@@ -14,6 +14,7 @@ import dk.trustworks.intranet.aggregates.finance.dto.EngagementByCompanyDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.FactFreshnessDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.IndustryDistributionDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.ServiceLinePenetrationDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.CreditNoteRateDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.cxo.NewVsRepeatClientRevenueDTO;
 import dk.trustworks.intranet.aggregates.finance.services.CxoClientService;
 import dk.trustworks.intranet.aggregates.finance.services.analytics.ClientProfitabilityProvider;
@@ -710,5 +711,33 @@ public class CxoClientResource {
         LocalDate from = (fromDate == null || fromDate.isBlank()) ? null : LocalDate.parse(fromDate);
         LocalDate to = (toDate == null || toDate.isBlank()) ? null : LocalDate.parse(toDate);
         return cxoClientService.newVsRepeatRevenue(from, to, parseCompanyIds(companyIds));
+    }
+
+    /**
+     * Gets the monthly credit-note rate plus the top-5 clients by credit-note volume.
+     *
+     * <p>Only invoices in {@code economics_status IN ('BOOKED', 'PAID')} are counted, so
+     * drafts and in-progress invoices are excluded from the ratio. The {@code creditNoteRatePct}
+     * is the percentage of total billed value that was credited back, returned as
+     * {@code 0.0} (never null) when no invoices fall in a given month.</p>
+     *
+     * @param fromDate ISO-8601 start date (optional, defaults to the 1st of the month 11 months ago)
+     * @param toDate   ISO-8601 end date (optional, defaults to today)
+     * @param companyIds comma-separated company UUIDs (optional)
+     * @return CreditNoteRateDTO with the monthly series and top-5 clients
+     */
+    @GET
+    @Path("/credit-note-rate")
+    public CreditNoteRateDTO creditNoteRate(
+            @QueryParam("fromDate") String fromDate,
+            @QueryParam("toDate") String toDate,
+            @QueryParam("companyIds") String companyIds) {
+
+        log.debugf("GET /clients/cxo/credit-note-rate: fromDate=%s, toDate=%s, companyIds=%s",
+                fromDate, toDate, companyIds);
+
+        LocalDate from = (fromDate == null || fromDate.isBlank()) ? null : LocalDate.parse(fromDate);
+        LocalDate to = (toDate == null || toDate.isBlank()) ? null : LocalDate.parse(toDate);
+        return cxoClientService.creditNoteRate(from, to, parseCompanyIds(companyIds));
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoClientResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoClientResource.java
@@ -58,21 +58,6 @@ public class CxoClientResource {
     jakarta.persistence.EntityManager em;
 
     /**
-     * Splits a comma-separated UUID list query param into a Set; returns null for blank input.
-     * Null means "no company filter" — services bind null to a SQL parameter and the WHERE clause
-     * `(:companyIds IS NULL OR fact.company_id IN (:companyIds))` short-circuits.
-     */
-    private static Set<String> parseCompanyIds(String raw) {
-        if (raw == null || raw.isBlank()) return null;
-        Set<String> out = new HashSet<>();
-        for (String s : raw.split(",")) {
-            String trimmed = s.trim();
-            if (!trimmed.isEmpty()) out.add(trimmed);
-        }
-        return out.isEmpty() ? null : out;
-    }
-
-    /**
      * Gets Active Clients (TTM) KPI data.
      * Returns the count of distinct clients with revenue in a trailing 12-month window,
      * along with year-over-year comparison and monthly sparkline trend.
@@ -710,7 +695,7 @@ public class CxoClientResource {
 
         LocalDate from = (fromDate == null || fromDate.isBlank()) ? null : LocalDate.parse(fromDate);
         LocalDate to = (toDate == null || toDate.isBlank()) ? null : LocalDate.parse(toDate);
-        return cxoClientService.newVsRepeatRevenue(from, to, parseCompanyIds(companyIds));
+        return cxoClientService.newVsRepeatRevenue(from, to, parseCommaSeparated(companyIds));
     }
 
     /**
@@ -738,6 +723,6 @@ public class CxoClientResource {
 
         LocalDate from = (fromDate == null || fromDate.isBlank()) ? null : LocalDate.parse(fromDate);
         LocalDate to = (toDate == null || toDate.isBlank()) ? null : LocalDate.parse(toDate);
-        return cxoClientService.creditNoteRate(from, to, parseCompanyIds(companyIds));
+        return cxoClientService.creditNoteRate(from, to, parseCommaSeparated(companyIds));
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
@@ -43,6 +43,7 @@ import dk.trustworks.intranet.aggregates.finance.dto.CareerLevelEconomicsDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.VoluntaryAttritionDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.cxo.CostToRevenueDataPointDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.cxo.GrossMarginTrendDataPointDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.RevenuePracticeDTO;
 import dk.trustworks.intranet.aggregates.finance.model.CareerLevelBonus;
 import dk.trustworks.intranet.aggregates.finance.services.ConsultantInsightsService;
 import dk.trustworks.intranet.aggregates.finance.services.CxoFinanceService;
@@ -1822,6 +1823,35 @@ public class CxoFinanceResource {
     public List<GrossMarginTrendDataPointDTO> grossMarginTrend(@QueryParam("companyIds") String companyIds) {
         log.debugf("GET /finance/cxo/gross-margin-trend: companyIds=%s", companyIds);
         return cxoFinanceService.grossMarginTrend(parseCompanyIds(companyIds));
+    }
+
+    /**
+     * CXO Command Center: monthly invoiced revenue broken down by practice (service line),
+     * with cost and margin overlay.
+     *
+     * <p>Revenue is attributed at the consultant level via {@code u.practice} of the delivering
+     * consultant — NOT the project-level service line — to avoid distortion from EXTERNAL
+     * consultants, mixed-practice projects, and "UD" (Undefined) buckets. Cost remains
+     * project-level (from {@code fact_project_financials_mat}). Months with cost but no
+     * revenue still appear in the response with an empty practice revenue map.</p>
+     *
+     * @param fromDate optional ISO date (YYYY-MM-DD); defaults to first day of (today − 17 months)
+     * @param toDate   optional ISO date (YYYY-MM-DD); defaults to today
+     * @param companyIds optional comma-separated list of company UUIDs to filter by
+     * @return wrapper containing the monthly series and the ordered practices list
+     */
+    @GET
+    @Path("/revenue-by-practice")
+    @RolesAllowed({"finance:read"})
+    public RevenuePracticeDTO revenueByPractice(
+            @QueryParam("fromDate") String fromDate,
+            @QueryParam("toDate") String toDate,
+            @QueryParam("companyIds") String companyIds) {
+        log.debugf("GET /finance/cxo/revenue-by-practice: fromDate=%s, toDate=%s, companyIds=%s",
+                fromDate, toDate, companyIds);
+        LocalDate from = (fromDate == null || fromDate.isBlank()) ? null : LocalDate.parse(fromDate);
+        LocalDate to = (toDate == null || toDate.isBlank()) ? null : LocalDate.parse(toDate);
+        return cxoFinanceService.revenueByPractice(from, to, parseCompanyIds(companyIds));
     }
 
     /**

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
@@ -42,6 +42,7 @@ import dk.trustworks.intranet.aggregates.finance.dto.CareerLevelConsultantsDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.CareerLevelEconomicsDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.VoluntaryAttritionDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.cxo.CostToRevenueDataPointDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.GrossMarginTrendDataPointDTO;
 import dk.trustworks.intranet.aggregates.finance.model.CareerLevelBonus;
 import dk.trustworks.intranet.aggregates.finance.services.ConsultantInsightsService;
 import dk.trustworks.intranet.aggregates.finance.services.CxoFinanceService;
@@ -1803,6 +1804,24 @@ public class CxoFinanceResource {
     public List<CostToRevenueDataPointDTO> costToRevenue(@QueryParam("companyIds") String companyIds) {
         log.debugf("GET /finance/cxo/cost-to-revenue: companyIds=%s", companyIds);
         return cxoFinanceService.costToRevenue(parseCompanyIds(companyIds));
+    }
+
+    /**
+     * CXO Command Center: trailing 18 months of gross margin data.
+     *
+     * Returns one data point per month with total revenue, total delivery cost,
+     * and the gross margin in percent (null when revenue is zero, though the SQL
+     * HAVING clause excludes zero-revenue months from the result set).
+     *
+     * @param companyIds optional comma-separated list of company UUIDs to filter by
+     * @return list of data points ordered by month_key ascending
+     */
+    @GET
+    @Path("/gross-margin-trend")
+    @RolesAllowed({"finance:read"})
+    public List<GrossMarginTrendDataPointDTO> grossMarginTrend(@QueryParam("companyIds") String companyIds) {
+        log.debugf("GET /finance/cxo/gross-margin-trend: companyIds=%s", companyIds);
+        return cxoFinanceService.grossMarginTrend(parseCompanyIds(companyIds));
     }
 
     /**

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
@@ -41,6 +41,7 @@ import dk.trustworks.intranet.aggregates.finance.dto.CareerLevelBonusDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.CareerLevelConsultantsDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.CareerLevelEconomicsDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.VoluntaryAttritionDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.CostToRevenueDataPointDTO;
 import dk.trustworks.intranet.aggregates.finance.model.CareerLevelBonus;
 import dk.trustworks.intranet.aggregates.finance.services.ConsultantInsightsService;
 import dk.trustworks.intranet.aggregates.finance.services.CxoFinanceService;
@@ -1785,6 +1786,23 @@ public class CxoFinanceResource {
         Set<String> companyIdSet = parseCommaSeparated(companyIds);
 
         return cxoFinanceService.getPracticeUtilizationForecast(practiceSet, companyIdSet);
+    }
+
+    /**
+     * CXO Command Center: trailing 18 months of cost-to-revenue ratio data.
+     *
+     * Returns one data point per month with revenue, direct delivery cost, OPEX,
+     * and the cost-to-revenue ratio in percent (null when revenue is zero).
+     *
+     * @param companyIds optional comma-separated list of company UUIDs to filter by
+     * @return list of data points ordered by month_key ascending
+     */
+    @GET
+    @Path("/cost-to-revenue")
+    @RolesAllowed({"finance:read"})
+    public List<CostToRevenueDataPointDTO> costToRevenue(@QueryParam("companyIds") String companyIds) {
+        log.debugf("GET /finance/cxo/cost-to-revenue: companyIds=%s", companyIds);
+        return cxoFinanceService.costToRevenue(parseCompanyIds(companyIds));
     }
 
     /**

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
@@ -97,21 +97,6 @@ public class CxoFinanceResource {
     RequestHeaderHolder requestHeaderHolder;
 
     /**
-     * Splits a comma-separated UUID list query param into a Set; returns null for blank input.
-     * Null means "no company filter" — services bind null to a SQL parameter and the WHERE clause
-     * `(:companyIds IS NULL OR fact.company_id IN (:companyIds))` short-circuits.
-     */
-    private static Set<String> parseCompanyIds(String raw) {
-        if (raw == null || raw.isBlank()) return null;
-        Set<String> out = new HashSet<>();
-        for (String s : raw.split(",")) {
-            String trimmed = s.trim();
-            if (!trimmed.isEmpty()) out.add(trimmed);
-        }
-        return out.isEmpty() ? null : out;
-    }
-
-    /**
      * Gets monthly revenue and margin trend data.
      *
      * @param fromDate Start date (ISO-8601 format, optional)
@@ -1803,7 +1788,7 @@ public class CxoFinanceResource {
     @Path("/cost-to-revenue")
     public List<CostToRevenueDataPointDTO> costToRevenue(@QueryParam("companyIds") String companyIds) {
         log.debugf("GET /finance/cxo/cost-to-revenue: companyIds=%s", companyIds);
-        return cxoFinanceService.costToRevenue(parseCompanyIds(companyIds));
+        return cxoFinanceService.costToRevenue(parseCommaSeparated(companyIds));
     }
 
     /**
@@ -1820,7 +1805,7 @@ public class CxoFinanceResource {
     @Path("/gross-margin-trend")
     public List<GrossMarginTrendDataPointDTO> grossMarginTrend(@QueryParam("companyIds") String companyIds) {
         log.debugf("GET /finance/cxo/gross-margin-trend: companyIds=%s", companyIds);
-        return cxoFinanceService.grossMarginTrend(parseCompanyIds(companyIds));
+        return cxoFinanceService.grossMarginTrend(parseCommaSeparated(companyIds));
     }
 
     /**
@@ -1848,7 +1833,7 @@ public class CxoFinanceResource {
                 fromDate, toDate, companyIds);
         LocalDate from = (fromDate == null || fromDate.isBlank()) ? null : LocalDate.parse(fromDate);
         LocalDate to = (toDate == null || toDate.isBlank()) ? null : LocalDate.parse(toDate);
-        return cxoFinanceService.revenueByPractice(from, to, parseCompanyIds(companyIds));
+        return cxoFinanceService.revenueByPractice(from, to, parseCommaSeparated(companyIds));
     }
 
     /**

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
@@ -1801,7 +1801,6 @@ public class CxoFinanceResource {
      */
     @GET
     @Path("/cost-to-revenue")
-    @RolesAllowed({"finance:read"})
     public List<CostToRevenueDataPointDTO> costToRevenue(@QueryParam("companyIds") String companyIds) {
         log.debugf("GET /finance/cxo/cost-to-revenue: companyIds=%s", companyIds);
         return cxoFinanceService.costToRevenue(parseCompanyIds(companyIds));
@@ -1819,7 +1818,6 @@ public class CxoFinanceResource {
      */
     @GET
     @Path("/gross-margin-trend")
-    @RolesAllowed({"finance:read"})
     public List<GrossMarginTrendDataPointDTO> grossMarginTrend(@QueryParam("companyIds") String companyIds) {
         log.debugf("GET /finance/cxo/gross-margin-trend: companyIds=%s", companyIds);
         return cxoFinanceService.grossMarginTrend(parseCompanyIds(companyIds));
@@ -1842,7 +1840,6 @@ public class CxoFinanceResource {
      */
     @GET
     @Path("/revenue-by-practice")
-    @RolesAllowed({"finance:read"})
     public RevenuePracticeDTO revenueByPractice(
             @QueryParam("fromDate") String fromDate,
             @QueryParam("toDate") String toDate,

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
@@ -94,6 +94,21 @@ public class CxoFinanceResource {
     RequestHeaderHolder requestHeaderHolder;
 
     /**
+     * Splits a comma-separated UUID list query param into a Set; returns null for blank input.
+     * Null means "no company filter" — services bind null to a SQL parameter and the WHERE clause
+     * `(:companyIds IS NULL OR fact.company_id IN (:companyIds))` short-circuits.
+     */
+    private static Set<String> parseCompanyIds(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        Set<String> out = new HashSet<>();
+        for (String s : raw.split(",")) {
+            String trimmed = s.trim();
+            if (!trimmed.isEmpty()) out.add(trimmed);
+        }
+        return out.isEmpty() ? null : out;
+    }
+
+    /**
      * Gets monthly revenue and margin trend data.
      *
      * @param fromDate Start date (ISO-8601 format, optional)

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
@@ -1826,14 +1826,12 @@ public class CxoFinanceResource {
     @GET
     @Path("/revenue-by-practice")
     public RevenuePracticeDTO revenueByPractice(
-            @QueryParam("fromDate") String fromDate,
-            @QueryParam("toDate") String toDate,
+            @QueryParam("fromDate") LocalDate fromDate,
+            @QueryParam("toDate") LocalDate toDate,
             @QueryParam("companyIds") String companyIds) {
         log.debugf("GET /finance/cxo/revenue-by-practice: fromDate=%s, toDate=%s, companyIds=%s",
                 fromDate, toDate, companyIds);
-        LocalDate from = (fromDate == null || fromDate.isBlank()) ? null : LocalDate.parse(fromDate);
-        LocalDate to = (toDate == null || toDate.isBlank()) ? null : LocalDate.parse(toDate);
-        return cxoFinanceService.revenueByPractice(from, to, parseCommaSeparated(companyIds));
+        return cxoFinanceService.revenueByPractice(fromDate, toDate, parseCommaSeparated(companyIds));
     }
 
     /**

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientService.java
@@ -16,7 +16,9 @@ import jakarta.persistence.Tuple;
 import lombok.extern.jbosslog.JBossLog;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.format.DateTimeFormatter;
+import java.time.format.TextStyle;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -27,6 +29,9 @@ import java.util.stream.Collectors;
 @JBossLog
 @ApplicationScoped
 public class CxoClientService {
+
+    /** Per-query timeout for CXO Command Center endpoints (matches the BFF's 15-second budget). */
+    private static final int CXO_QUERY_TIMEOUT_MS = 15_000;
 
     @Inject
     EntityManager em;
@@ -2335,7 +2340,7 @@ public class CxoClientService {
         if (hasCompanyFilter) {
             query.setParameter("companyIds", companyIds);
         }
-        query.setHint("javax.persistence.query.timeout", 15_000);
+        query.setHint("javax.persistence.query.timeout", CXO_QUERY_TIMEOUT_MS);
 
         @SuppressWarnings("unchecked")
         List<Tuple> rows = query.getResultList();
@@ -2377,22 +2382,13 @@ public class CxoClientService {
         }
 
         log.debugf("newVsRepeatRevenue: returned %d quarters (companyFilter=%s)",
-                Integer.valueOf(quarters.size()), Boolean.toString(hasCompanyFilter));
+                quarters.size(), Boolean.toString(hasCompanyFilter));
         return new NewVsRepeatClientRevenueDTO(quarters);
     }
 
     // ============================================================================
     // CXO Command Center: Credit Note Rate
     // ============================================================================
-
-    private static final String[] CREDIT_NOTE_MONTH_LABELS = {
-            "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-    };
-
-    private static String creditNoteMonthLabel(int year, int monthNumber) {
-        return CREDIT_NOTE_MONTH_LABELS[monthNumber - 1] + " " + year;
-    }
 
     /**
      * Returns the monthly credit-note rate series plus the top-5 clients by credit-note
@@ -2462,7 +2458,7 @@ public class CxoClientService {
         if (hasCompanyFilter) {
             monthlyQuery.setParameter("companyIds", companyIds);
         }
-        monthlyQuery.setHint("javax.persistence.query.timeout", 15_000);
+        monthlyQuery.setHint("javax.persistence.query.timeout", CXO_QUERY_TIMEOUT_MS);
 
         Query topClientsQuery = em.createNativeQuery(topClientsSql, Tuple.class);
         topClientsQuery.setParameter("fromDate", from);
@@ -2470,7 +2466,7 @@ public class CxoClientService {
         if (hasCompanyFilter) {
             topClientsQuery.setParameter("companyIds", companyIds);
         }
-        topClientsQuery.setHint("javax.persistence.query.timeout", 15_000);
+        topClientsQuery.setHint("javax.persistence.query.timeout", CXO_QUERY_TIMEOUT_MS);
 
         @SuppressWarnings("unchecked")
         List<Tuple> monthlyRows = monthlyQuery.getResultList();
@@ -2492,7 +2488,7 @@ public class CxoClientService {
                     monthKey,
                     year,
                     monthNumber,
-                    creditNoteMonthLabel(year, monthNumber),
+                    Month.of(monthNumber).getDisplayName(TextStyle.SHORT, Locale.ENGLISH) + " " + year,
                     invoiceAmt,
                     creditNoteAmt,
                     ratePct
@@ -2508,8 +2504,8 @@ public class CxoClientService {
         }
 
         log.debugf("creditNoteRate: %d monthly buckets, %d top clients (companyFilter=%s)",
-                Integer.valueOf(monthly.size()),
-                Integer.valueOf(topClients.size()),
+                monthly.size(),
+                topClients.size(),
                 Boolean.toString(hasCompanyFilter));
         return new CreditNoteRateDTO(monthly, topClients);
     }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientService.java
@@ -1,6 +1,9 @@
 package dk.trustworks.intranet.aggregates.finance.services;
 
 import dk.trustworks.intranet.aggregates.finance.dto.*;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.CreditNoteRateDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.CreditNoteTopClientDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.MonthlyCreditNoteDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.cxo.NewVsRepeatClientRevenueDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.cxo.QuarterlyNewVsRepeatDTO;
 import dk.trustworks.intranet.dao.crm.model.Client;
@@ -2376,5 +2379,138 @@ public class CxoClientService {
         log.debugf("newVsRepeatRevenue: returned %d quarters (companyFilter=%s)",
                 Integer.valueOf(quarters.size()), Boolean.toString(hasCompanyFilter));
         return new NewVsRepeatClientRevenueDTO(quarters);
+    }
+
+    // ============================================================================
+    // CXO Command Center: Credit Note Rate
+    // ============================================================================
+
+    private static final String[] CREDIT_NOTE_MONTH_LABELS = {
+            "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    };
+
+    private static String creditNoteMonthLabel(int year, int monthNumber) {
+        return CREDIT_NOTE_MONTH_LABELS[monthNumber - 1] + " " + year;
+    }
+
+    /**
+     * Returns the monthly credit-note rate series plus the top-5 clients by credit-note
+     * volume, mirroring the BFF route at {@code /api/cxo/clients/credit-note-rate}.
+     *
+     * <p>Only invoices in {@code economics_status IN ('BOOKED', 'PAID')} are counted, so
+     * drafts and in-progress invoices do not skew the ratio. The credit-note rate is
+     * computed in Java (not SQL) for parity with the BFF: when the denominator is zero
+     * the rate is {@code 0.0} rather than null.</p>
+     *
+     * @param fromDate inclusive start of the date window; defaults to the 1st of the month
+     *                 11 months before today when {@code null} (matches BFF default)
+     * @param toDate   inclusive end of the date window; defaults to today when {@code null}
+     * @param companyIds optional set of company UUIDs; {@code null}/empty means no company filter
+     * @return wrapper with the time-ordered monthly series and the top-5 clients
+     */
+    public CreditNoteRateDTO creditNoteRate(LocalDate fromDate, LocalDate toDate, Set<String> companyIds) {
+        LocalDate today = LocalDate.now();
+        LocalDate from = fromDate != null ? fromDate : today.withDayOfMonth(1).minusMonths(11);
+        LocalDate to = toDate != null ? toDate : today;
+
+        boolean hasCompanyFilter = companyIds != null && !companyIds.isEmpty();
+        String companyFilter = hasCompanyFilter ? " AND i.companyuuid IN (:companyIds)" : "";
+
+        String monthlySql = "SELECT " +
+                "  DATE_FORMAT(i.invoicedate, '%Y%m')     AS month_key, " +
+                "  YEAR(i.invoicedate)                     AS year_num, " +
+                "  MONTH(i.invoicedate)                    AS month_number, " +
+                "  SUM(CASE WHEN i.type IN ('INVOICE', 'PHANTOM') " +
+                "        THEN COALESCE(ii.rate * ii.hours, 0) " +
+                "        ELSE 0 " +
+                "      END)                                AS invoice_amount, " +
+                "  ABS(SUM(CASE WHEN i.type = 'CREDIT_NOTE' " +
+                "        THEN COALESCE(ii.rate * ii.hours, 0) " +
+                "        ELSE 0 " +
+                "      END))                               AS credit_note_amount " +
+                "FROM invoices i " +
+                "JOIN invoiceitems ii ON ii.invoiceuuid = i.uuid " +
+                "WHERE i.economics_status IN ('BOOKED', 'PAID') " +
+                "  AND i.invoicedate BETWEEN :fromDate AND :toDate " +
+                "  AND ii.rate IS NOT NULL " +
+                "  AND ii.hours IS NOT NULL" +
+                companyFilter + " " +
+                "GROUP BY DATE_FORMAT(i.invoicedate, '%Y%m'), YEAR(i.invoicedate), MONTH(i.invoicedate) " +
+                "ORDER BY month_key";
+
+        String topClientsSql = "SELECT " +
+                "  i.clientname                  AS clientname, " +
+                "  ABS(SUM(ii.rate * ii.hours))  AS total_credit_note_amount, " +
+                "  COUNT(DISTINCT i.uuid)        AS credit_note_count " +
+                "FROM invoices i " +
+                "JOIN invoiceitems ii ON ii.invoiceuuid = i.uuid " +
+                "WHERE i.type = 'CREDIT_NOTE' " +
+                "  AND i.economics_status IN ('BOOKED', 'PAID') " +
+                "  AND i.invoicedate BETWEEN :fromDate AND :toDate " +
+                "  AND ii.rate IS NOT NULL " +
+                "  AND ii.hours IS NOT NULL " +
+                "  AND i.clientname IS NOT NULL" +
+                companyFilter + " " +
+                "GROUP BY i.clientname " +
+                "ORDER BY total_credit_note_amount DESC " +
+                "LIMIT 5";
+
+        Query monthlyQuery = em.createNativeQuery(monthlySql, Tuple.class);
+        monthlyQuery.setParameter("fromDate", from);
+        monthlyQuery.setParameter("toDate", to);
+        if (hasCompanyFilter) {
+            monthlyQuery.setParameter("companyIds", companyIds);
+        }
+        monthlyQuery.setHint("javax.persistence.query.timeout", 15_000);
+
+        Query topClientsQuery = em.createNativeQuery(topClientsSql, Tuple.class);
+        topClientsQuery.setParameter("fromDate", from);
+        topClientsQuery.setParameter("toDate", to);
+        if (hasCompanyFilter) {
+            topClientsQuery.setParameter("companyIds", companyIds);
+        }
+        topClientsQuery.setHint("javax.persistence.query.timeout", 15_000);
+
+        @SuppressWarnings("unchecked")
+        List<Tuple> monthlyRows = monthlyQuery.getResultList();
+        @SuppressWarnings("unchecked")
+        List<Tuple> topClientRows = topClientsQuery.getResultList();
+
+        List<MonthlyCreditNoteDTO> monthly = new ArrayList<>(monthlyRows.size());
+        for (Tuple row : monthlyRows) {
+            String monthKey = row.get("month_key", String.class);
+            int year = ((Number) row.get("year_num")).intValue();
+            int monthNumber = ((Number) row.get("month_number")).intValue();
+            double invoiceAmt = toDouble(row.get("invoice_amount"));
+            double creditNoteAmt = toDouble(row.get("credit_note_amount"));
+            double total = invoiceAmt + creditNoteAmt;
+            double ratePct = total > 0
+                    ? Math.round((creditNoteAmt / total) * 10000.0) / 100.0
+                    : 0.0;
+            monthly.add(new MonthlyCreditNoteDTO(
+                    monthKey,
+                    year,
+                    monthNumber,
+                    creditNoteMonthLabel(year, monthNumber),
+                    invoiceAmt,
+                    creditNoteAmt,
+                    ratePct
+            ));
+        }
+
+        List<CreditNoteTopClientDTO> topClients = new ArrayList<>(topClientRows.size());
+        for (Tuple row : topClientRows) {
+            String clientName = row.get("clientname", String.class);
+            double creditNoteAmt = toDouble(row.get("total_credit_note_amount"));
+            long creditNoteCount = ((Number) row.get("credit_note_count")).longValue();
+            topClients.add(new CreditNoteTopClientDTO(clientName, creditNoteAmt, creditNoteCount));
+        }
+
+        log.debugf("creditNoteRate: %d monthly buckets, %d top clients (companyFilter=%s)",
+                Integer.valueOf(monthly.size()),
+                Integer.valueOf(topClients.size()),
+                Boolean.toString(hasCompanyFilter));
+        return new CreditNoteRateDTO(monthly, topClients);
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientService.java
@@ -1,12 +1,15 @@
 package dk.trustworks.intranet.aggregates.finance.services;
 
 import dk.trustworks.intranet.aggregates.finance.dto.*;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.NewVsRepeatClientRevenueDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.QuarterlyNewVsRepeatDTO;
 import dk.trustworks.intranet.dao.crm.model.Client;
 import dk.trustworks.intranet.utils.TwConstants;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
+import jakarta.persistence.Tuple;
 import lombok.extern.jbosslog.JBossLog;
 
 import java.time.LocalDate;
@@ -2235,5 +2238,143 @@ public class CxoClientService {
                 totalClients,
                 Math.round(totalRevenueM * 100.0) / 100.0
         );
+    }
+
+    // ============================================================================
+    // CXO Command Center: New vs Repeat Client Revenue (quarterly)
+    // ============================================================================
+
+    /**
+     * Mutable accumulator used while folding native query rows into per-quarter buckets.
+     * Kept private to this service because it is not part of the API contract.
+     */
+    private static final class QuarterAccumulator {
+        final int year;
+        final int quarter;
+        double newRev;
+        double repeatRev;
+
+        QuarterAccumulator(int year, int quarter) {
+            this.year = year;
+            this.quarter = quarter;
+        }
+    }
+
+    /**
+     * Returns quarterly revenue split into NEW vs REPEAT client buckets, mirroring the BFF
+     * route at {@code /api/cxo/clients/new-vs-repeat-revenue}.
+     *
+     * <p>Classification rule: a project's revenue is "NEW" for the quarter that contains
+     * the project's first-ever invoice; otherwise the same project's revenue is "REPEAT".
+     * The classification is per project, not per client, because the underlying invoice
+     * data is keyed on {@code projectuuid}.</p>
+     *
+     * @param fromDate inclusive start of the date window; defaults to the 1st of the month
+     *                 two years ago when {@code null} (matches BFF default)
+     * @param toDate   inclusive end of the date window; defaults to today when {@code null}
+     * @param companyIds optional set of company UUIDs; {@code null}/empty means no company filter
+     * @return wrapper with the time-ordered quarterly breakdown
+     */
+    public NewVsRepeatClientRevenueDTO newVsRepeatRevenue(LocalDate fromDate, LocalDate toDate, Set<String> companyIds) {
+        LocalDate today = LocalDate.now();
+        LocalDate from = fromDate != null ? fromDate : today.minusYears(2).withDayOfMonth(1);
+        LocalDate to = toDate != null ? toDate : today;
+
+        boolean hasCompanyFilter = companyIds != null && !companyIds.isEmpty();
+        String companyFilter = hasCompanyFilter ? " AND i.companyuuid IN (:companyIds)" : "";
+
+        // CTE 1: project_first_invoice — earliest invoice date per project across all time.
+        // CTE 2: quarter_revenue — per project per quarter revenue, with quarter_start derived
+        //        so the final SELECT can compare it to first_invoice_date.
+        // Final: classify NEW vs REPEAT and SUM revenue per (year, quarter, client_type).
+        String sql = "WITH project_first_invoice AS ( " +
+                "  SELECT projectuuid, MIN(invoicedate) AS first_invoice_date " +
+                "  FROM invoices " +
+                "  WHERE type IN ('INVOICE', 'PHANTOM') " +
+                "    AND status IN ('CREATED', 'DRAFT') " +
+                "    AND projectuuid IS NOT NULL " +
+                "    AND projectuuid != '' " +
+                "  GROUP BY projectuuid " +
+                "), " +
+                "quarter_revenue AS ( " +
+                "  SELECT " +
+                "    YEAR(i.invoicedate)    AS yr, " +
+                "    QUARTER(i.invoicedate) AS qtr, " +
+                "    DATE(CONCAT( " +
+                "      YEAR(i.invoicedate), '-', " +
+                "      LPAD((QUARTER(i.invoicedate) - 1) * 3 + 1, 2, '0'), " +
+                "      '-01' " +
+                "    )) AS quarter_start, " +
+                "    i.projectuuid, " +
+                "    pfi.first_invoice_date, " +
+                "    SUM(ii.rate * ii.hours) AS revenue " +
+                "  FROM invoices i " +
+                "  JOIN invoiceitems ii ON ii.invoiceuuid = i.uuid " +
+                "  JOIN project_first_invoice pfi ON pfi.projectuuid = i.projectuuid " +
+                "  WHERE i.type IN ('INVOICE', 'PHANTOM') " +
+                "    AND i.status IN ('CREATED', 'DRAFT') " +
+                "    AND i.invoicedate BETWEEN :fromDate AND :toDate" +
+                companyFilter + " " +
+                "  GROUP BY yr, qtr, quarter_start, i.projectuuid, pfi.first_invoice_date " +
+                ") " +
+                "SELECT " +
+                "  yr, " +
+                "  qtr, " +
+                "  CASE WHEN first_invoice_date >= quarter_start THEN 'NEW' ELSE 'REPEAT' END AS client_type, " +
+                "  SUM(revenue) AS total_revenue " +
+                "FROM quarter_revenue " +
+                "GROUP BY yr, qtr, client_type " +
+                "ORDER BY yr, qtr, client_type";
+
+        Query query = em.createNativeQuery(sql, Tuple.class);
+        query.setParameter("fromDate", from);
+        query.setParameter("toDate", to);
+        if (hasCompanyFilter) {
+            query.setParameter("companyIds", companyIds);
+        }
+        query.setHint("javax.persistence.query.timeout", 15_000);
+
+        @SuppressWarnings("unchecked")
+        List<Tuple> rows = query.getResultList();
+
+        // Aggregate per (year, quarter). TreeMap on the composite int key gives natural
+        // chronological ordering without parsing strings back out.
+        TreeMap<Integer, QuarterAccumulator> byKey = new TreeMap<>();
+        for (Tuple row : rows) {
+            int yr = ((Number) row.get("yr")).intValue();
+            int qtr = ((Number) row.get("qtr")).intValue();
+            String clientType = row.get("client_type", String.class);
+            double revenue = row.get("total_revenue") == null ? 0.0
+                    : ((Number) row.get("total_revenue")).doubleValue();
+
+            int key = yr * 10 + qtr;
+            QuarterAccumulator acc = byKey.computeIfAbsent(key, k -> new QuarterAccumulator(yr, qtr));
+            if ("NEW".equals(clientType)) {
+                acc.newRev += revenue;
+            } else {
+                acc.repeatRev += revenue;
+            }
+        }
+
+        List<QuarterlyNewVsRepeatDTO> quarters = new ArrayList<>(byKey.size());
+        for (QuarterAccumulator acc : byKey.values()) {
+            double total = acc.newRev + acc.repeatRev;
+            Double repeatSharePercent = total > 0
+                    ? Math.round((acc.repeatRev / total) * 10000.0) / 100.0
+                    : null;
+            quarters.add(new QuarterlyNewVsRepeatDTO(
+                    acc.year,
+                    acc.quarter,
+                    "Q" + acc.quarter + " " + acc.year,
+                    acc.newRev,
+                    acc.repeatRev,
+                    total,
+                    repeatSharePercent
+            ));
+        }
+
+        log.debugf("newVsRepeatRevenue: returned %d quarters (companyFilter=%s)",
+                Integer.valueOf(quarters.size()), Boolean.toString(hasCompanyFilter));
+        return new NewVsRepeatClientRevenueDTO(quarters);
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientService.java
@@ -2269,8 +2269,8 @@ public class CxoClientService {
     }
 
     /**
-     * Returns quarterly revenue split into NEW vs REPEAT client buckets, mirroring the BFF
-     * route at {@code /api/cxo/clients/new-vs-repeat-revenue}.
+     * Returns quarterly revenue split into NEW vs REPEAT client buckets. Ported from the
+     * legacy BFF route at {@code /api/cxo/clients/new-vs-repeat-revenue}.
      *
      * <p>Classification rule: a project's revenue is "NEW" for the quarter that contains
      * the project's first-ever invoice; otherwise the same project's revenue is "REPEAT".
@@ -2392,12 +2392,12 @@ public class CxoClientService {
 
     /**
      * Returns the monthly credit-note rate series plus the top-5 clients by credit-note
-     * volume, mirroring the BFF route at {@code /api/cxo/clients/credit-note-rate}.
+     * volume. Ported from the legacy BFF route at {@code /api/cxo/clients/credit-note-rate}.
      *
      * <p>Only invoices in {@code economics_status IN ('BOOKED', 'PAID')} are counted, so
      * drafts and in-progress invoices do not skew the ratio. The credit-note rate is
-     * computed in Java (not SQL) for parity with the BFF: when the denominator is zero
-     * the rate is {@code 0.0} rather than null.</p>
+     * computed in Java (not SQL): when the denominator is zero the rate is {@code 0.0}
+     * rather than null.</p>
      *
      * @param fromDate inclusive start of the date window; defaults to the 1st of the month
      *                 11 months before today when {@code null} (matches BFF default)

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
@@ -54,13 +54,16 @@ import jakarta.persistence.Tuple;
 import lombok.extern.jbosslog.JBossLog;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.YearMonth;
+import java.time.format.TextStyle;
 
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -6008,14 +6011,8 @@ public class CxoFinanceService {
     // CXO Command Center: Cost-to-Revenue
     // ============================================================================
 
-    private static final String[] MONTH_LABELS = {
-            "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-    };
-
-    private static String costToRevenueMonthLabel(int year, int monthNumber) {
-        return MONTH_LABELS[monthNumber - 1] + " " + year;
-    }
+    /** Per-query timeout for CXO Command Center endpoints (matches the BFF's 15-second budget). */
+    private static final int CXO_QUERY_TIMEOUT_MS = 15_000;
 
     /**
      * Returns trailing 18 months of cost-to-revenue data, optionally filtered by company UUIDs.
@@ -6034,8 +6031,8 @@ public class CxoFinanceService {
         int fromMonth = fromDate.getMonthValue();
         int toYear = today.getYear();
         int toMonth = today.getMonthValue();
-        String fromMonthKey = String.format("%d%02d", fromYear, fromMonth);
-        String toMonthKey = String.format("%d%02d", toYear, toMonth);
+        String fromMonthKey = String.format("%04d%02d", fromYear, fromMonth);
+        String toMonthKey = String.format("%04d%02d", toYear, toMonth);
 
         boolean hasCompanyFilter = companyIds != null && !companyIds.isEmpty();
         String companyFilterRevenue = hasCompanyFilter ? " AND r.company_id IN (:companyIds)" : "";
@@ -6062,8 +6059,7 @@ public class CxoFinanceService {
                 "LEFT JOIN ( " +
                 "  SELECT month_key, company_id, SUM(direct_delivery_cost_dkk) AS delivery_cost " +
                 "  FROM fact_project_financials_mat " +
-                "  WHERE (year > :fromYear OR (year = :fromYear AND month_number >= :fromMonth)) " +
-                "    AND (year < :toYear OR (year = :toYear AND month_number <= :toMonth))" +
+                "  WHERE month_key BETWEEN :fromMonthKey AND :toMonthKey" +
                 companyFilterDelivery + " " +
                 "  GROUP BY month_key, company_id " +
                 ") d ON d.month_key = r.month_key AND d.company_id = r.company_id " +
@@ -6071,27 +6067,22 @@ public class CxoFinanceService {
                 "  SELECT month_key, company_id, SUM(opex_amount_dkk) AS opex_cost " +
                 "  FROM fact_opex_mat " +
                 "  WHERE cost_type = 'OPEX' " +
-                "    AND (month_key >= :fromMonthKey AND month_key <= :toMonthKey)" +
+                "    AND month_key BETWEEN :fromMonthKey AND :toMonthKey" +
                 companyFilterOpex + " " +
                 "  GROUP BY month_key, company_id " +
                 ") o ON o.month_key = r.month_key AND o.company_id = r.company_id " +
-                "WHERE (r.year > :fromYear OR (r.year = :fromYear AND r.month_number >= :fromMonth)) " +
-                "  AND (r.year < :toYear OR (r.year = :toYear AND r.month_number <= :toMonth))" +
+                "WHERE r.month_key BETWEEN :fromMonthKey AND :toMonthKey" +
                 companyFilterRevenue + " " +
                 "GROUP BY r.month_key, r.year, r.month_number " +
                 "ORDER BY r.month_key";
 
         Query query = em.createNativeQuery(sql, Tuple.class);
-        query.setParameter("fromYear", fromYear);
-        query.setParameter("toYear", toYear);
-        query.setParameter("fromMonth", fromMonth);
-        query.setParameter("toMonth", toMonth);
         query.setParameter("fromMonthKey", fromMonthKey);
         query.setParameter("toMonthKey", toMonthKey);
         if (hasCompanyFilter) {
             query.setParameter("companyIds", companyIds);
         }
-        query.setHint("javax.persistence.query.timeout", 15_000);
+        query.setHint("javax.persistence.query.timeout", CXO_QUERY_TIMEOUT_MS);
 
         @SuppressWarnings("unchecked")
         List<Tuple> rows = query.getResultList();
@@ -6110,7 +6101,7 @@ public class CxoFinanceService {
                     monthKey,
                     year,
                     monthNumber,
-                    costToRevenueMonthLabel(year, monthNumber),
+                    Month.of(monthNumber).getDisplayName(TextStyle.SHORT, Locale.ENGLISH) + " " + year,
                     revenueDkk,
                     deliveryCostDkk,
                     opexDkk,
@@ -6143,6 +6134,8 @@ public class CxoFinanceService {
         int fromMonth = fromDate.getMonthValue();
         int toYear = today.getYear();
         int toMonth = today.getMonthValue();
+        String fromMonthKey = String.format("%04d%02d", fromYear, fromMonth);
+        String toMonthKey = String.format("%04d%02d", toYear, toMonth);
 
         boolean hasCompanyFilter = companyIds != null && !companyIds.isEmpty();
         String companyFilter = hasCompanyFilter ? " AND company_id IN (:companyIds)" : "";
@@ -6163,22 +6156,19 @@ public class CxoFinanceService {
                 "    ELSE NULL " +
                 "  END AS gross_margin_pct " +
                 "FROM fact_project_financials_mat " +
-                "WHERE (year > :fromYear OR (year = :fromYear AND month_number >= :fromMonth)) " +
-                "  AND (year < :toYear OR (year = :toYear AND month_number <= :toMonth))" +
+                "WHERE month_key BETWEEN :fromMonthKey AND :toMonthKey" +
                 companyFilter + " " +
                 "GROUP BY month_key, year, month_number " +
                 "HAVING SUM(recognized_revenue_dkk) > 0 " +
                 "ORDER BY month_key";
 
         Query query = em.createNativeQuery(sql, Tuple.class);
-        query.setParameter("fromYear", fromYear);
-        query.setParameter("toYear", toYear);
-        query.setParameter("fromMonth", fromMonth);
-        query.setParameter("toMonth", toMonth);
+        query.setParameter("fromMonthKey", fromMonthKey);
+        query.setParameter("toMonthKey", toMonthKey);
         if (hasCompanyFilter) {
             query.setParameter("companyIds", companyIds);
         }
-        query.setHint("javax.persistence.query.timeout", 15_000);
+        query.setHint("javax.persistence.query.timeout", CXO_QUERY_TIMEOUT_MS);
 
         @SuppressWarnings("unchecked")
         List<Tuple> rows = query.getResultList();
@@ -6196,7 +6186,7 @@ public class CxoFinanceService {
                     monthKey,
                     year,
                     monthNumber,
-                    costToRevenueMonthLabel(year, monthNumber),
+                    Month.of(monthNumber).getDisplayName(TextStyle.SHORT, Locale.ENGLISH) + " " + year,
                     totalRevenueDkk,
                     totalCostDkk,
                     grossMarginPct
@@ -6244,6 +6234,8 @@ public class CxoFinanceService {
         int fromMonth = from.getMonthValue();
         int toYear = to.getYear();
         int toMonth = to.getMonthValue();
+        String fromMonthKey = String.format("%04d%02d", fromYear, fromMonth);
+        String toMonthKey = String.format("%04d%02d", toYear, toMonth);
 
         boolean hasCompanyFilter = companyIds != null && !companyIds.isEmpty();
         String revenueCompanyFilter = hasCompanyFilter ? " AND us.companyuuid IN (:companyIds)" : "";
@@ -6289,7 +6281,7 @@ public class CxoFinanceService {
         if (hasCompanyFilter) {
             revenueQuery.setParameter("companyIds", companyIds);
         }
-        revenueQuery.setHint("javax.persistence.query.timeout", 15_000);
+        revenueQuery.setHint("javax.persistence.query.timeout", CXO_QUERY_TIMEOUT_MS);
 
         @SuppressWarnings("unchecked")
         List<Tuple> revenueRows = revenueQuery.getResultList();
@@ -6301,21 +6293,18 @@ public class CxoFinanceService {
                 "  month_number, " +
                 "  SUM(direct_delivery_cost_dkk) AS cost_dkk " +
                 "FROM fact_project_financials_mat " +
-                "WHERE (year > :fromYear OR (year = :fromYear AND month_number >= :fromMonth)) " +
-                "  AND (year < :toYear OR (year = :toYear AND month_number <= :toMonth))" +
+                "WHERE month_key BETWEEN :fromMonthKey AND :toMonthKey" +
                 costCompanyFilter + " " +
                 "GROUP BY month_key, year, month_number " +
                 "ORDER BY month_key";
 
         Query costQuery = em.createNativeQuery(costSql, Tuple.class);
-        costQuery.setParameter("fromYear", fromYear);
-        costQuery.setParameter("fromMonth", fromMonth);
-        costQuery.setParameter("toYear", toYear);
-        costQuery.setParameter("toMonth", toMonth);
+        costQuery.setParameter("fromMonthKey", fromMonthKey);
+        costQuery.setParameter("toMonthKey", toMonthKey);
         if (hasCompanyFilter) {
             costQuery.setParameter("companyIds", companyIds);
         }
-        costQuery.setHint("javax.persistence.query.timeout", 15_000);
+        costQuery.setHint("javax.persistence.query.timeout", CXO_QUERY_TIMEOUT_MS);
 
         @SuppressWarnings("unchecked")
         List<Tuple> costRows = costQuery.getResultList();
@@ -6395,7 +6384,7 @@ public class CxoFinanceService {
                     monthKey,
                     agg.year,
                     agg.monthNumber,
-                    costToRevenueMonthLabel(agg.year, agg.monthNumber),
+                    Month.of(agg.monthNumber).getDisplayName(TextStyle.SHORT, Locale.ENGLISH) + " " + agg.year,
                     practiceRevenue,
                     totalRevenueDkk,
                     totalCostDkk,

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
@@ -32,6 +32,7 @@ import dk.trustworks.intranet.aggregates.finance.dto.OpexRowExportDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.RevenueSourceDataDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.VoluntaryAttritionDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.cxo.CostToRevenueDataPointDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.GrossMarginTrendDataPointDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.PracticeUtilizationMonthDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.BudgetHoursByMonthDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.FutureNetAvailableDTO;
@@ -6115,6 +6116,91 @@ public class CxoFinanceService {
         }
 
         log.debugf("costToRevenue: returned %d data points (companyFilter=%s)", result.size(), Boolean.toString(hasCompanyFilter));
+        return result;
+    }
+
+    // ============================================================================
+    // CXO Command Center: Gross Margin Trend
+    // ============================================================================
+
+    /**
+     * Returns trailing 18 months of gross margin data, optionally filtered by company UUIDs.
+     *
+     * Mirrors the BFF route at /api/cxo/finance/gross-margin-trend (same SQL, same date window).
+     * Only months with positive revenue are included (HAVING SUM(recognized_revenue_dkk) > 0)
+     * to avoid nonsensical margins from zero or negative revenue months.
+     *
+     * @param companyIds optional set of company UUIDs; null means no company filter
+     * @return monthly data points ordered by month_key ascending (may be empty)
+     */
+    public List<GrossMarginTrendDataPointDTO> grossMarginTrend(Set<String> companyIds) {
+        LocalDate today = LocalDate.now();
+        LocalDate fromDate = today.withDayOfMonth(1).minusMonths(17);
+        int fromYear = fromDate.getYear();
+        int fromMonth = fromDate.getMonthValue();
+        int toYear = today.getYear();
+        int toMonth = today.getMonthValue();
+
+        boolean hasCompanyFilter = companyIds != null && !companyIds.isEmpty();
+        String companyFilter = hasCompanyFilter ? " AND company_id IN (:companyIds)" : "";
+
+        String sql = "SELECT " +
+                "  month_key, " +
+                "  year           AS year_num, " +
+                "  month_number, " +
+                "  SUM(recognized_revenue_dkk)     AS total_revenue_dkk, " +
+                "  SUM(direct_delivery_cost_dkk)   AS total_cost_dkk, " +
+                "  CASE " +
+                "    WHEN SUM(recognized_revenue_dkk) > 0 " +
+                "    THEN ROUND( " +
+                "      (SUM(recognized_revenue_dkk) - SUM(direct_delivery_cost_dkk)) " +
+                "      / NULLIF(SUM(recognized_revenue_dkk), 0) * 100, " +
+                "      2 " +
+                "    ) " +
+                "    ELSE NULL " +
+                "  END AS gross_margin_pct " +
+                "FROM fact_project_financials_mat " +
+                "WHERE (year > :fromYear OR (year = :fromYear AND month_number >= :fromMonth)) " +
+                "  AND (year < :toYear OR (year = :toYear AND month_number <= :toMonth))" +
+                companyFilter + " " +
+                "GROUP BY month_key, year, month_number " +
+                "HAVING SUM(recognized_revenue_dkk) > 0 " +
+                "ORDER BY month_key";
+
+        Query query = em.createNativeQuery(sql, Tuple.class);
+        query.setParameter("fromYear", fromYear);
+        query.setParameter("toYear", toYear);
+        query.setParameter("fromMonth", fromMonth);
+        query.setParameter("toMonth", toMonth);
+        if (hasCompanyFilter) {
+            query.setParameter("companyIds", companyIds);
+        }
+        query.setHint("javax.persistence.query.timeout", 15_000);
+
+        @SuppressWarnings("unchecked")
+        List<Tuple> rows = query.getResultList();
+
+        List<GrossMarginTrendDataPointDTO> result = new ArrayList<>(rows.size());
+        for (Tuple t : rows) {
+            String monthKey = t.get("month_key", String.class);
+            int year = ((Number) t.get("year_num")).intValue();
+            int monthNumber = ((Number) t.get("month_number")).intValue();
+            double totalRevenueDkk = ((Number) t.get("total_revenue_dkk")).doubleValue();
+            double totalCostDkk = ((Number) t.get("total_cost_dkk")).doubleValue();
+            Object marginRaw = t.get("gross_margin_pct");
+            Double grossMarginPct = marginRaw == null ? null : ((Number) marginRaw).doubleValue();
+            result.add(new GrossMarginTrendDataPointDTO(
+                    monthKey,
+                    year,
+                    monthNumber,
+                    costToRevenueMonthLabel(year, monthNumber),
+                    totalRevenueDkk,
+                    totalCostDkk,
+                    grossMarginPct
+            ));
+        }
+
+        log.debugf("grossMarginTrend: returned %d data points (companyFilter=%s)", result.size(), Boolean.toString(hasCompanyFilter));
         return result;
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
@@ -33,6 +33,8 @@ import dk.trustworks.intranet.aggregates.finance.dto.RevenueSourceDataDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.VoluntaryAttritionDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.cxo.CostToRevenueDataPointDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.cxo.GrossMarginTrendDataPointDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.MonthlyRevenuePracticeDataPoint;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.RevenuePracticeDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.PracticeUtilizationMonthDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.BudgetHoursByMonthDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.FutureNetAvailableDTO;
@@ -61,6 +63,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**
@@ -6202,5 +6205,218 @@ public class CxoFinanceService {
 
         log.debugf("grossMarginTrend: returned %d data points (companyFilter=%s)", result.size(), Boolean.toString(hasCompanyFilter));
         return result;
+    }
+
+    // ============================================================================
+    // CXO Command Center: Revenue by Practice
+    // ============================================================================
+
+    /**
+     * Canonical order for known practice ids in the {@code practices} response array.
+     * Anything else returned by the SQL is folded into {@code "OTHER"} which, when present,
+     * is appended after this list.
+     */
+    private static final List<String> KNOWN_PRACTICES = List.of("PM", "SA", "BA", "DEV", "CYB");
+
+    /**
+     * Returns trailing-window revenue broken down by practice (consultant-level attribution),
+     * with cost and margin overlay. Mirrors the BFF route at
+     * {@code /api/cxo/finance/revenue-by-practice}.
+     *
+     * <p>The revenue query attributes each invoice line item to {@code u.practice} of the
+     * delivering consultant (NOT the project-level service line). The cost query aggregates
+     * direct delivery cost by month from {@code fact_project_financials_mat}. Java assembles
+     * the two streams: cost-only months are present in the result with empty practice
+     * revenue, and any practice id outside {@link #KNOWN_PRACTICES} is collapsed into
+     * {@code "OTHER"}.</p>
+     *
+     * @param fromDate inclusive start of date window; defaults to first day of (now − 17 months) when null
+     * @param toDate   inclusive end of date window; defaults to today when null
+     * @param companyIds optional set of company UUIDs; null/empty means no company filter
+     * @return wrapper with the time-ordered month series and the ordered practices list
+     */
+    public RevenuePracticeDTO revenueByPractice(LocalDate fromDate, LocalDate toDate, Set<String> companyIds) {
+        LocalDate today = LocalDate.now();
+        LocalDate from = fromDate != null ? fromDate : today.withDayOfMonth(1).minusMonths(17);
+        LocalDate to = toDate != null ? toDate : today;
+
+        int fromYear = from.getYear();
+        int fromMonth = from.getMonthValue();
+        int toYear = to.getYear();
+        int toMonth = to.getMonthValue();
+
+        boolean hasCompanyFilter = companyIds != null && !companyIds.isEmpty();
+        String revenueCompanyFilter = hasCompanyFilter ? " AND us.companyuuid IN (:companyIds)" : "";
+        String costCompanyFilter = hasCompanyFilter ? " AND companyuuid IN (:companyIds)" : "";
+
+        // ----- Revenue query: consultant-level attribution via u.practice -----
+        String revenueSql = "SELECT " +
+                "  DATE_FORMAT(i.invoicedate, '%Y%m')    AS month_key, " +
+                "  YEAR(i.invoicedate)                   AS year_val, " +
+                "  MONTH(i.invoicedate)                  AS month_number, " +
+                "  COALESCE(u.practice, 'OTHER')         AS service_line_id, " +
+                "  SUM( " +
+                "    ii.rate * ii.hours " +
+                "    * CASE WHEN i.type = 'CREDIT_NOTE' THEN -1 ELSE 1 END " +
+                "    * CASE WHEN i.currency = 'DKK' THEN 1 ELSE COALESCE(cur.conversion, 1) END " +
+                "  ) AS revenue_dkk " +
+                "FROM invoiceitems ii " +
+                "JOIN invoices i ON ii.invoiceuuid = i.uuid " +
+                "JOIN `user` u ON u.uuid = ii.consultantuuid " +
+                "LEFT JOIN userstatus us ON us.useruuid = ii.consultantuuid " +
+                "  AND us.statusdate = ( " +
+                "    SELECT MAX(us2.statusdate) FROM userstatus us2 " +
+                "    WHERE us2.useruuid = ii.consultantuuid AND us2.statusdate <= i.invoicedate " +
+                "  ) " +
+                "LEFT JOIN currences cur ON cur.currency = i.currency " +
+                "  AND cur.month = DATE_FORMAT(i.invoicedate, '%Y%m') " +
+                "WHERE i.status = 'CREATED' " +
+                "  AND i.type IN ('INVOICE', 'PHANTOM', 'CREDIT_NOTE') " +
+                "  AND ii.rate IS NOT NULL AND ii.hours IS NOT NULL " +
+                "  AND ii.consultantuuid IS NOT NULL " +
+                "  AND us.type = 'CONSULTANT' " +
+                "  AND (YEAR(i.invoicedate) > :fromYear OR (YEAR(i.invoicedate) = :fromYear AND MONTH(i.invoicedate) >= :fromMonth)) " +
+                "  AND (YEAR(i.invoicedate) < :toYear OR (YEAR(i.invoicedate) = :toYear AND MONTH(i.invoicedate) <= :toMonth))" +
+                revenueCompanyFilter + " " +
+                "GROUP BY month_key, year_val, month_number, COALESCE(u.practice, 'OTHER') " +
+                "ORDER BY month_key, service_line_id";
+
+        Query revenueQuery = em.createNativeQuery(revenueSql, Tuple.class);
+        revenueQuery.setParameter("fromYear", fromYear);
+        revenueQuery.setParameter("fromMonth", fromMonth);
+        revenueQuery.setParameter("toYear", toYear);
+        revenueQuery.setParameter("toMonth", toMonth);
+        if (hasCompanyFilter) {
+            revenueQuery.setParameter("companyIds", companyIds);
+        }
+        revenueQuery.setHint("javax.persistence.query.timeout", 15_000);
+
+        @SuppressWarnings("unchecked")
+        List<Tuple> revenueRows = revenueQuery.getResultList();
+
+        // ----- Cost query: project-level direct delivery cost grouped by month -----
+        String costSql = "SELECT " +
+                "  month_key, " +
+                "  year                          AS year_val, " +
+                "  month_number, " +
+                "  SUM(direct_delivery_cost_dkk) AS cost_dkk " +
+                "FROM fact_project_financials_mat " +
+                "WHERE (year > :fromYear OR (year = :fromYear AND month_number >= :fromMonth)) " +
+                "  AND (year < :toYear OR (year = :toYear AND month_number <= :toMonth))" +
+                costCompanyFilter + " " +
+                "GROUP BY month_key, year, month_number " +
+                "ORDER BY month_key";
+
+        Query costQuery = em.createNativeQuery(costSql, Tuple.class);
+        costQuery.setParameter("fromYear", fromYear);
+        costQuery.setParameter("fromMonth", fromMonth);
+        costQuery.setParameter("toYear", toYear);
+        costQuery.setParameter("toMonth", toMonth);
+        if (hasCompanyFilter) {
+            costQuery.setParameter("companyIds", companyIds);
+        }
+        costQuery.setHint("javax.persistence.query.timeout", 15_000);
+
+        @SuppressWarnings("unchecked")
+        List<Tuple> costRows = costQuery.getResultList();
+
+        // ----- Index cost rows by month_key -----
+        Map<String, Double> costByMonth = new LinkedHashMap<>(costRows.size());
+        for (Tuple t : costRows) {
+            String monthKey = t.get("month_key", String.class);
+            double costDkk = ((Number) t.get("cost_dkk")).doubleValue();
+            costByMonth.put(monthKey, costDkk);
+        }
+
+        // ----- Group revenue rows by month → (practiceId → revenue) -----
+        // TreeMap keeps natural string ordering of YYYYMM, matching BFF localeCompare sort.
+        Map<String, MonthAggregate> monthMap = new TreeMap<>();
+        for (Tuple t : revenueRows) {
+            String monthKey = t.get("month_key", String.class);
+            int year = ((Number) t.get("year_val")).intValue();
+            int monthNumber = ((Number) t.get("month_number")).intValue();
+            String rawPracticeId = t.get("service_line_id", String.class);
+            double revenue = ((Number) t.get("revenue_dkk")).doubleValue();
+
+            // Defensive remap: anything outside KNOWN_PRACTICES becomes OTHER (matches BFF).
+            String practiceId = (rawPracticeId != null && KNOWN_PRACTICES.contains(rawPracticeId))
+                    ? rawPracticeId
+                    : "OTHER";
+
+            MonthAggregate agg = monthMap.computeIfAbsent(
+                    monthKey,
+                    k -> new MonthAggregate(year, monthNumber, new LinkedHashMap<>())
+            );
+            agg.practices.merge(practiceId, revenue, Double::sum);
+        }
+
+        // ----- Ensure cost-only months are represented (with empty practice revenue) -----
+        for (Tuple t : costRows) {
+            String monthKey = t.get("month_key", String.class);
+            if (!monthMap.containsKey(monthKey)) {
+                int year = ((Number) t.get("year_val")).intValue();
+                int monthNumber = ((Number) t.get("month_number")).intValue();
+                monthMap.put(monthKey, new MonthAggregate(year, monthNumber, new LinkedHashMap<>()));
+            }
+        }
+
+        // ----- Determine which practices have data (preserve canonical order; OTHER last) -----
+        Set<String> practiceSet = new HashSet<>();
+        for (MonthAggregate agg : monthMap.values()) {
+            practiceSet.addAll(agg.practices.keySet());
+        }
+        List<String> practices = new ArrayList<>(KNOWN_PRACTICES.size() + 1);
+        for (String p : KNOWN_PRACTICES) {
+            if (practiceSet.contains(p)) practices.add(p);
+        }
+        if (practiceSet.contains("OTHER")) practices.add("OTHER");
+
+        // ----- Build month data points (sorted by monthKey ascending via TreeMap) -----
+        List<MonthlyRevenuePracticeDataPoint> months = new ArrayList<>(monthMap.size());
+        for (Map.Entry<String, MonthAggregate> entry : monthMap.entrySet()) {
+            String monthKey = entry.getKey();
+            MonthAggregate agg = entry.getValue();
+
+            // LinkedHashMap with insertion order matching the practices list → stable JSON key order.
+            Map<String, Double> practiceRevenue = new LinkedHashMap<>(practices.size());
+            double totalRevenueDkk = 0.0;
+            for (String p : practices) {
+                double rev = agg.practices.getOrDefault(p, 0.0);
+                practiceRevenue.put(p, rev);
+                totalRevenueDkk += rev;
+            }
+
+            double totalCostDkk = costByMonth.getOrDefault(monthKey, 0.0);
+            Double marginPercent = totalRevenueDkk > 0
+                    ? Math.round(((totalRevenueDkk - totalCostDkk) / totalRevenueDkk) * 10000.0) / 100.0
+                    : null;
+
+            months.add(new MonthlyRevenuePracticeDataPoint(
+                    monthKey,
+                    agg.year,
+                    agg.monthNumber,
+                    costToRevenueMonthLabel(agg.year, agg.monthNumber),
+                    practiceRevenue,
+                    totalRevenueDkk,
+                    totalCostDkk,
+                    marginPercent
+            ));
+        }
+
+        log.debugf("revenueByPractice: returned %d months / %d practices (companyFilter=%s)",
+                months.size(), practices.size(), Boolean.toString(hasCompanyFilter));
+        return new RevenuePracticeDTO(months, practices);
+    }
+
+    /** Mutable per-month aggregator used during revenueByPractice assembly. */
+    private static final class MonthAggregate {
+        final int year;
+        final int monthNumber;
+        final Map<String, Double> practices;
+        MonthAggregate(int year, int monthNumber, Map<String, Double> practices) {
+            this.year = year;
+            this.monthNumber = monthNumber;
+            this.practices = practices;
+        }
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
@@ -103,6 +103,25 @@ public class CxoFinanceService {
     @Inject
     DistributionAwareOpexProvider opexProvider;
 
+    // -------------------------------------------------------------------------
+    // Generic helpers for safe DB value conversion (BIT, Boolean, Number, etc.)
+    // Mirrors the pattern in CxoClientService so MariaDB BIT columns and other
+    // edge cases are handled uniformly across the CXO services.
+    // -------------------------------------------------------------------------
+
+    private static double toDouble(Object v) {
+        if (v == null) return 0d;
+        if (v instanceof Number n) return n.doubleValue();
+        if (v instanceof Boolean b) return b ? 1d : 0d;
+        if (v instanceof byte[] bytes) {
+            return (bytes.length > 0 && bytes[0] != 0) ? 1d : 0d;
+        }
+        if (v instanceof java.util.BitSet bs) {
+            return bs.isEmpty() ? 0d : 1d;
+        }
+        return Double.parseDouble(v.toString());
+    }
+
     /**
      * Retrieves monthly revenue and margin data for the specified period and filters.
      *
@@ -6017,9 +6036,9 @@ public class CxoFinanceService {
     /**
      * Returns trailing 18 months of cost-to-revenue data, optionally filtered by company UUIDs.
      *
-     * Mirrors the BFF route at /api/cxo/finance/cost-to-revenue (same SQL, same date window).
-     * The trailing 18-month window is computed from {@link LocalDate#now()} so that the result
-     * is always anchored on the current calendar month.
+     * Ported from the legacy BFF route /api/cxo/finance/cost-to-revenue. The trailing 18-month
+     * window is computed from {@link LocalDate#now()} so that the result is always anchored on
+     * the current calendar month.
      *
      * @param companyIds optional set of company UUIDs; null means no company filter
      * @return monthly data points ordered by month_key ascending (may be empty)
@@ -6092,11 +6111,13 @@ public class CxoFinanceService {
             String monthKey = t.get("month_key", String.class);
             int year = ((Number) t.get("year_num")).intValue();
             int monthNumber = ((Number) t.get("month_number")).intValue();
-            double revenueDkk = ((Number) t.get("revenue_dkk")).doubleValue();
-            double deliveryCostDkk = ((Number) t.get("delivery_cost_dkk")).doubleValue();
-            double opexDkk = ((Number) t.get("opex_dkk")).doubleValue();
+            double revenueDkk = toDouble(t.get("revenue_dkk"));
+            double deliveryCostDkk = toDouble(t.get("delivery_cost_dkk"));
+            double opexDkk = toDouble(t.get("opex_dkk"));
             Object ratioRaw = t.get("cost_to_revenue_ratio_pct");
-            Double costToRevenueRatioPct = ratioRaw == null ? null : ((Number) ratioRaw).doubleValue();
+            // Preserve the explicit null guard: toDouble would coerce null to 0.0,
+            // but the frontend contract expects a real null when revenue == 0.
+            Double costToRevenueRatioPct = ratioRaw == null ? null : toDouble(ratioRaw);
             result.add(new CostToRevenueDataPointDTO(
                     monthKey,
                     year,
@@ -6120,9 +6141,9 @@ public class CxoFinanceService {
     /**
      * Returns trailing 18 months of gross margin data, optionally filtered by company UUIDs.
      *
-     * Mirrors the BFF route at /api/cxo/finance/gross-margin-trend (same SQL, same date window).
-     * Only months with positive revenue are included (HAVING SUM(recognized_revenue_dkk) > 0)
-     * to avoid nonsensical margins from zero or negative revenue months.
+     * Ported from the legacy BFF route /api/cxo/finance/gross-margin-trend. Only months with
+     * positive revenue are included (HAVING SUM(recognized_revenue_dkk) > 0) to avoid
+     * nonsensical margins from zero or negative revenue months.
      *
      * @param companyIds optional set of company UUIDs; null means no company filter
      * @return monthly data points ordered by month_key ascending (may be empty)
@@ -6178,10 +6199,12 @@ public class CxoFinanceService {
             String monthKey = t.get("month_key", String.class);
             int year = ((Number) t.get("year_num")).intValue();
             int monthNumber = ((Number) t.get("month_number")).intValue();
-            double totalRevenueDkk = ((Number) t.get("total_revenue_dkk")).doubleValue();
-            double totalCostDkk = ((Number) t.get("total_cost_dkk")).doubleValue();
+            double totalRevenueDkk = toDouble(t.get("total_revenue_dkk"));
+            double totalCostDkk = toDouble(t.get("total_cost_dkk"));
             Object marginRaw = t.get("gross_margin_pct");
-            Double grossMarginPct = marginRaw == null ? null : ((Number) marginRaw).doubleValue();
+            // Preserve the explicit null guard: HAVING currently filters zero-revenue
+            // months but the frontend contract is `number | null`, so keep null-safety.
+            Double grossMarginPct = marginRaw == null ? null : toDouble(marginRaw);
             result.add(new GrossMarginTrendDataPointDTO(
                     monthKey,
                     year,
@@ -6210,7 +6233,7 @@ public class CxoFinanceService {
 
     /**
      * Returns trailing-window revenue broken down by practice (consultant-level attribution),
-     * with cost and margin overlay. Mirrors the BFF route at
+     * with cost and margin overlay. Ported from the legacy BFF route at
      * {@code /api/cxo/finance/revenue-by-practice}.
      *
      * <p>The revenue query attributes each invoice line item to {@code u.practice} of the
@@ -6309,25 +6332,74 @@ public class CxoFinanceService {
         @SuppressWarnings("unchecked")
         List<Tuple> costRows = costQuery.getResultList();
 
+        RevenuePracticeDTO response = buildRevenueByPracticeResponse(revenueRows, costRows);
+
+        log.debugf("revenueByPractice: returned %d months / %d practices (companyFilter=%s)",
+                response.months().size(), response.practices().size(), Boolean.toString(hasCompanyFilter));
+        return response;
+    }
+
+    /**
+     * Mutable per-month aggregator used during revenueByPractice assembly.
+     * Package-private so that {@link #buildRevenueByPracticeResponse(List, List)} can be
+     * unit-tested without booting Quarkus.
+     */
+    static final class MonthAggregate {
+        final int year;
+        final int monthNumber;
+        final Map<String, Double> practices;
+        MonthAggregate(int year, int monthNumber, Map<String, Double> practices) {
+            this.year = year;
+            this.monthNumber = monthNumber;
+            this.practices = practices;
+        }
+    }
+
+    /**
+     * Pure post-query aggregation for {@link #revenueByPractice(LocalDate, LocalDate, Set)}.
+     * Extracted to a package-private static method so it can be unit-tested without a database.
+     *
+     * <p>Steps:
+     * <ol>
+     *   <li>Index cost rows by {@code month_key} into a flat map.</li>
+     *   <li>Group revenue rows by {@code month_key} into ({@code practiceId} → revenue), folding
+     *       any practice id outside {@link #KNOWN_PRACTICES} into {@code "OTHER"}.</li>
+     *   <li>Ensure cost-only months are represented in the output (with empty practice revenue).</li>
+     *   <li>Determine which practices appear at all, preserving the canonical order
+     *       {@code [PM, SA, BA, DEV, CYB]} with {@code "OTHER"} appended last when present.</li>
+     *   <li>Emit one {@link MonthlyRevenuePracticeDataPoint} per month with the per-month margin
+     *       computed in Java ({@code null} when revenue ≤ 0).</li>
+     * </ol></p>
+     *
+     * @param revenueRows tuples with columns: {@code month_key}, {@code year_val}, {@code month_number},
+     *                    {@code service_line_id}, {@code revenue_dkk}
+     * @param costRows    tuples with columns: {@code month_key}, {@code year_val}, {@code month_number},
+     *                    {@code cost_dkk}
+     * @return assembled DTO ready for JSON serialization
+     */
+    static RevenuePracticeDTO buildRevenueByPracticeResponse(
+            List<Tuple> revenueRows,
+            List<Tuple> costRows) {
+
         // ----- Index cost rows by month_key -----
         Map<String, Double> costByMonth = new LinkedHashMap<>(costRows.size());
         for (Tuple t : costRows) {
             String monthKey = t.get("month_key", String.class);
-            double costDkk = ((Number) t.get("cost_dkk")).doubleValue();
+            double costDkk = toDouble(t.get("cost_dkk"));
             costByMonth.put(monthKey, costDkk);
         }
 
         // ----- Group revenue rows by month → (practiceId → revenue) -----
-        // TreeMap keeps natural string ordering of YYYYMM, matching BFF localeCompare sort.
+        // TreeMap keeps natural string ordering of YYYYMM (ascending chronological).
         Map<String, MonthAggregate> monthMap = new TreeMap<>();
         for (Tuple t : revenueRows) {
             String monthKey = t.get("month_key", String.class);
             int year = ((Number) t.get("year_val")).intValue();
             int monthNumber = ((Number) t.get("month_number")).intValue();
             String rawPracticeId = t.get("service_line_id", String.class);
-            double revenue = ((Number) t.get("revenue_dkk")).doubleValue();
+            double revenue = toDouble(t.get("revenue_dkk"));
 
-            // Defensive remap: anything outside KNOWN_PRACTICES becomes OTHER (matches BFF).
+            // Defensive remap: anything outside KNOWN_PRACTICES becomes OTHER.
             String practiceId = (rawPracticeId != null && KNOWN_PRACTICES.contains(rawPracticeId))
                     ? rawPracticeId
                     : "OTHER";
@@ -6392,20 +6464,6 @@ public class CxoFinanceService {
             ));
         }
 
-        log.debugf("revenueByPractice: returned %d months / %d practices (companyFilter=%s)",
-                months.size(), practices.size(), Boolean.toString(hasCompanyFilter));
         return new RevenuePracticeDTO(months, practices);
-    }
-
-    /** Mutable per-month aggregator used during revenueByPractice assembly. */
-    private static final class MonthAggregate {
-        final int year;
-        final int monthNumber;
-        final Map<String, Double> practices;
-        MonthAggregate(int year, int monthNumber, Map<String, Double> practices) {
-            this.year = year;
-            this.monthNumber = monthNumber;
-            this.practices = practices;
-        }
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
@@ -31,6 +31,7 @@ import dk.trustworks.intranet.aggregates.finance.dto.InvoiceItemExportDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.OpexRowExportDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.RevenueSourceDataDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.VoluntaryAttritionDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.CostToRevenueDataPointDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.PracticeUtilizationMonthDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.BudgetHoursByMonthDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.FutureNetAvailableDTO;
@@ -5996,6 +5997,124 @@ public class CxoFinanceService {
         }
 
         log.debugf("getPracticeUtilizationForecast: returned %d entries", result.size());
+        return result;
+    }
+
+    // ============================================================================
+    // CXO Command Center: Cost-to-Revenue
+    // ============================================================================
+
+    private static final String[] MONTH_LABELS = {
+            "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    };
+
+    private static String costToRevenueMonthLabel(int year, int monthNumber) {
+        return MONTH_LABELS[monthNumber - 1] + " " + year;
+    }
+
+    /**
+     * Returns trailing 18 months of cost-to-revenue data, optionally filtered by company UUIDs.
+     *
+     * Mirrors the BFF route at /api/cxo/finance/cost-to-revenue (same SQL, same date window).
+     * The trailing 18-month window is computed from {@link LocalDate#now()} so that the result
+     * is always anchored on the current calendar month.
+     *
+     * @param companyIds optional set of company UUIDs; null means no company filter
+     * @return monthly data points ordered by month_key ascending (may be empty)
+     */
+    public List<CostToRevenueDataPointDTO> costToRevenue(Set<String> companyIds) {
+        LocalDate today = LocalDate.now();
+        LocalDate fromDate = today.withDayOfMonth(1).minusMonths(17);
+        int fromYear = fromDate.getYear();
+        int fromMonth = fromDate.getMonthValue();
+        int toYear = today.getYear();
+        int toMonth = today.getMonthValue();
+        String fromMonthKey = String.format("%d%02d", fromYear, fromMonth);
+        String toMonthKey = String.format("%d%02d", toYear, toMonth);
+
+        boolean hasCompanyFilter = companyIds != null && !companyIds.isEmpty();
+        String companyFilterRevenue = hasCompanyFilter ? " AND r.company_id IN (:companyIds)" : "";
+        String companyFilterDelivery = hasCompanyFilter ? " AND company_id IN (:companyIds)" : "";
+        String companyFilterOpex = hasCompanyFilter ? " AND company_id IN (:companyIds)" : "";
+
+        String sql = "SELECT " +
+                "  r.month_key, " +
+                "  r.year          AS year_num, " +
+                "  r.month_number, " +
+                "  SUM(r.net_revenue_dkk)                      AS revenue_dkk, " +
+                "  COALESCE(SUM(d.delivery_cost), 0)            AS delivery_cost_dkk, " +
+                "  COALESCE(SUM(o.opex_cost), 0)                AS opex_dkk, " +
+                "  CASE " +
+                "    WHEN SUM(r.net_revenue_dkk) > 0 " +
+                "    THEN ROUND( " +
+                "      (COALESCE(SUM(d.delivery_cost), 0) + COALESCE(SUM(o.opex_cost), 0)) " +
+                "      / SUM(r.net_revenue_dkk) * 100, " +
+                "      2 " +
+                "    ) " +
+                "    ELSE NULL " +
+                "  END AS cost_to_revenue_ratio_pct " +
+                "FROM fact_company_revenue_mat r " +
+                "LEFT JOIN ( " +
+                "  SELECT month_key, company_id, SUM(direct_delivery_cost_dkk) AS delivery_cost " +
+                "  FROM fact_project_financials_mat " +
+                "  WHERE (year > :fromYear OR (year = :fromYear AND month_number >= :fromMonth)) " +
+                "    AND (year < :toYear OR (year = :toYear AND month_number <= :toMonth))" +
+                companyFilterDelivery + " " +
+                "  GROUP BY month_key, company_id " +
+                ") d ON d.month_key = r.month_key AND d.company_id = r.company_id " +
+                "LEFT JOIN ( " +
+                "  SELECT month_key, company_id, SUM(opex_amount_dkk) AS opex_cost " +
+                "  FROM fact_opex_mat " +
+                "  WHERE cost_type = 'OPEX' " +
+                "    AND (month_key >= :fromMonthKey AND month_key <= :toMonthKey)" +
+                companyFilterOpex + " " +
+                "  GROUP BY month_key, company_id " +
+                ") o ON o.month_key = r.month_key AND o.company_id = r.company_id " +
+                "WHERE (r.year > :fromYear OR (r.year = :fromYear AND r.month_number >= :fromMonth)) " +
+                "  AND (r.year < :toYear OR (r.year = :toYear AND r.month_number <= :toMonth))" +
+                companyFilterRevenue + " " +
+                "GROUP BY r.month_key, r.year, r.month_number " +
+                "ORDER BY r.month_key";
+
+        Query query = em.createNativeQuery(sql, Tuple.class);
+        query.setParameter("fromYear", fromYear);
+        query.setParameter("toYear", toYear);
+        query.setParameter("fromMonth", fromMonth);
+        query.setParameter("toMonth", toMonth);
+        query.setParameter("fromMonthKey", fromMonthKey);
+        query.setParameter("toMonthKey", toMonthKey);
+        if (hasCompanyFilter) {
+            query.setParameter("companyIds", companyIds);
+        }
+        query.setHint("javax.persistence.query.timeout", 15_000);
+
+        @SuppressWarnings("unchecked")
+        List<Tuple> rows = query.getResultList();
+
+        List<CostToRevenueDataPointDTO> result = new ArrayList<>(rows.size());
+        for (Tuple t : rows) {
+            String monthKey = t.get("month_key", String.class);
+            int year = ((Number) t.get("year_num")).intValue();
+            int monthNumber = ((Number) t.get("month_number")).intValue();
+            double revenueDkk = ((Number) t.get("revenue_dkk")).doubleValue();
+            double deliveryCostDkk = ((Number) t.get("delivery_cost_dkk")).doubleValue();
+            double opexDkk = ((Number) t.get("opex_dkk")).doubleValue();
+            Object ratioRaw = t.get("cost_to_revenue_ratio_pct");
+            Double costToRevenueRatioPct = ratioRaw == null ? null : ((Number) ratioRaw).doubleValue();
+            result.add(new CostToRevenueDataPointDTO(
+                    monthKey,
+                    year,
+                    monthNumber,
+                    costToRevenueMonthLabel(year, monthNumber),
+                    revenueDkk,
+                    deliveryCostDkk,
+                    opexDkk,
+                    costToRevenueRatioPct
+            ));
+        }
+
+        log.debugf("costToRevenue: returned %d data points (companyFilter=%s)", result.size(), Boolean.toString(hasCompanyFilter));
         return result;
     }
 }

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/CxoDtoJsonShapeTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/dto/cxo/CxoDtoJsonShapeTest.java
@@ -1,0 +1,101 @@
+package dk.trustworks.intranet.aggregates.finance.dto.cxo;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that the new CXO DTO records serialize to the exact JSON keys the
+ * frontend TypeScript types in src/lib/types/cxo.ts already consume. A record
+ * component rename or @JsonProperty addition would silently break the frontend;
+ * this test fails fast.
+ *
+ * Plain Jackson serialization (no Quarkus) — runs without DB.
+ */
+class CxoDtoJsonShapeTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private Set<String> keysOf(Object dto) throws Exception {
+        JsonNode node = mapper.valueToTree(dto);
+        Set<String> keys = new java.util.HashSet<>();
+        node.fieldNames().forEachRemaining(keys::add);
+        return keys;
+    }
+
+    @Test
+    void costToRevenueDataPointDto_jsonKeys() throws Exception {
+        var dto = new CostToRevenueDataPointDTO("202501", 2025, 1, "Jan 2025", 100.0, 30.0, 20.0, 50.0);
+        assertEquals(
+            Set.of("monthKey", "year", "monthNumber", "monthLabel",
+                   "revenueDkk", "deliveryCostDkk", "opexDkk", "costToRevenueRatioPct"),
+            keysOf(dto));
+    }
+
+    @Test
+    void grossMarginTrendDataPointDto_jsonKeys() throws Exception {
+        var dto = new GrossMarginTrendDataPointDTO("202501", 2025, 1, "Jan 2025", 100.0, 30.0, 70.0);
+        assertEquals(
+            Set.of("monthKey", "year", "monthNumber", "monthLabel",
+                   "totalRevenueDkk", "totalCostDkk", "grossMarginPct"),
+            keysOf(dto));
+    }
+
+    @Test
+    void monthlyRevenuePracticeDataPoint_jsonKeys() throws Exception {
+        var dto = new MonthlyRevenuePracticeDataPoint("202501", 2025, 1, "Jan 2025",
+                Map.of("PM", 100.0), 100.0, 30.0, 70.0);
+        assertEquals(
+            Set.of("monthKey", "year", "monthNumber", "monthLabel",
+                   "practiceRevenue", "totalRevenueDkk", "totalCostDkk", "marginPercent"),
+            keysOf(dto));
+    }
+
+    @Test
+    void revenuePracticeDto_jsonKeys() throws Exception {
+        var dto = new RevenuePracticeDTO(List.of(), List.of("PM"));
+        assertEquals(Set.of("months", "practices"), keysOf(dto));
+    }
+
+    @Test
+    void quarterlyNewVsRepeatDto_jsonKeys() throws Exception {
+        var dto = new QuarterlyNewVsRepeatDTO(2025, 1, "Q1 2025", 100.0, 50.0, 150.0, 33.33);
+        assertEquals(
+            Set.of("year", "quarter", "quarterLabel",
+                   "newRevenueDkk", "repeatRevenueDkk", "totalRevenueDkk", "repeatSharePercent"),
+            keysOf(dto));
+    }
+
+    @Test
+    void newVsRepeatClientRevenueDto_jsonKeys() throws Exception {
+        var dto = new NewVsRepeatClientRevenueDTO(List.of());
+        assertEquals(Set.of("quarters"), keysOf(dto));
+    }
+
+    @Test
+    void monthlyCreditNoteDto_jsonKeys() throws Exception {
+        var dto = new MonthlyCreditNoteDTO("202501", 2025, 1, "Jan 2025", 100.0, 5.0, 5.0);
+        assertEquals(
+            Set.of("monthKey", "year", "monthNumber", "monthLabel",
+                   "invoiceAmountDkk", "creditNoteAmountDkk", "creditNoteRatePct"),
+            keysOf(dto));
+    }
+
+    @Test
+    void creditNoteTopClientDto_jsonKeys() throws Exception {
+        var dto = new CreditNoteTopClientDTO("Acme A/S", 5000.0, 3L);
+        assertEquals(Set.of("clientName", "creditNoteAmountDkk", "creditNoteCount"), keysOf(dto));
+    }
+
+    @Test
+    void creditNoteRateDto_jsonKeys() throws Exception {
+        var dto = new CreditNoteRateDTO(List.of(), List.of());
+        assertEquals(Set.of("monthly", "topClients"), keysOf(dto));
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientServiceCreditNoteRateTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientServiceCreditNoteRateTest.java
@@ -39,6 +39,11 @@ class CxoClientServiceCreditNoteRateTest {
             assertTrue(c.creditNoteAmountDkk() > 0);
             assertTrue(c.creditNoteCount() > 0);
         }
+        for (int i = 1; i < result.topClients().size(); i++) {
+            assertTrue(
+                result.topClients().get(i - 1).creditNoteAmountDkk() >= result.topClients().get(i).creditNoteAmountDkk(),
+                "topClients must be sorted by creditNoteAmountDkk DESC at index " + i);
+        }
     }
 
     @Test
@@ -53,5 +58,7 @@ class CxoClientServiceCreditNoteRateTest {
         Set<String> companyIds = Set.of("00000000-0000-0000-0000-000000000001");
         CreditNoteRateDTO result = service.creditNoteRate(null, null, companyIds);
         assertNotNull(result);
+        assertTrue(result.monthly().isEmpty(), "filter with random UUIDs should return empty");
+        assertTrue(result.topClients().isEmpty(), "filter with random UUIDs should return empty");
     }
 }

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientServiceCreditNoteRateTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientServiceCreditNoteRateTest.java
@@ -1,0 +1,57 @@
+package dk.trustworks.intranet.aggregates.finance.services;
+
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.CreditNoteRateDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.CreditNoteTopClientDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.MonthlyCreditNoteDTO;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class CxoClientServiceCreditNoteRateTest {
+
+    @Inject
+    CxoClientService service;
+
+    @Test
+    void creditNoteRate_defaultRange_returnsWrapper() {
+        CreditNoteRateDTO result = service.creditNoteRate(null, null, null);
+        assertNotNull(result);
+        assertNotNull(result.monthly());
+        assertNotNull(result.topClients());
+        assertTrue(result.topClients().size() <= 5, "Top clients capped at 5");
+        for (MonthlyCreditNoteDTO m : result.monthly()) {
+            assertNotNull(m.monthKey());
+            assertEquals(6, m.monthKey().length());
+            assertTrue(m.year() >= 2020 && m.year() <= 2030);
+            assertTrue(m.monthNumber() >= 1 && m.monthNumber() <= 12);
+            assertTrue(m.creditNoteRatePct() >= 0.0);
+            assertTrue(m.invoiceAmountDkk() >= 0.0);
+            assertTrue(m.creditNoteAmountDkk() >= 0.0);
+        }
+        for (CreditNoteTopClientDTO c : result.topClients()) {
+            assertNotNull(c.clientName());
+            assertTrue(c.creditNoteAmountDkk() > 0);
+            assertTrue(c.creditNoteCount() > 0);
+        }
+    }
+
+    @Test
+    void creditNoteRate_explicitRange_doesNotThrow() {
+        CreditNoteRateDTO result = service.creditNoteRate(
+                LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), null);
+        assertNotNull(result);
+    }
+
+    @Test
+    void creditNoteRate_withCompanyFilter_doesNotThrow() {
+        Set<String> companyIds = Set.of("00000000-0000-0000-0000-000000000001");
+        CreditNoteRateDTO result = service.creditNoteRate(null, null, companyIds);
+        assertNotNull(result);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientServiceNewVsRepeatRevenueTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientServiceNewVsRepeatRevenueTest.java
@@ -1,0 +1,49 @@
+package dk.trustworks.intranet.aggregates.finance.services;
+
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.NewVsRepeatClientRevenueDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.QuarterlyNewVsRepeatDTO;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class CxoClientServiceNewVsRepeatRevenueTest {
+
+    @Inject
+    CxoClientService service;
+
+    @Test
+    void newVsRepeatRevenue_defaultRange_returnsWrapper() {
+        NewVsRepeatClientRevenueDTO result = service.newVsRepeatRevenue(null, null, null);
+        assertNotNull(result);
+        assertNotNull(result.quarters());
+        for (QuarterlyNewVsRepeatDTO q : result.quarters()) {
+            assertTrue(q.year() >= 2020 && q.year() <= 2030, "year out of range");
+            assertTrue(q.quarter() >= 1 && q.quarter() <= 4);
+            assertNotNull(q.quarterLabel());
+            assertTrue(q.quarterLabel().matches("Q[1-4] \\d{4}"));
+            assertTrue(q.newRevenueDkk() >= 0);
+            assertTrue(q.repeatRevenueDkk() >= 0);
+            assertEquals(q.newRevenueDkk() + q.repeatRevenueDkk(), q.totalRevenueDkk(), 0.01);
+        }
+    }
+
+    @Test
+    void newVsRepeatRevenue_explicitRange_doesNotThrow() {
+        NewVsRepeatClientRevenueDTO result = service.newVsRepeatRevenue(
+                LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), null);
+        assertNotNull(result);
+    }
+
+    @Test
+    void newVsRepeatRevenue_withCompanyFilter_doesNotThrow() {
+        Set<String> companyIds = Set.of("00000000-0000-0000-0000-000000000001");
+        NewVsRepeatClientRevenueDTO result = service.newVsRepeatRevenue(null, null, companyIds);
+        assertNotNull(result);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientServiceNewVsRepeatRevenueTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoClientServiceNewVsRepeatRevenueTest.java
@@ -45,5 +45,6 @@ class CxoClientServiceNewVsRepeatRevenueTest {
         Set<String> companyIds = Set.of("00000000-0000-0000-0000-000000000001");
         NewVsRepeatClientRevenueDTO result = service.newVsRepeatRevenue(null, null, companyIds);
         assertNotNull(result);
+        assertTrue(result.quarters().isEmpty(), "filter with random UUIDs should return empty");
     }
 }

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceCostToRevenueTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceCostToRevenueTest.java
@@ -40,6 +40,6 @@ class CxoFinanceServiceCostToRevenueTest {
                                         "00000000-0000-0000-0000-000000000002");
         List<CostToRevenueDataPointDTO> result = service.costToRevenue(companyIds);
         assertNotNull(result, "Service must return a list even with no matching rows");
-        // No further assertions: with random UUIDs the result is expected to be empty.
+        assertTrue(result.isEmpty(), "filter with random UUIDs should return empty");
     }
 }

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceCostToRevenueTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceCostToRevenueTest.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -16,19 +17,29 @@ class CxoFinanceServiceCostToRevenueTest {
     CxoFinanceService service;
 
     @Test
-    void costToRevenue_noCompanyFilter_returnsTrailing18Months() {
+    void costToRevenue_noCompanyFilter_executesAndReturnsList() {
+        // Verifies: SQL parses, executes against real schema, returns List (not null).
+        // Shape assertions only run when fixtures provide data.
         List<CostToRevenueDataPointDTO> result = service.costToRevenue(null);
-        assertNotNull(result);
-        // trailing 18 months — may be 0 if test fixtures have no overlapping data,
-        // so the meaningful assertions are about shape, not size
-        if (!result.isEmpty()) {
-            CostToRevenueDataPointDTO first = result.getFirst();
-            assertNotNull(first.monthKey());
-            assertEquals(6, first.monthKey().length(), "month_key should be YYYYMM");
-            assertTrue(first.year() >= 2020 && first.year() <= 2030);
-            assertTrue(first.monthNumber() >= 1 && first.monthNumber() <= 12);
-            assertNotNull(first.monthLabel());
-            assertTrue(first.monthLabel().matches("[A-Z][a-z]{2} \\d{4}"), "monthLabel should be 'Mmm YYYY'");
+        assertNotNull(result, "Service must return a list, never null");
+        for (CostToRevenueDataPointDTO row : result) {
+            assertNotNull(row.monthKey(), "monthKey must be set");
+            assertEquals(6, row.monthKey().length(), "monthKey must be YYYYMM");
+            assertTrue(row.year() >= 2020 && row.year() <= 2030, "year out of expected range");
+            assertTrue(row.monthNumber() >= 1 && row.monthNumber() <= 12, "monthNumber out of range");
+            assertNotNull(row.monthLabel(), "monthLabel must be set");
+            assertTrue(row.monthLabel().matches("[A-Z][a-z]{2} \\d{4}"), "monthLabel format must be 'Mmm YYYY'");
         }
+    }
+
+    @Test
+    void costToRevenue_withCompanyFilter_doesNotThrow() {
+        // Verifies: companyIds filter path SQL parses + runs.
+        // Real UUIDs not needed — empty result is the expected outcome with random UUIDs.
+        Set<String> companyIds = Set.of("00000000-0000-0000-0000-000000000001",
+                                        "00000000-0000-0000-0000-000000000002");
+        List<CostToRevenueDataPointDTO> result = service.costToRevenue(companyIds);
+        assertNotNull(result, "Service must return a list even with no matching rows");
+        // No further assertions: with random UUIDs the result is expected to be empty.
     }
 }

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceCostToRevenueTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceCostToRevenueTest.java
@@ -1,0 +1,34 @@
+package dk.trustworks.intranet.aggregates.finance.services;
+
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.CostToRevenueDataPointDTO;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class CxoFinanceServiceCostToRevenueTest {
+
+    @Inject
+    CxoFinanceService service;
+
+    @Test
+    void costToRevenue_noCompanyFilter_returnsTrailing18Months() {
+        List<CostToRevenueDataPointDTO> result = service.costToRevenue(null);
+        assertNotNull(result);
+        // trailing 18 months — may be 0 if test fixtures have no overlapping data,
+        // so the meaningful assertions are about shape, not size
+        if (!result.isEmpty()) {
+            CostToRevenueDataPointDTO first = result.getFirst();
+            assertNotNull(first.monthKey());
+            assertEquals(6, first.monthKey().length(), "month_key should be YYYYMM");
+            assertTrue(first.year() >= 2020 && first.year() <= 2030);
+            assertTrue(first.monthNumber() >= 1 && first.monthNumber() <= 12);
+            assertNotNull(first.monthLabel());
+            assertTrue(first.monthLabel().matches("[A-Z][a-z]{2} \\d{4}"), "monthLabel should be 'Mmm YYYY'");
+        }
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceGrossMarginTrendTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceGrossMarginTrendTest.java
@@ -1,0 +1,42 @@
+package dk.trustworks.intranet.aggregates.finance.services;
+
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.GrossMarginTrendDataPointDTO;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class CxoFinanceServiceGrossMarginTrendTest {
+
+    @Inject
+    CxoFinanceService service;
+
+    @Test
+    void grossMarginTrend_noCompanyFilter_executesAndReturnsList() {
+        List<GrossMarginTrendDataPointDTO> result = service.grossMarginTrend(null);
+        assertNotNull(result, "Service must return a list, never null");
+        for (GrossMarginTrendDataPointDTO row : result) {
+            assertNotNull(row.monthKey());
+            assertEquals(6, row.monthKey().length(), "monthKey must be YYYYMM");
+            assertTrue(row.year() >= 2020 && row.year() <= 2030);
+            assertTrue(row.monthNumber() >= 1 && row.monthNumber() <= 12);
+            assertNotNull(row.monthLabel());
+            assertTrue(row.monthLabel().matches("[A-Z][a-z]{2} \\d{4}"));
+            // HAVING clause guarantees revenue > 0 for every row
+            assertTrue(row.totalRevenueDkk() > 0, "HAVING clause should exclude zero-revenue months");
+        }
+    }
+
+    @Test
+    void grossMarginTrend_withCompanyFilter_doesNotThrow() {
+        Set<String> companyIds = Set.of("00000000-0000-0000-0000-000000000001",
+                                        "00000000-0000-0000-0000-000000000002");
+        List<GrossMarginTrendDataPointDTO> result = service.grossMarginTrend(companyIds);
+        assertNotNull(result);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceGrossMarginTrendTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceGrossMarginTrendTest.java
@@ -38,5 +38,6 @@ class CxoFinanceServiceGrossMarginTrendTest {
                                         "00000000-0000-0000-0000-000000000002");
         List<GrossMarginTrendDataPointDTO> result = service.grossMarginTrend(companyIds);
         assertNotNull(result);
+        assertTrue(result.isEmpty(), "filter with random UUIDs should return empty");
     }
 }

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceRevenueByPracticeTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceRevenueByPracticeTest.java
@@ -1,0 +1,56 @@
+package dk.trustworks.intranet.aggregates.finance.services;
+
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.RevenuePracticeDTO;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.MonthlyRevenuePracticeDataPoint;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class CxoFinanceServiceRevenueByPracticeTest {
+
+    @Inject
+    CxoFinanceService service;
+
+    @Test
+    void revenueByPractice_defaultRange_returnsWrapper() {
+        RevenuePracticeDTO result = service.revenueByPractice(null, null, null);
+        assertNotNull(result);
+        assertNotNull(result.months());
+        assertNotNull(result.practices());
+        // practices list is ordered; verify each entry is one of the known set or "OTHER"
+        for (String p : result.practices()) {
+            assertTrue(List.of("PM", "SA", "BA", "DEV", "CYB", "OTHER").contains(p),
+                    "Unexpected practice id: " + p);
+        }
+        // Each month row's practiceRevenue keys must be a subset of the practices list
+        for (MonthlyRevenuePracticeDataPoint m : result.months()) {
+            assertNotNull(m.monthKey());
+            assertEquals(6, m.monthKey().length());
+            assertNotNull(m.practiceRevenue());
+            assertTrue(result.practices().containsAll(m.practiceRevenue().keySet()),
+                    "practiceRevenue keys must be a subset of practices list");
+        }
+    }
+
+    @Test
+    void revenueByPractice_explicitRange_doesNotThrow() {
+        LocalDate from = LocalDate.of(2024, 1, 1);
+        LocalDate to = LocalDate.of(2024, 12, 31);
+        RevenuePracticeDTO result = service.revenueByPractice(from, to, null);
+        assertNotNull(result);
+    }
+
+    @Test
+    void revenueByPractice_withCompanyFilter_doesNotThrow() {
+        Set<String> companyIds = Set.of("00000000-0000-0000-0000-000000000001");
+        RevenuePracticeDTO result = service.revenueByPractice(null, null, companyIds);
+        assertNotNull(result);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceRevenueByPracticeTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceServiceRevenueByPracticeTest.java
@@ -52,5 +52,7 @@ class CxoFinanceServiceRevenueByPracticeTest {
         Set<String> companyIds = Set.of("00000000-0000-0000-0000-000000000001");
         RevenuePracticeDTO result = service.revenueByPractice(null, null, companyIds);
         assertNotNull(result);
+        assertTrue(result.months().isEmpty(), "filter with random UUIDs should return empty");
+        assertTrue(result.practices().isEmpty(), "filter with random UUIDs should return empty");
     }
 }

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/RevenueByPracticeAggregationTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/RevenueByPracticeAggregationTest.java
@@ -1,0 +1,114 @@
+package dk.trustworks.intranet.aggregates.finance.services;
+
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.MonthlyRevenuePracticeDataPoint;
+import dk.trustworks.intranet.aggregates.finance.dto.cxo.RevenuePracticeDTO;
+import jakarta.persistence.Tuple;
+import jakarta.persistence.TupleElement;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pure unit test for the in-memory aggregation logic in
+ * CxoFinanceService.buildRevenueByPracticeResponse.
+ *
+ * No Quarkus boot, no DB. Synthetic Tuples drive every branch:
+ *  - cost-only month back-fill
+ *  - unknown practice id → "OTHER"
+ *  - "OTHER" appended last in the practices list
+ *  - LinkedHashMap order preserved in practiceRevenue
+ */
+class RevenueByPracticeAggregationTest {
+
+    /** Minimal fake Tuple backed by a Map. */
+    private static Tuple tuple(Map<String, Object> values) {
+        return new Tuple() {
+            @Override public <X> X get(TupleElement<X> tupleElement) { throw new UnsupportedOperationException(); }
+            @Override public <X> X get(String alias, Class<X> type) { return type.cast(values.get(alias)); }
+            @Override public Object get(String alias) { return values.get(alias); }
+            @Override public <X> X get(int i, Class<X> type) { throw new UnsupportedOperationException(); }
+            @Override public Object get(int i) { throw new UnsupportedOperationException(); }
+            @Override public Object[] toArray() { return values.values().toArray(); }
+            @Override public List<TupleElement<?>> getElements() { throw new UnsupportedOperationException(); }
+        };
+    }
+
+    private static Tuple revenueRow(String monthKey, int year, int monthNumber, String practice, double revenue) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("month_key", monthKey);
+        m.put("year_val", year);
+        m.put("month_number", monthNumber);
+        m.put("service_line_id", practice);
+        m.put("revenue_dkk", revenue);
+        return tuple(m);
+    }
+
+    private static Tuple costRow(String monthKey, int year, int monthNumber, double cost) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("month_key", monthKey);
+        m.put("year_val", year);
+        m.put("month_number", monthNumber);
+        m.put("cost_dkk", cost);
+        return tuple(m);
+    }
+
+    @Test
+    void unknownPracticeIdsCollapseToOther() {
+        List<Tuple> revenue = List.of(
+            revenueRow("202501", 2025, 1, "ZZZ", 100.0));
+        List<Tuple> cost = List.of();
+        RevenuePracticeDTO result = CxoFinanceService.buildRevenueByPracticeResponse(revenue, cost);
+        assertEquals(List.of("OTHER"), result.practices());
+        assertEquals(1, result.months().size());
+        assertEquals(100.0, result.months().get(0).practiceRevenue().get("OTHER"));
+    }
+
+    @Test
+    void otherIsAppendedLastInPracticesList() {
+        List<Tuple> revenue = List.of(
+            revenueRow("202501", 2025, 1, "OTHER", 10.0),
+            revenueRow("202501", 2025, 1, "PM", 20.0),
+            revenueRow("202501", 2025, 1, "DEV", 30.0));
+        RevenuePracticeDTO result = CxoFinanceService.buildRevenueByPracticeResponse(revenue, List.of());
+        assertEquals("OTHER", result.practices().get(result.practices().size() - 1));
+        // Known practices come first in canonical order
+        assertEquals(List.of("PM", "DEV", "OTHER"), result.practices());
+    }
+
+    @Test
+    void costOnlyMonthIsBackfilledWithZeroRevenue() {
+        List<Tuple> revenue = List.of();
+        List<Tuple> cost = List.of(costRow("202503", 2025, 3, 500.0));
+        RevenuePracticeDTO result = CxoFinanceService.buildRevenueByPracticeResponse(revenue, cost);
+        assertEquals(1, result.months().size());
+        MonthlyRevenuePracticeDataPoint m = result.months().get(0);
+        assertEquals("202503", m.monthKey());
+        assertEquals(0.0, m.totalRevenueDkk());
+        assertEquals(500.0, m.totalCostDkk());
+        assertNull(m.marginPercent(), "marginPercent must be null when revenue is 0");
+    }
+
+    @Test
+    void marginPercentIsRoundedToTwoDecimals() {
+        List<Tuple> revenue = List.of(revenueRow("202501", 2025, 1, "PM", 1000.0));
+        List<Tuple> cost = List.of(costRow("202501", 2025, 1, 333.0));
+        RevenuePracticeDTO result = CxoFinanceService.buildRevenueByPracticeResponse(revenue, cost);
+        // (1000 - 333) / 1000 = 66.7%
+        assertEquals(66.7, result.months().get(0).marginPercent(), 0.01);
+    }
+
+    @Test
+    void monthsAreSortedChronologically() {
+        List<Tuple> revenue = List.of(
+            revenueRow("202503", 2025, 3, "PM", 30.0),
+            revenueRow("202501", 2025, 1, "PM", 10.0),
+            revenueRow("202502", 2025, 2, "PM", 20.0));
+        RevenuePracticeDTO result = CxoFinanceService.buildRevenueByPracticeResponse(revenue, List.of());
+        assertEquals(List.of("202501", "202502", "202503"),
+            result.months().stream().map(MonthlyRevenuePracticeDataPoint::monthKey).toList());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -7,3 +7,9 @@ quarkus.s3.devservices.enabled=false
 # profile so legacy test fixtures (which predate the attribution bridge table)
 # stay green. Tests that exercise the new flow opt in via @TestProfile.
 feature.invoicing.internal.attribution-driven=false
+
+# Provide empty defaults for the cvtool integration so @QuarkusTest boots even
+# when CVTOOL_USERNAME / CVTOOL_PASSWORD env vars are not set on a developer
+# machine. The values are not used in any current test path.
+cvtool.username=test
+cvtool.password=test


### PR DESCRIPTION
## Summary
- Migrates 5 Next.js BFF routes (CXO Finance + Clients) from direct mysql2 SQL to new Quarkus REST endpoints
- Extends `CxoFinanceResource` (3 endpoints: cost-to-revenue, gross-margin-trend, revenue-by-practice) and `CxoClientResource` (2 endpoints: new-vs-repeat-revenue, credit-note-rate)
- 9 new Java record DTOs in `aggregates/finance/dto/cxo/` with camelCase fields, `@JsonProperty`-free, defensive constructor validation, and `Double` boxing for nullable fields per frontend contract
- Class-level `@RolesAllowed({"dashboard:read"})` inherited (no per-domain scopes — those don't exist in `AdminScopeAugmentor` yet)
- 17 new tests across 7 test classes (5 service smoke + 1 JSON-shape parity + 1 aggregation logic)
- Latent BFF SQL bug fixed silently (`d.company_id`/`o.company_id` aliases referenced inside inner subqueries; bare `company_id` is what actually executes)

Pairs with frontend PR converting the 5 BFF route bodies to thin `backendFetch` proxies (https://github.com/trustworksdk/trustworks-intranet-v3/pull/new/cxo-direct-db-phase1).

Spec: `docs/superpowers/specs/2026-05-03-frontend-direct-db-elimination-design.md`
Plan: `docs/superpowers/plans/2026-05-03-frontend-direct-db-elimination-phase-1.md`

This is Phase 1 of 5. Phases 2-5 will migrate Sales+Forecast, People+Executive, Delivery+Practices, then delete `mysql2` + `db.ts` + rotate the leaked DB password.

## Test plan
- [x] `./mvnw -DskipTests compile` clean
- [x] `./mvnw test-compile` clean
- [x] 14 fast tests (no Quarkus boot) pass: `CxoDtoJsonShapeTest`, `RevenueByPracticeAggregationTest`
- [ ] CI runs full `@QuarkusTest` suite against real DB
- [ ] After merge to `staging`: smoke-test `/cxo-command-center` Finance + Clients tabs
- [ ] After promotion to `master`: smoke-test in production