### PR TITLE
Promote staging → master: onboarding upload storage

### DIFF
--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/dto/OnboardingValidateResponse.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/dto/OnboardingValidateResponse.java
@@ -1,9 +1,20 @@
 package dk.trustworks.intranet.recruitmentservice.dto;
 
+/**
+ * Public-page response for {@code GET /onboarding/tokens/{uuid}/validate}
+ * (and the upload endpoint, which returns the refreshed status so the UI
+ * can lock zones without a second round trip).
+ *
+ * <p>{@link #fields} reflects which document types the token <i>asks</i>
+ * for. {@link #submitted} reflects which of those have already been
+ * uploaded — once a type is {@code true} the corresponding upload zone
+ * must be locked client-side.</p>
+ */
 public record OnboardingValidateResponse(
         boolean valid,
         boolean expired,
-        FieldFlags fields
+        FieldFlags fields,
+        Submitted submitted
 ) {
     public record FieldFlags(
             boolean driversLicense,
@@ -11,11 +22,23 @@ public record OnboardingValidateResponse(
             boolean criminalRecord
     ) {}
 
+    public record Submitted(
+            boolean driversLicense,
+            boolean healthInsurance,
+            boolean criminalRecord
+    ) {
+        public static Submitted none() {
+            return new Submitted(false, false, false);
+        }
+    }
+
     public static OnboardingValidateResponse ofInvalid() {
-        return new OnboardingValidateResponse(false, false, new FieldFlags(false, false, false));
+        return new OnboardingValidateResponse(false, false,
+                new FieldFlags(false, false, false), Submitted.none());
     }
 
     public static OnboardingValidateResponse ofExpired() {
-        return new OnboardingValidateResponse(false, true, new FieldFlags(false, false, false));
+        return new OnboardingValidateResponse(false, true,
+                new FieldFlags(false, false, false), Submitted.none());
     }
 }

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/model/OnboardingDocumentType.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/model/OnboardingDocumentType.java
@@ -1,0 +1,18 @@
+package dk.trustworks.intranet.recruitmentservice.model;
+
+/**
+ * Identity-document categories that the public onboarding upload page
+ * accepts. Mirrors the {@code document_type} ENUM column on
+ * {@code onboarding_upload_submissions}.
+ *
+ * <p>The set is intentionally closed: only documents the recruitment HR
+ * team needs at hire time, and only documents the candidate / new-hire
+ * was explicitly asked to upload via the token flags
+ * ({@code show_drivers_license}, {@code show_health_insurance},
+ * {@code show_criminal_record}).</p>
+ */
+public enum OnboardingDocumentType {
+    DRIVERS_LICENSE,
+    HEALTH_INSURANCE,
+    CRIMINAL_RECORD
+}

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/model/OnboardingUploadSubmission.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/model/OnboardingUploadSubmission.java
@@ -1,0 +1,116 @@
+package dk.trustworks.intranet.recruitmentservice.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Audit row for a single identity-document upload made through the public
+ * onboarding upload page. One row per {@code (token, document_type)} pair —
+ * the {@code uk_ous_token_doctype} unique key enforces "one upload per type
+ * per token" at the DB level so a leaked link cannot flood storage with
+ * duplicates.
+ *
+ * <p>Storage is dual-pathed:</p>
+ * <ul>
+ *   <li><b>Candidate-linked tokens</b> ({@link #candidateUuid} set) →
+ *       file lives in S3 via {@code S3FileService}; {@link #s3FileUuid}
+ *       holds the file UUID.</li>
+ *   <li><b>User-linked tokens</b> ({@link #userUuid} set) → file lives in
+ *       SharePoint under {@code {EMPLOYEE folder}/{username}/Onboarding/};
+ *       {@link #sharepointDriveItemId} and {@link #sharepointWebUrl} hold
+ *       the Microsoft Graph identifiers.</li>
+ * </ul>
+ *
+ * <p>The {@code candidate_uuid} XOR {@code user_uuid} invariant is mirrored
+ * by a CHECK constraint on the table, and so is the storage_target ↔
+ * identifier consistency.</p>
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "onboarding_upload_submissions")
+public class OnboardingUploadSubmission extends PanacheEntityBase {
+
+    @Id
+    @Column(name = "uuid", length = 36, nullable = false, updatable = false)
+    private String uuid;
+
+    @Column(name = "token_uuid", length = 36, nullable = false)
+    private String tokenUuid;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "document_type", nullable = false)
+    private OnboardingDocumentType documentType;
+
+    /** Soft-FK to {@code recruitment_candidates.uuid}. Mutually exclusive with {@link #userUuid}. */
+    @Column(name = "candidate_uuid", length = 36)
+    private String candidateUuid;
+
+    /** Soft-FK to {@code users.uuid}. Mutually exclusive with {@link #candidateUuid}. */
+    @Column(name = "user_uuid", length = 36)
+    private String userUuid;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "storage_target", nullable = false)
+    private StorageTarget storageTarget;
+
+    @Column(name = "s3_file_uuid", length = 36)
+    private String s3FileUuid;
+
+    @Column(name = "sharepoint_drive_item_id", length = 255)
+    private String sharepointDriveItemId;
+
+    @Column(name = "sharepoint_web_url", length = 1024)
+    private String sharepointWebUrl;
+
+    @Column(name = "original_filename", length = 500, nullable = false)
+    private String originalFilename;
+
+    @Column(name = "content_type", length = 100, nullable = false)
+    private String contentType;
+
+    @Column(name = "file_size_bytes", nullable = false)
+    private long fileSizeBytes;
+
+    @Column(name = "uploaded_at", nullable = false, updatable = false)
+    private LocalDateTime uploadedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (uuid == null) {
+            uuid = UUID.randomUUID().toString();
+        }
+        if (uploadedAt == null) {
+            uploadedAt = LocalDateTime.now();
+        }
+    }
+
+    public enum StorageTarget {
+        S3,
+        SHAREPOINT
+    }
+
+    /** All submissions made for the given token, ordered by upload time. */
+    public static List<OnboardingUploadSubmission> findByToken(String tokenUuid) {
+        return list("tokenUuid = ?1 ORDER BY uploadedAt", tokenUuid);
+    }
+
+    /** Whether the {@code (token, type)} pair already has a submission row. */
+    public static boolean existsForTokenAndType(String tokenUuid, OnboardingDocumentType type) {
+        return count("tokenUuid = ?1 AND documentType = ?2", tokenUuid, type) > 0;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/notifications/RecruitmentHrSlackNotifier.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/notifications/RecruitmentHrSlackNotifier.java
@@ -192,9 +192,28 @@ public class RecruitmentHrSlackNotifier {
      * <p>Idempotent across the JVM lifetime per {@code token.uuid}. Slack
      * failures are logged and swallowed so the upload transaction never
      * rolls back.</p>
+     *
+     * <p>Display name and link URL are pre-resolved by the caller (the
+     * upload service has the user / candidate context in hand and runs
+     * outside any DB transaction, so the notifier no longer reaches back
+     * into Panache). Pass {@code "unknown"} for {@code displayName} or
+     * {@code ""} for {@code linkUrl} if the caller could not resolve
+     * either — never null.</p>
+     *
+     * @param token        the onboarding token whose required types are now all submitted
+     * @param submissions  the full set of submissions for the token (unused
+     *                     for the message body itself but kept for
+     *                     forward-compatibility / count metrics)
+     * @param displayName  candidate full name OR {@code "Full Name (username)"}
+     *                     for the user flow; never null
+     * @param linkUrl      candidate dossier URL (candidate flow) or the
+     *                     SharePoint folder webUrl (user flow); may be empty
+     *                     but never null
      */
     public void notifyOnboardingComplete(OnboardingUploadToken token,
-                                         List<OnboardingUploadSubmission> submissions) {
+                                         List<OnboardingUploadSubmission> submissions,
+                                         String displayName,
+                                         String linkUrl) {
         if (token == null || token.getUuid() == null) {
             log.warn("notifyOnboardingComplete: token or token UUID is null, skipping");
             return;
@@ -205,8 +224,11 @@ public class RecruitmentHrSlackNotifier {
         }
 
         try {
-            String message = formatOnboardingCompleteMessage(token,
-                    submissions == null ? List.of() : submissions);
+            String message = formatOnboardingCompleteMessage(
+                    token,
+                    submissions == null ? List.of() : submissions,
+                    displayName == null ? "unknown" : displayName,
+                    linkUrl == null ? "" : linkUrl);
             slackService.sendMessage(channelId, message, botTokenKey);
             log.infof("HR Slack onboarding-complete notification posted for token=%s channel=%s",
                     token.getUuid(), channelId);
@@ -218,59 +240,18 @@ public class RecruitmentHrSlackNotifier {
 
     /** Visible for tests. */
     String formatOnboardingCompleteMessage(OnboardingUploadToken token,
-                                           List<OnboardingUploadSubmission> submissions) {
+                                           List<OnboardingUploadSubmission> submissions,
+                                           String displayName,
+                                           String linkUrl) {
         int count = submissions.size();
         if (token.getCandidateUuid() != null) {
-            String candidateName = resolveCandidateName(token.getCandidateUuid());
-            String dossierUrl = stripTrailingSlash(dossierBaseUrl) + "/" + token.getCandidateUuid();
-            return ":file_folder: Candidate " + candidateName
+            return ":file_folder: Candidate " + displayName
                     + " has uploaded all required onboarding identity documents ("
-                    + count + " file(s)). " + dossierUrl;
+                    + count + " file(s)). " + linkUrl;
         }
         // User flow.
-        String userUuid = token.getUserUuid();
-        String fullName = "unknown";
-        String username = "unknown";
-        if (userUuid != null) {
-            try {
-                User u = User.findById(userUuid);
-                if (u != null) {
-                    String first = nullSafe(u.getFirstname()).trim();
-                    String last = nullSafe(u.getLastname()).trim();
-                    String composed = (first + " " + last).trim();
-                    if (!composed.isEmpty()) fullName = composed;
-                    if (u.getUsername() != null && !u.getUsername().isBlank()) {
-                        username = u.getUsername();
-                    }
-                }
-            } catch (RuntimeException e) {
-                log.debugf(e, "Could not resolve user for uuid=%s", userUuid);
-            }
-        }
-        String folderUrl = "";
-        for (int i = submissions.size() - 1; i >= 0; i--) {
-            String url = submissions.get(i).getSharepointWebUrl();
-            if (url != null && !url.isBlank()) {
-                folderUrl = url;
-                break;
-            }
-        }
-        return ":file_folder: " + fullName + " (" + username
-                + ") has uploaded all required onboarding identity documents to SharePoint. "
-                + folderUrl;
-    }
-
-    private static String resolveCandidateName(String candidateUuid) {
-        if (candidateUuid == null) return "unknown";
-        try {
-            RecruitmentCandidate c = RecruitmentCandidate.findById(candidateUuid);
-            if (c != null) {
-                String full = (nullSafe(c.getFirstName()) + " " + nullSafe(c.getLastName())).trim();
-                if (!full.isEmpty()) return full;
-            }
-        } catch (RuntimeException e) {
-            log.debugf(e, "Could not resolve candidate name for uuid=%s", candidateUuid);
-        }
-        return "unknown";
+        return ":file_folder: " + displayName
+                + " has uploaded all required onboarding identity documents to SharePoint. "
+                + linkUrl;
     }
 }

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/notifications/RecruitmentHrSlackNotifier.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/notifications/RecruitmentHrSlackNotifier.java
@@ -3,6 +3,8 @@ package dk.trustworks.intranet.recruitmentservice.notifications;
 import dk.trustworks.intranet.communicationsservice.services.SlackService;
 import dk.trustworks.intranet.domain.user.entity.User;
 import dk.trustworks.intranet.model.Company;
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingUploadSubmission;
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingUploadToken;
 import dk.trustworks.intranet.recruitmentservice.model.RecruitmentCandidate;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -44,6 +46,13 @@ public class RecruitmentHrSlackNotifier {
      * Convert flow to re-enter on PARTIAL/FAILED→COMPLETED transitions.
      */
     private static final Set<String> NOTIFIED_CANDIDATE_UUIDS = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Dedup set for the onboarding-upload-complete notification, keyed on
+     * token UUID. Prevents a duplicate Slack post if the final upload's
+     * persistence retries (e.g. constraint-violation re-throw under load).
+     */
+    private static final Set<String> NOTIFIED_ONBOARDING_TOKEN_UUIDS = ConcurrentHashMap.newKeySet();
 
     @Inject
     SlackService slackService;
@@ -162,6 +171,105 @@ public class RecruitmentHrSlackNotifier {
             }
         } catch (RuntimeException e) {
             log.debugf(e, "Could not resolve recruiter name for uuid=%s", recruiterUuid);
+        }
+        return "unknown";
+    }
+
+    // ── Onboarding-upload completion ───────────────────────────────────────
+
+    /**
+     * Notify HR that every required identity document has been uploaded
+     * via the public onboarding upload page. Two flavours:
+     *
+     * <ul>
+     *   <li><b>Candidate flow</b> — message names the candidate and links
+     *       to the recruitment dossier page.</li>
+     *   <li><b>User flow</b> — message names the new hire (full name +
+     *       username) and links to their SharePoint onboarding folder via
+     *       the most recent submission's {@code webUrl}.</li>
+     * </ul>
+     *
+     * <p>Idempotent across the JVM lifetime per {@code token.uuid}. Slack
+     * failures are logged and swallowed so the upload transaction never
+     * rolls back.</p>
+     */
+    public void notifyOnboardingComplete(OnboardingUploadToken token,
+                                         List<OnboardingUploadSubmission> submissions) {
+        if (token == null || token.getUuid() == null) {
+            log.warn("notifyOnboardingComplete: token or token UUID is null, skipping");
+            return;
+        }
+        if (!NOTIFIED_ONBOARDING_TOKEN_UUIDS.add(token.getUuid())) {
+            log.debugf("notifyOnboardingComplete: already notified token=%s, skipping", token.getUuid());
+            return;
+        }
+
+        try {
+            String message = formatOnboardingCompleteMessage(token,
+                    submissions == null ? List.of() : submissions);
+            slackService.sendMessage(channelId, message, botTokenKey);
+            log.infof("HR Slack onboarding-complete notification posted for token=%s channel=%s",
+                    token.getUuid(), channelId);
+        } catch (Exception e) {
+            log.errorf(e, "HR Slack onboarding-complete notification failed for token=%s: %s",
+                    token.getUuid(), e.getMessage());
+        }
+    }
+
+    /** Visible for tests. */
+    String formatOnboardingCompleteMessage(OnboardingUploadToken token,
+                                           List<OnboardingUploadSubmission> submissions) {
+        int count = submissions.size();
+        if (token.getCandidateUuid() != null) {
+            String candidateName = resolveCandidateName(token.getCandidateUuid());
+            String dossierUrl = stripTrailingSlash(dossierBaseUrl) + "/" + token.getCandidateUuid();
+            return ":file_folder: Candidate " + candidateName
+                    + " has uploaded all required onboarding identity documents ("
+                    + count + " file(s)). " + dossierUrl;
+        }
+        // User flow.
+        String userUuid = token.getUserUuid();
+        String fullName = "unknown";
+        String username = "unknown";
+        if (userUuid != null) {
+            try {
+                User u = User.findById(userUuid);
+                if (u != null) {
+                    String first = nullSafe(u.getFirstname()).trim();
+                    String last = nullSafe(u.getLastname()).trim();
+                    String composed = (first + " " + last).trim();
+                    if (!composed.isEmpty()) fullName = composed;
+                    if (u.getUsername() != null && !u.getUsername().isBlank()) {
+                        username = u.getUsername();
+                    }
+                }
+            } catch (RuntimeException e) {
+                log.debugf(e, "Could not resolve user for uuid=%s", userUuid);
+            }
+        }
+        String folderUrl = "";
+        for (int i = submissions.size() - 1; i >= 0; i--) {
+            String url = submissions.get(i).getSharepointWebUrl();
+            if (url != null && !url.isBlank()) {
+                folderUrl = url;
+                break;
+            }
+        }
+        return ":file_folder: " + fullName + " (" + username
+                + ") has uploaded all required onboarding identity documents to SharePoint. "
+                + folderUrl;
+    }
+
+    private static String resolveCandidateName(String candidateUuid) {
+        if (candidateUuid == null) return "unknown";
+        try {
+            RecruitmentCandidate c = RecruitmentCandidate.findById(candidateUuid);
+            if (c != null) {
+                String full = (nullSafe(c.getFirstName()) + " " + nullSafe(c.getLastName())).trim();
+                if (!full.isEmpty()) return full;
+            }
+        } catch (RuntimeException e) {
+            log.debugf(e, "Could not resolve candidate name for uuid=%s", candidateUuid);
         }
         return "unknown";
     }

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/resources/OnboardingResource.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/resources/OnboardingResource.java
@@ -4,7 +4,11 @@ import dk.trustworks.intranet.recruitmentservice.dto.OnboardingTokenRequest;
 import dk.trustworks.intranet.recruitmentservice.dto.OnboardingTokenResponse;
 import dk.trustworks.intranet.recruitmentservice.dto.OnboardingValidateResponse;
 import dk.trustworks.intranet.recruitmentservice.dto.OnboardingValidateResponse.FieldFlags;
+import dk.trustworks.intranet.recruitmentservice.dto.OnboardingValidateResponse.Submitted;
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingDocumentType;
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingUploadSubmission;
 import dk.trustworks.intranet.recruitmentservice.model.OnboardingUploadToken;
+import dk.trustworks.intranet.recruitmentservice.services.OnboardingUploadService;
 import dk.trustworks.intranet.security.RequestHeaderHolder;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
@@ -12,8 +16,10 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
@@ -24,18 +30,25 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.jbosslog.JBossLog;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @JBossLog
 @RequestScoped
 @Path("/onboarding")
 @Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class OnboardingResource {
 
     @Inject
     RequestHeaderHolder requestHeaderHolder;
+
+    @Inject
+    OnboardingUploadService onboardingUploadService;
 
     // ── Public endpoint ────────────────────────────────────────────────────────
 
@@ -54,11 +67,98 @@ public class OnboardingResource {
         if (token.isExpired()) {
             return OnboardingValidateResponse.ofExpired();
         }
+        List<OnboardingUploadSubmission> submissions =
+                OnboardingUploadSubmission.findByToken(tokenUuid);
+        boolean dl = false, hi = false, cr = false;
+        for (OnboardingUploadSubmission s : submissions) {
+            switch (s.getDocumentType()) {
+                case DRIVERS_LICENSE -> dl = true;
+                case HEALTH_INSURANCE -> hi = true;
+                case CRIMINAL_RECORD -> cr = true;
+            }
+        }
         return new OnboardingValidateResponse(
                 true,
                 false,
-                new FieldFlags(token.isShowDriversLicense(), token.isShowHealthInsurance(), token.isShowCriminalRecord())
+                new FieldFlags(token.isShowDriversLicense(), token.isShowHealthInsurance(), token.isShowCriminalRecord()),
+                new Submitted(dl, hi, cr)
         );
+    }
+
+    /**
+     * Public endpoint: persist a single uploaded identity document for the
+     * given onboarding token. Routes to S3 (candidate token) or SharePoint
+     * (user token) and returns the refreshed validate response so the
+     * page can lock zones in one round trip.
+     *
+     * <p>Same silence rule as {@link #validate(String)} — invalid /
+     * expired tokens get a generic 403 with no body so we never leak
+     * token existence to unauthenticated callers.</p>
+     */
+    @POST
+    @PermitAll
+    @Path("/tokens/{tokenUuid}/upload")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public Response upload(@PathParam("tokenUuid") String tokenUuid,
+                           @RestForm("documentType") String documentTypeRaw,
+                           @RestForm("file") FileUpload file) {
+        if (file == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("{\"error\":\"FILE_REQUIRED\"}")
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+        if (documentTypeRaw == null || documentTypeRaw.isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("{\"error\":\"DOCUMENT_TYPE_REQUIRED\"}")
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+        OnboardingDocumentType type;
+        try {
+            type = OnboardingDocumentType.valueOf(documentTypeRaw);
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("{\"error\":\"DOCUMENT_TYPE_INVALID\"}")
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+
+        // Reject oversize before allocating a heap buffer for the bytes.
+        // The framework's max-body-size already bounded the temp file, but
+        // we don't want to copy 40MB into the heap just to reject it.
+        if (file.size() > 10L * 1024 * 1024) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("{\"error\":\"FILE_TOO_LARGE\"}")
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+
+        byte[] bytes;
+        try {
+            bytes = Files.readAllBytes(file.uploadedFile());
+        } catch (IOException e) {
+            log.errorf(e, "[OnboardingResource] Failed to read uploaded bytes token=%s", tokenUuid);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity("{\"error\":\"UPLOAD_READ_FAILED\"}")
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+
+        try {
+            OnboardingValidateResponse response = onboardingUploadService.handleUpload(
+                    tokenUuid,
+                    type,
+                    file.fileName(),
+                    file.contentType(),
+                    bytes);
+            return Response.ok(response).build();
+        } catch (ForbiddenException fe) {
+            // Same silence rule as /validate — never leak token existence.
+            return Response.status(Response.Status.FORBIDDEN).build();
+        } catch (BadRequestException bre) {
+            return bre.getResponse();
+        }
     }
 
     // ── Protected lookup endpoints ─────────────────────────────────────────────
@@ -85,6 +185,7 @@ public class OnboardingResource {
 
     @POST
     @Transactional
+    @Consumes(MediaType.APPLICATION_JSON)
     @RolesAllowed({"recruitment:write"})
     @Path("/tokens")
     public Response create(@Valid OnboardingTokenRequest req) {
@@ -124,6 +225,7 @@ public class OnboardingResource {
 
     @PUT
     @Transactional
+    @Consumes(MediaType.APPLICATION_JSON)
     @RolesAllowed({"recruitment:write"})
     @Path("/tokens/{uuid}")
     public OnboardingTokenResponse update(@PathParam("uuid") String uuid, @Valid OnboardingTokenRequest req) {

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingSubmissionPersister.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingSubmissionPersister.java
@@ -1,0 +1,35 @@
+package dk.trustworks.intranet.recruitmentservice.services;
+
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingUploadSubmission;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+/**
+ * Narrow transactional boundary around the {@code onboarding_upload_submissions}
+ * audit-row insert. Lives in its own bean so the surrounding
+ * {@link OnboardingUploadService#handleUpload} can execute the slow
+ * S3/SharePoint upload <i>outside</i> any DB transaction (no connection held
+ * for the 1–5 s round trip), then call into here for a small write-only TX.
+ *
+ * <p>Pattern: persist-then-upload was the original shape; we deliberately
+ * inverted it (upload-then-persist) so a persist failure can drive a
+ * compensating storage delete in the caller — a storage failure cannot leave
+ * an audit row behind.</p>
+ *
+ * <p>Errors (DB constraint violations, etc.) propagate to the caller for
+ * compensation handling; this bean does not swallow them.</p>
+ */
+@ApplicationScoped
+public class OnboardingSubmissionPersister {
+
+    /**
+     * Persist the given submission row in a fresh, narrow transaction.
+     * Throws {@link jakarta.persistence.PersistenceException} (or its subclasses,
+     * including the wrapped {@code org.hibernate.exception.ConstraintViolationException})
+     * on unique-key collision against {@code uk_ous_token_doctype}.
+     */
+    @Transactional
+    public void persist(OnboardingUploadSubmission row) {
+        row.persist();
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
@@ -7,19 +7,21 @@ import dk.trustworks.intranet.recruitmentservice.dto.OnboardingValidateResponse;
 import dk.trustworks.intranet.recruitmentservice.model.OnboardingDocumentType;
 import dk.trustworks.intranet.recruitmentservice.model.OnboardingUploadSubmission;
 import dk.trustworks.intranet.recruitmentservice.model.OnboardingUploadToken;
+import dk.trustworks.intranet.recruitmentservice.model.RecruitmentCandidate;
 import dk.trustworks.intranet.recruitmentservice.notifications.RecruitmentHrSlackNotifier;
 import dk.trustworks.intranet.sharepoint.dto.DriveItem;
 import dk.trustworks.intranet.sharepoint.service.SharePointService;
 import dk.trustworks.intranet.domain.user.entity.UserStatus;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
+import jakarta.persistence.PersistenceException;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.jbosslog.JBossLog;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.time.LocalDate;
 import java.util.HashSet;
@@ -33,9 +35,28 @@ import java.util.UUID;
  * or SharePoint (user flow), persists an audit row, and triggers a single
  * HR Slack notification once all required types are received.
  *
- * <p>Failures from the Slack notifier are caught and logged so a
- * downstream notification problem can never roll back a successful upload
- * — the candidate / new-hire's file must land before any UX nicety.</p>
+ * <h3>Transactional shape</h3>
+ * <p>The method itself is <b>not</b> {@code @Transactional}. We deliberately
+ * keep the slow S3/SharePoint upload (1–5 s round trip) <i>outside</i> any
+ * DB transaction so we don't hold a connection while waiting on a
+ * remote HTTP API. The narrow audit-row insert runs in its own
+ * transaction via {@link OnboardingSubmissionPersister}.</p>
+ *
+ * <p><b>Order of operations:</b></p>
+ * <ol>
+ *   <li>Read-only validation (token lookup, expiry, type-allowed,
+ *       existsForTokenAndType, MIME / size / magic-byte / filename) — no TX.</li>
+ *   <li>Pre-resolve display name + link URL for the eventual Slack message
+ *       so the notifier needs no further DB reads.</li>
+ *   <li>Upload bytes to S3 / SharePoint — <i>still no TX</i>.</li>
+ *   <li>Persist the audit row in a small REQUIRED tx via
+ *       {@link OnboardingSubmissionPersister#persist}.</li>
+ *   <li>If persist fails (e.g. concurrent uploads racing on
+ *       {@code uk_ous_token_doctype}) → compensating delete of the
+ *       just-uploaded storage object + translate to <b>409
+ *       ALREADY_SUBMITTED</b>.</li>
+ *   <li>Re-read submissions and run the HR notifier (best-effort).</li>
+ * </ol>
  *
  * <h3>PII boundary</h3>
  * <p>Filenames and bytes are never logged. Only outcome, token UUID,
@@ -71,44 +92,46 @@ public class OnboardingUploadService {
     @Inject
     RecruitmentHrSlackNotifier recruitmentHrSlackNotifier;
 
+    @Inject
+    OnboardingSubmissionPersister onboardingSubmissionPersister;
+
+    @ConfigProperty(name = "recruitment.hr.slack.dossier-base-url",
+            defaultValue = "https://intra.trustworks.dk/recruitment/candidates")
+    String dossierBaseUrl;
+
     /**
      * Persist a single uploaded identity document for the given token,
      * routing to S3 or SharePoint based on token ownership. Returns a
      * fresh {@link OnboardingValidateResponse} reflecting the post-upload
      * submitted-state so the caller can lock the relevant zone in one
      * round trip.
+     *
+     * <p>Not annotated {@code @Transactional} — see class-level Javadoc.</p>
      */
-    @Transactional
     public OnboardingValidateResponse handleUpload(String tokenUuid,
                                                    OnboardingDocumentType type,
                                                    String filename,
                                                    String contentType,
                                                    byte[] bytes) {
-        // 1. Token validity — same silence rule as /validate (403, no leak).
+        // ── 1. Read-only validation (no DB writes, no transaction) ───────
         OnboardingUploadToken token = OnboardingUploadToken.findById(tokenUuid);
         if (token == null || token.isExpired()) {
+            // Same silence rule as /validate (403, no leak).
             throw new ForbiddenException();
         }
 
-        // 2. Token-flag gate: the type must be one the token explicitly asked for.
+        // Token-flag gate: the type must be one the token explicitly asked for.
         if (!isTypeAllowedByToken(token, type)) {
-            throw new BadRequestException(
-                    Response.status(Response.Status.BAD_REQUEST)
-                            .entity("{\"error\":\"DOCUMENT_TYPE_NOT_ALLOWED\"}")
-                            .type(MediaType.APPLICATION_JSON)
-                            .build());
+            throw badRequest("DOCUMENT_TYPE_NOT_ALLOWED");
         }
 
-        // 3. Single-shot per type (DB unique key is the source of truth).
+        // Single-shot per type — first-pass check (race-safe DB unique key
+        // is the actual source of truth and is enforced again at persist).
         if (OnboardingUploadSubmission.existsForTokenAndType(tokenUuid, type)) {
-            throw new WebApplicationException(
-                    Response.status(Response.Status.CONFLICT)
-                            .entity("{\"error\":\"ALREADY_SUBMITTED\"}")
-                            .type(MediaType.APPLICATION_JSON)
-                            .build());
+            throw alreadySubmitted();
         }
 
-        // 4. Bytes / MIME / size sanity check.
+        // Bytes / MIME / size sanity check.
         if (bytes == null || bytes.length == 0) {
             throw badRequest("EMPTY_FILE");
         }
@@ -125,13 +148,13 @@ public class OnboardingUploadService {
             throw badRequest("UNSUPPORTED_MEDIA_TYPE");
         }
 
-        // 5. Sanitise filename — never trust public input as a path component.
+        // Sanitise filename — never trust public input as a path component.
         String safeFilename = sanitiseFilename(filename);
         if (safeFilename.isBlank()) {
             throw badRequest("INVALID_FILENAME");
         }
 
-        // 6. Branch on token ownership (XOR enforced both at DB and here).
+        // Branch on token ownership (XOR enforced both at DB and here).
         boolean candidateFlow = token.getCandidateUuid() != null;
         boolean userFlow = token.getUserUuid() != null;
         if (candidateFlow == userFlow) {
@@ -141,6 +164,18 @@ public class OnboardingUploadService {
             throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
         }
 
+        // For the user flow, resolve the SharePoint location now so any
+        // configuration / user-state failure surfaces before we attempt the
+        // upload (and before we have something to compensate for).
+        UserUploadContext userCtx = userFlow ? resolveUserUploadContext(token.getUserUuid()) : null;
+
+        // ── 2. Pre-resolve Slack notification context (no further reads
+        //       needed once we hand off to the notifier). ────────────────
+        NotificationContext notifyCtx = candidateFlow
+                ? buildCandidateNotificationContext(token.getCandidateUuid())
+                : buildUserNotificationContext(userCtx);
+
+        // ── 3. Upload bytes — outside any DB transaction. ────────────────
         OnboardingUploadSubmission row = new OnboardingUploadSubmission();
         row.setTokenUuid(tokenUuid);
         row.setDocumentType(type);
@@ -148,29 +183,69 @@ public class OnboardingUploadService {
         row.setContentType(normalisedContentType);
         row.setFileSizeBytes(bytes.length);
 
+        // Storage handles for compensating delete on persist failure.
+        String uploadedS3FileUuid = null;
+        String uploadedSharepointDriveItemId = null;
+        String uploadedSharepointSiteUrl = null;
+        String uploadedSharepointDriveName = null;
+
         if (candidateFlow) {
             String fileUuid = recruitmentS3StorageService.storeIdentityDocument(
                     bytes, safeFilename, UUID.fromString(token.getCandidateUuid()));
             row.setCandidateUuid(token.getCandidateUuid());
             row.setStorageTarget(OnboardingUploadSubmission.StorageTarget.S3);
             row.setS3FileUuid(fileUuid);
+            uploadedS3FileUuid = fileUuid;
         } else {
-            DriveItem driveItem = uploadToSharePoint(token.getUserUuid(), safeFilename, bytes);
+            DriveItem driveItem = sharePointService.uploadFile(
+                    userCtx.siteUrl(), userCtx.driveName(),
+                    userCtx.folderPath(), safeFilename, bytes);
             row.setUserUuid(token.getUserUuid());
             row.setStorageTarget(OnboardingUploadSubmission.StorageTarget.SHAREPOINT);
             row.setSharepointDriveItemId(driveItem.id());
             row.setSharepointWebUrl(driveItem.webUrl());
+            uploadedSharepointDriveItemId = driveItem.id();
+            uploadedSharepointSiteUrl = userCtx.siteUrl();
+            uploadedSharepointDriveName = userCtx.driveName();
+            // Patch the notifier link URL with the actual webUrl (most
+            // direct link to the just-uploaded folder for the user flow).
+            if (driveItem.webUrl() != null && !driveItem.webUrl().isBlank()) {
+                notifyCtx = notifyCtx.withLinkUrl(driveItem.webUrl());
+            }
         }
 
-        row.persist();
+        // ── 4. Persist audit row in a narrow REQUIRED tx. ────────────────
+        try {
+            onboardingSubmissionPersister.persist(row);
+        } catch (RuntimeException pe) {
+            // Concurrent racer beat us to (token, type). Compensate the
+            // just-uploaded storage object (orphan otherwise) and translate
+            // to 409 ALREADY_SUBMITTED — what the second caller would have
+            // received from the precheck.
+            if (isUniqueViolation(pe)) {
+                compensateStorageUpload(uploadedS3FileUuid,
+                        uploadedSharepointSiteUrl, uploadedSharepointDriveName,
+                        uploadedSharepointDriveItemId, tokenUuid, type);
+                throw alreadySubmitted();
+            }
+            // Any other persistence failure → still try to compensate (we
+            // would otherwise leave an orphan in storage with no audit row),
+            // then re-throw so the resource maps it to a 5xx.
+            compensateStorageUpload(uploadedS3FileUuid,
+                    uploadedSharepointSiteUrl, uploadedSharepointDriveName,
+                    uploadedSharepointDriveItemId, tokenUuid, type);
+            throw pe;
+        }
+
         log.infof("Onboarding upload stored token=%s type=%s storage=%s submission=%s",
                 tokenUuid, type, row.getStorageTarget(), row.getUuid());
 
-        // 7. If we now have every required type, fire the HR notification.
+        // ── 5. Re-read submissions outside the persist tx and notify. ────
         List<OnboardingUploadSubmission> all = OnboardingUploadSubmission.findByToken(tokenUuid);
         if (allRequiredTypesSubmitted(token, all)) {
             try {
-                recruitmentHrSlackNotifier.notifyOnboardingComplete(token, all);
+                recruitmentHrSlackNotifier.notifyOnboardingComplete(
+                        token, all, notifyCtx.displayName(), notifyCtx.linkUrl());
             } catch (Exception e) {
                 // Notification is best-effort — never roll back a stored upload.
                 log.errorf(e, "Slack onboarding-complete notification failed for token=%s", tokenUuid);
@@ -181,6 +256,27 @@ public class OnboardingUploadService {
     }
 
     // ── helpers ────────────────────────────────────────────────────────────
+
+    /**
+     * Resolved SharePoint upload target for the user flow, captured up-front
+     * so the actual upload step is a pure I/O call with no further DB reads.
+     */
+    private record UserUploadContext(
+            String siteUrl,
+            String driveName,
+            String folderPath,
+            String fullName,
+            String username) {}
+
+    /**
+     * Pre-resolved context for the HR Slack notifier — see the
+     * {@link RecruitmentHrSlackNotifier#notifyOnboardingComplete} signature.
+     */
+    private record NotificationContext(String displayName, String linkUrl) {
+        NotificationContext withLinkUrl(String newLink) {
+            return new NotificationContext(this.displayName, newLink);
+        }
+    }
 
     private static boolean isTypeAllowedByToken(OnboardingUploadToken token, OnboardingDocumentType type) {
         return switch (type) {
@@ -202,7 +298,7 @@ public class OnboardingUploadService {
         return true;
     }
 
-    private DriveItem uploadToSharePoint(String userUuid, String filename, byte[] bytes) {
+    private UserUploadContext resolveUserUploadContext(String userUuid) {
         User user = User.findById(userUuid);
         if (user == null) {
             log.errorf("Onboarding upload: user %s not found", userUuid);
@@ -229,8 +325,97 @@ public class OnboardingUploadService {
         String folderPath = (basePath.isEmpty() ? "" : stripTrailingSlash(basePath) + "/")
                 + sanitisePathSegment(username) + "/Onboarding";
 
-        return sharePointService.uploadFile(
-                location.getSiteUrl(), location.getDriveName(), folderPath, filename, bytes);
+        String first = nullSafe(user.getFirstname()).trim();
+        String last = nullSafe(user.getLastname()).trim();
+        String fullName = (first + " " + last).trim();
+        if (fullName.isEmpty()) fullName = username;
+
+        return new UserUploadContext(
+                location.getSiteUrl(), location.getDriveName(), folderPath, fullName, username);
+    }
+
+    private NotificationContext buildCandidateNotificationContext(String candidateUuid) {
+        String displayName = "unknown";
+        try {
+            RecruitmentCandidate c = RecruitmentCandidate.findById(candidateUuid);
+            if (c != null) {
+                String full = (nullSafe(c.getFirstName()) + " " + nullSafe(c.getLastName())).trim();
+                if (!full.isEmpty()) displayName = full;
+            }
+        } catch (RuntimeException e) {
+            log.debugf(e, "Could not resolve candidate name for uuid=%s", candidateUuid);
+        }
+        String linkUrl = stripTrailingSlash(dossierBaseUrl) + "/" + candidateUuid;
+        return new NotificationContext(displayName, linkUrl);
+    }
+
+    private NotificationContext buildUserNotificationContext(UserUploadContext userCtx) {
+        // The link URL is patched to the DriveItem.webUrl after upload — at
+        // this point we don't have it yet, so seed with an empty string.
+        String displayName = userCtx.fullName() + " (" + userCtx.username() + ")";
+        return new NotificationContext(displayName, "");
+    }
+
+    /**
+     * Best-effort compensating delete of a just-uploaded storage object.
+     * Failures are logged at ERROR with all metadata needed to manually
+     * clean up the orphan; we never propagate a compensation failure to
+     * the caller — they already have a 409/500 to deal with.
+     */
+    private void compensateStorageUpload(String s3FileUuid,
+                                         String spSiteUrl, String spDriveName, String spDriveItemId,
+                                         String tokenUuid, OnboardingDocumentType type) {
+        if (s3FileUuid != null) {
+            try {
+                recruitmentS3StorageService.deleteGeneratedPdf(s3FileUuid);
+                log.infof("Compensating delete OK token=%s type=%s storage=S3 fileUuid=%s",
+                        tokenUuid, type, s3FileUuid);
+            } catch (RuntimeException e) {
+                log.errorf(e, "ORPHAN: compensating S3 delete FAILED token=%s type=%s fileUuid=%s",
+                        tokenUuid, type, s3FileUuid);
+            }
+            return;
+        }
+        if (spDriveItemId != null) {
+            try {
+                sharePointService.deleteFileById(spSiteUrl, spDriveName, spDriveItemId);
+                log.infof("Compensating delete OK token=%s type=%s storage=SHAREPOINT itemId=%s",
+                        tokenUuid, type, spDriveItemId);
+            } catch (RuntimeException e) {
+                log.errorf(e, "ORPHAN: compensating SharePoint delete FAILED token=%s type=%s site=%s drive=%s itemId=%s",
+                        tokenUuid, type, spSiteUrl, spDriveName, spDriveItemId);
+            }
+        }
+    }
+
+    /**
+     * True if the given exception (or any of its causes) is a Hibernate / JPA
+     * unique-constraint violation. Hibernate sometimes wraps the underlying
+     * {@code org.hibernate.exception.ConstraintViolationException} inside a
+     * {@link PersistenceException}; some Quarkus paths rewrap further.
+     */
+    static boolean isUniqueViolation(Throwable t) {
+        Throwable cur = t;
+        for (int depth = 0; cur != null && depth < 8; depth++) {
+            String name = cur.getClass().getName();
+            if ("org.hibernate.exception.ConstraintViolationException".equals(name)) {
+                return true;
+            }
+            // SQLIntegrityConstraintViolationException is the JDBC layer.
+            if ("java.sql.SQLIntegrityConstraintViolationException".equals(name)) {
+                return true;
+            }
+            cur = cur.getCause();
+        }
+        return false;
+    }
+
+    private static WebApplicationException alreadySubmitted() {
+        return new WebApplicationException(
+                Response.status(Response.Status.CONFLICT)
+                        .entity("{\"error\":\"ALREADY_SUBMITTED\"}")
+                        .type(MediaType.APPLICATION_JSON)
+                        .build());
     }
 
     private static BadRequestException badRequest(String code) {
@@ -296,7 +481,12 @@ public class OnboardingUploadService {
     }
 
     private static String stripTrailingSlash(String s) {
+        if (s == null || s.isEmpty()) return "";
         return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+
+    private static String nullSafe(String s) {
+        return s == null ? "" : s;
     }
 
     private OnboardingValidateResponse buildResponse(OnboardingUploadToken token,

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
@@ -1,0 +1,321 @@
+package dk.trustworks.intranet.recruitmentservice.services;
+
+import dk.trustworks.intranet.documentservice.model.SharePointLocationEntity;
+import dk.trustworks.intranet.documentservice.model.enums.SharePointLocationType;
+import dk.trustworks.intranet.domain.user.entity.User;
+import dk.trustworks.intranet.recruitmentservice.dto.OnboardingValidateResponse;
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingDocumentType;
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingUploadSubmission;
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingUploadToken;
+import dk.trustworks.intranet.recruitmentservice.notifications.RecruitmentHrSlackNotifier;
+import dk.trustworks.intranet.sharepoint.dto.DriveItem;
+import dk.trustworks.intranet.sharepoint.service.SharePointService;
+import dk.trustworks.intranet.domain.user.entity.UserStatus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.jbosslog.JBossLog;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Application service that orchestrates the public onboarding upload
+ * endpoint. Validates the token, routes the bytes to S3 (candidate flow)
+ * or SharePoint (user flow), persists an audit row, and triggers a single
+ * HR Slack notification once all required types are received.
+ *
+ * <p>Failures from the Slack notifier are caught and logged so a
+ * downstream notification problem can never roll back a successful upload
+ * — the candidate / new-hire's file must land before any UX nicety.</p>
+ *
+ * <h3>PII boundary</h3>
+ * <p>Filenames and bytes are never logged. Only outcome, token UUID,
+ * document-type, and storage target are emitted at INFO level.</p>
+ */
+@JBossLog
+@ApplicationScoped
+public class OnboardingUploadService {
+
+    /**
+     * Allow-list of MIME types accepted by the upload endpoint.
+     *
+     * <p>The client-asserted Content-Type is paired with a magic-byte check
+     * in {@link #magicMatches} so a caller cannot bypass the format
+     * restriction by lying about the type ({@code application/octet-stream}
+     * is intentionally excluded).</p>
+     */
+    private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
+            "application/pdf",
+            "image/jpeg",
+            "image/png"
+    );
+
+    /** Hard size cap. 10 MiB matches the client-side check. */
+    private static final long MAX_BYTES = 10L * 1024 * 1024;
+
+    @Inject
+    RecruitmentS3StorageService recruitmentS3StorageService;
+
+    @Inject
+    SharePointService sharePointService;
+
+    @Inject
+    RecruitmentHrSlackNotifier recruitmentHrSlackNotifier;
+
+    /**
+     * Persist a single uploaded identity document for the given token,
+     * routing to S3 or SharePoint based on token ownership. Returns a
+     * fresh {@link OnboardingValidateResponse} reflecting the post-upload
+     * submitted-state so the caller can lock the relevant zone in one
+     * round trip.
+     */
+    @Transactional
+    public OnboardingValidateResponse handleUpload(String tokenUuid,
+                                                   OnboardingDocumentType type,
+                                                   String filename,
+                                                   String contentType,
+                                                   byte[] bytes) {
+        // 1. Token validity — same silence rule as /validate (403, no leak).
+        OnboardingUploadToken token = OnboardingUploadToken.findById(tokenUuid);
+        if (token == null || token.isExpired()) {
+            throw new ForbiddenException();
+        }
+
+        // 2. Token-flag gate: the type must be one the token explicitly asked for.
+        if (!isTypeAllowedByToken(token, type)) {
+            throw new BadRequestException(
+                    Response.status(Response.Status.BAD_REQUEST)
+                            .entity("{\"error\":\"DOCUMENT_TYPE_NOT_ALLOWED\"}")
+                            .type(MediaType.APPLICATION_JSON)
+                            .build());
+        }
+
+        // 3. Single-shot per type (DB unique key is the source of truth).
+        if (OnboardingUploadSubmission.existsForTokenAndType(tokenUuid, type)) {
+            throw new WebApplicationException(
+                    Response.status(Response.Status.CONFLICT)
+                            .entity("{\"error\":\"ALREADY_SUBMITTED\"}")
+                            .type(MediaType.APPLICATION_JSON)
+                            .build());
+        }
+
+        // 4. Bytes / MIME / size sanity check.
+        if (bytes == null || bytes.length == 0) {
+            throw badRequest("EMPTY_FILE");
+        }
+        if (bytes.length > MAX_BYTES) {
+            throw badRequest("FILE_TOO_LARGE");
+        }
+        String normalisedContentType = normaliseContentType(contentType);
+        if (!ALLOWED_MIME_TYPES.contains(normalisedContentType)) {
+            throw badRequest("UNSUPPORTED_MEDIA_TYPE");
+        }
+        if (!magicMatches(normalisedContentType, bytes)) {
+            // Asserted MIME and actual bytes disagree — refuse rather than
+            // trust the public-facing Content-Type header.
+            throw badRequest("UNSUPPORTED_MEDIA_TYPE");
+        }
+
+        // 5. Sanitise filename — never trust public input as a path component.
+        String safeFilename = sanitiseFilename(filename);
+        if (safeFilename.isBlank()) {
+            throw badRequest("INVALID_FILENAME");
+        }
+
+        // 6. Branch on token ownership (XOR enforced both at DB and here).
+        boolean candidateFlow = token.getCandidateUuid() != null;
+        boolean userFlow = token.getUserUuid() != null;
+        if (candidateFlow == userFlow) {
+            // Either both null or both set — token row is corrupt; fail closed.
+            log.errorf("Onboarding token %s has invalid owner state (candidate=%s,user=%s)",
+                    tokenUuid, token.getCandidateUuid(), token.getUserUuid());
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+
+        OnboardingUploadSubmission row = new OnboardingUploadSubmission();
+        row.setTokenUuid(tokenUuid);
+        row.setDocumentType(type);
+        row.setOriginalFilename(safeFilename);
+        row.setContentType(normalisedContentType);
+        row.setFileSizeBytes(bytes.length);
+
+        if (candidateFlow) {
+            String fileUuid = recruitmentS3StorageService.storeIdentityDocument(
+                    bytes, safeFilename, UUID.fromString(token.getCandidateUuid()));
+            row.setCandidateUuid(token.getCandidateUuid());
+            row.setStorageTarget(OnboardingUploadSubmission.StorageTarget.S3);
+            row.setS3FileUuid(fileUuid);
+        } else {
+            DriveItem driveItem = uploadToSharePoint(token.getUserUuid(), safeFilename, bytes);
+            row.setUserUuid(token.getUserUuid());
+            row.setStorageTarget(OnboardingUploadSubmission.StorageTarget.SHAREPOINT);
+            row.setSharepointDriveItemId(driveItem.id());
+            row.setSharepointWebUrl(driveItem.webUrl());
+        }
+
+        row.persist();
+        log.infof("Onboarding upload stored token=%s type=%s storage=%s submission=%s",
+                tokenUuid, type, row.getStorageTarget(), row.getUuid());
+
+        // 7. If we now have every required type, fire the HR notification.
+        List<OnboardingUploadSubmission> all = OnboardingUploadSubmission.findByToken(tokenUuid);
+        if (allRequiredTypesSubmitted(token, all)) {
+            try {
+                recruitmentHrSlackNotifier.notifyOnboardingComplete(token, all);
+            } catch (Exception e) {
+                // Notification is best-effort — never roll back a stored upload.
+                log.errorf(e, "Slack onboarding-complete notification failed for token=%s", tokenUuid);
+            }
+        }
+
+        return buildResponse(token, all);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    private static boolean isTypeAllowedByToken(OnboardingUploadToken token, OnboardingDocumentType type) {
+        return switch (type) {
+            case DRIVERS_LICENSE -> token.isShowDriversLicense();
+            case HEALTH_INSURANCE -> token.isShowHealthInsurance();
+            case CRIMINAL_RECORD -> token.isShowCriminalRecord();
+        };
+    }
+
+    private static boolean allRequiredTypesSubmitted(OnboardingUploadToken token,
+                                                     List<OnboardingUploadSubmission> submissions) {
+        Set<OnboardingDocumentType> have = new HashSet<>();
+        for (OnboardingUploadSubmission s : submissions) {
+            have.add(s.getDocumentType());
+        }
+        if (token.isShowDriversLicense() && !have.contains(OnboardingDocumentType.DRIVERS_LICENSE)) return false;
+        if (token.isShowHealthInsurance() && !have.contains(OnboardingDocumentType.HEALTH_INSURANCE)) return false;
+        if (token.isShowCriminalRecord() && !have.contains(OnboardingDocumentType.CRIMINAL_RECORD)) return false;
+        return true;
+    }
+
+    private DriveItem uploadToSharePoint(String userUuid, String filename, byte[] bytes) {
+        User user = User.findById(userUuid);
+        if (user == null) {
+            log.errorf("Onboarding upload: user %s not found", userUuid);
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        UserStatus status = user.getUserStatus(LocalDate.now());
+        if (status == null || status.getCompany() == null || status.getCompany().getUuid() == null) {
+            log.errorf("Onboarding upload: user %s has no active company", userUuid);
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        String companyUuid = status.getCompany().getUuid();
+        SharePointLocationEntity location = SharePointLocationEntity.findByCompanyAndType(
+                companyUuid, SharePointLocationType.EMPLOYEE);
+        if (location == null) {
+            log.errorf("Onboarding upload: no EMPLOYEE SharePoint location configured for company %s", companyUuid);
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        String username = user.getUsername();
+        if (username == null || username.isBlank()) {
+            log.errorf("Onboarding upload: user %s has no username", userUuid);
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        String basePath = location.getFolderPath() == null ? "" : location.getFolderPath();
+        String folderPath = (basePath.isEmpty() ? "" : stripTrailingSlash(basePath) + "/")
+                + sanitisePathSegment(username) + "/Onboarding";
+
+        return sharePointService.uploadFile(
+                location.getSiteUrl(), location.getDriveName(), folderPath, filename, bytes);
+    }
+
+    private static BadRequestException badRequest(String code) {
+        return new BadRequestException(
+                Response.status(Response.Status.BAD_REQUEST)
+                        .entity("{\"error\":\"" + code + "\"}")
+                        .type(MediaType.APPLICATION_JSON)
+                        .build());
+    }
+
+    /**
+     * Positive allowlist filename sanitiser: keep only ASCII alphanumerics,
+     * dot, underscore, hyphen, and space. Collapses any run of dots so
+     * "{@code ..}" cannot resurface from a unicode look-alike. Returns ""
+     * if nothing usable remains.
+     */
+    static String sanitiseFilename(String raw) {
+        if (raw == null) return "";
+        String filtered = raw.replaceAll("[^a-zA-Z0-9._\\- ]", "");
+        // Collapse any run of dots to a single dot — a positive allowlist
+        // already blocks unicode look-alikes for `.`, this guards against
+        // `....pdf`-style obfuscation.
+        filtered = filtered.replaceAll("\\.{2,}", ".");
+        return filtered.trim();
+    }
+
+    /** Same rules as {@link #sanitiseFilename} but for an arbitrary path segment. */
+    static String sanitisePathSegment(String raw) {
+        return sanitiseFilename(raw);
+    }
+
+    /** Strip optional charset suffix and lowercase. */
+    private static String normaliseContentType(String contentType) {
+        if (contentType == null) return "";
+        int semi = contentType.indexOf(';');
+        String bare = semi >= 0 ? contentType.substring(0, semi) : contentType;
+        return bare.trim().toLowerCase();
+    }
+
+    /**
+     * Verify the first bytes of the upload match the asserted MIME type.
+     * Defense against a caller that lies about Content-Type to slip an
+     * unintended file format past the allowlist.
+     *
+     * <ul>
+     *   <li>PDF: {@code 25 50 44 46} ("%PDF")</li>
+     *   <li>JPEG: {@code FF D8 FF}</li>
+     *   <li>PNG: {@code 89 50 4E 47 0D 0A 1A 0A}</li>
+     * </ul>
+     */
+    static boolean magicMatches(String contentType, byte[] bytes) {
+        if (bytes == null || bytes.length < 4) return false;
+        return switch (contentType) {
+            case "application/pdf" ->
+                    bytes[0] == 0x25 && bytes[1] == 0x50 && bytes[2] == 0x44 && bytes[3] == 0x46;
+            case "image/jpeg" ->
+                    (bytes[0] & 0xff) == 0xff && (bytes[1] & 0xff) == 0xd8 && (bytes[2] & 0xff) == 0xff;
+            case "image/png" -> bytes.length >= 8
+                    && (bytes[0] & 0xff) == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4e && bytes[3] == 0x47
+                    && bytes[4] == 0x0d && bytes[5] == 0x0a && bytes[6] == 0x1a && bytes[7] == 0x0a;
+            default -> false;
+        };
+    }
+
+    private static String stripTrailingSlash(String s) {
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+
+    private OnboardingValidateResponse buildResponse(OnboardingUploadToken token,
+                                                     List<OnboardingUploadSubmission> submissions) {
+        boolean dl = false, hi = false, cr = false;
+        for (OnboardingUploadSubmission s : submissions) {
+            switch (s.getDocumentType()) {
+                case DRIVERS_LICENSE -> dl = true;
+                case HEALTH_INSURANCE -> hi = true;
+                case CRIMINAL_RECORD -> cr = true;
+            }
+        }
+        return new OnboardingValidateResponse(
+                true,
+                false,
+                new OnboardingValidateResponse.FieldFlags(
+                        token.isShowDriversLicense(),
+                        token.isShowHealthInsurance(),
+                        token.isShowCriminalRecord()),
+                new OnboardingValidateResponse.Submitted(dl, hi, cr));
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/RecruitmentS3StorageService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/RecruitmentS3StorageService.java
@@ -83,6 +83,37 @@ public class RecruitmentS3StorageService {
     }
 
     /**
+     * Store an identity document uploaded via the public onboarding upload
+     * page (driver's license, health insurance card, or criminal record
+     * certificate). Mirrors {@link #storeAppendix} — same S3 bucket, same
+     * {@code File.type = "DOCUMENT"}, same {@code relateduuid =
+     * candidateUuid} linkage so the retention reaper / future cleanup can
+     * trace the file back to its candidate.
+     *
+     * @return the new {@code fileUuid} the caller persists on the
+     *         {@code onboarding_upload_submissions} row.
+     */
+    public String storeIdentityDocument(byte[] bytes, String filename, UUID candidateUuid) {
+        Objects.requireNonNull(bytes, "bytes must not be null");
+        Objects.requireNonNull(filename, "filename must not be null");
+        Objects.requireNonNull(candidateUuid, "candidateUuid must not be null");
+
+        String fileUuid = UUID.randomUUID().toString();
+        File file = new File(
+                fileUuid,
+                candidateUuid.toString(),
+                "DOCUMENT",
+                filename,
+                filename,
+                LocalDate.now(),
+                bytes);
+        s3FileService.save(file);
+        log.infof("Stored onboarding identity document candidate=%s fileUuid=%s size=%d",
+                candidateUuid, fileUuid, bytes.length);
+        return fileUuid;
+    }
+
+    /**
      * Fetch the bytes of a previously stored generated PDF.
      *
      * @throws IllegalStateException if the file is not found in S3

--- a/src/main/java/dk/trustworks/intranet/sharepoint/client/GraphApiClient.java
+++ b/src/main/java/dk/trustworks/intranet/sharepoint/client/GraphApiClient.java
@@ -8,6 +8,7 @@ import dk.trustworks.intranet.sharepoint.dto.DriveItemCollectionResponse;
 import dk.trustworks.intranet.sharepoint.dto.Site;
 import io.quarkus.oidc.client.filter.OidcClientFilter;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.Encoded;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -204,6 +205,26 @@ public interface GraphApiClient {
         @PathParam("driveId") String driveId,
         @PathParam("itemId") String itemId,
         UpdateItemRequest patch
+    );
+
+    /**
+     * Deletes a DriveItem by its ID. Used as a compensating action when a
+     * caller has already uploaded a file but needs to remove it (e.g. the
+     * subsequent audit-row persist failed and the upload must be undone).
+     *
+     * <p>Returns 204 on success, 404 if the item is already gone (treat as
+     * idempotent). Other 4xx/5xx errors propagate via the registered
+     * {@code GraphResponseExceptionMapper}.</p>
+     *
+     * @param driveId the unique drive identifier
+     * @param itemId  the unique item identifier
+     * @see <a href="https://learn.microsoft.com/en-us/graph/api/driveitem-delete">Delete DriveItem</a>
+     */
+    @DELETE
+    @Path("/drives/{driveId}/items/{itemId}")
+    void deleteItem(
+        @PathParam("driveId") String driveId,
+        @PathParam("itemId") String itemId
     );
 
     /**

--- a/src/main/java/dk/trustworks/intranet/sharepoint/service/SharePointService.java
+++ b/src/main/java/dk/trustworks/intranet/sharepoint/service/SharePointService.java
@@ -257,6 +257,38 @@ public class SharePointService {
     }
 
     /**
+     * Deletes a previously uploaded file by its DriveItem id, given the
+     * site / drive context the upload returned. Used by compensating-delete
+     * paths (e.g. an upload succeeded but the caller's subsequent audit-row
+     * persist failed and the orphan must be removed).
+     *
+     * <p>404s are swallowed as a successful idempotent delete; any other
+     * {@link SharePointException} is re-thrown so callers can decide whether
+     * to log-and-continue or surface to the user.</p>
+     *
+     * @param siteUrl   the SharePoint site URL the upload used
+     * @param driveName the document library name the upload used
+     * @param driveItemId the DriveItem id returned by the original upload
+     */
+    public void deleteFileById(String siteUrl, String driveName, String driveItemId) {
+        log.infof("Deleting drive item: site=%s, drive=%s, itemId=%s",
+                siteUrl, driveName, driveItemId);
+
+        String siteId = resolveSiteId(siteUrl);
+        String driveId = resolveDriveId(siteId, driveName);
+
+        try {
+            graphClient.deleteItem(driveId, driveItemId);
+        } catch (SharePointException e) {
+            if (e.getStatusCode() == 404) {
+                log.debugf("Drive item already gone (404), treating delete as success: %s", driveItemId);
+                return;
+            }
+            throw e;
+        }
+    }
+
+    /**
      * Gets file metadata without downloading content.
      *
      * @param siteUrl the SharePoint site URL

--- a/src/main/resources/db/migration/V327__create_onboarding_upload_submissions.sql
+++ b/src/main/resources/db/migration/V327__create_onboarding_upload_submissions.sql
@@ -1,0 +1,26 @@
+CREATE TABLE onboarding_upload_submissions (
+    uuid                     VARCHAR(36)  NOT NULL PRIMARY KEY,
+    token_uuid               VARCHAR(36)  NOT NULL COMMENT 'Soft-FK to onboarding_upload_tokens.uuid',
+    document_type            ENUM('DRIVERS_LICENSE','HEALTH_INSURANCE','CRIMINAL_RECORD') NOT NULL,
+    candidate_uuid           VARCHAR(36)  NULL     COMMENT 'Soft-FK to recruitment_candidates.uuid',
+    user_uuid                VARCHAR(36)  NULL     COMMENT 'Soft-FK to users.uuid',
+    storage_target           ENUM('S3','SHAREPOINT') NOT NULL,
+    s3_file_uuid             VARCHAR(36)  NULL     COMMENT 'fileservice File UUID; set when storage_target=S3',
+    sharepoint_drive_item_id VARCHAR(255) NULL     COMMENT 'Microsoft Graph DriveItem.id; set when storage_target=SHAREPOINT',
+    sharepoint_web_url       VARCHAR(1024) NULL    COMMENT 'Microsoft Graph DriveItem.webUrl; HR convenience link',
+    original_filename        VARCHAR(500) NOT NULL,
+    content_type             VARCHAR(100) NOT NULL,
+    file_size_bytes          BIGINT       NOT NULL,
+    uploaded_at              TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_ous_token_doctype (token_uuid, document_type),
+    KEY idx_ous_candidate (candidate_uuid),
+    KEY idx_ous_user      (user_uuid),
+    CONSTRAINT chk_ous_owner CHECK (
+        (candidate_uuid IS NOT NULL AND user_uuid IS NULL) OR
+        (candidate_uuid IS NULL     AND user_uuid IS NOT NULL)
+    ),
+    CONSTRAINT chk_ous_storage CHECK (
+        (storage_target = 'S3'         AND s3_file_uuid IS NOT NULL) OR
+        (storage_target = 'SHAREPOINT' AND sharepoint_drive_item_id IS NOT NULL)
+    )
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/migration/V327__create_onboarding_upload_submissions.sql
+++ b/src/main/resources/db/migration/V327__create_onboarding_upload_submissions.sql
@@ -11,7 +11,7 @@ CREATE TABLE onboarding_upload_submissions (
     original_filename        VARCHAR(500) NOT NULL,
     content_type             VARCHAR(100) NOT NULL,
     file_size_bytes          BIGINT       NOT NULL,
-    uploaded_at              TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    uploaded_at              DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     UNIQUE KEY uk_ous_token_doctype (token_uuid, document_type),
     KEY idx_ous_candidate (candidate_uuid),
     KEY idx_ous_user      (user_uuid),

--- a/src/test/java/dk/trustworks/intranet/recruitmentservice/resources/OnboardingUploadResourceTest.java
+++ b/src/test/java/dk/trustworks/intranet/recruitmentservice/resources/OnboardingUploadResourceTest.java
@@ -1,0 +1,514 @@
+package dk.trustworks.intranet.recruitmentservice.resources;
+
+import dk.trustworks.intranet.documentservice.model.SharePointLocationEntity;
+import dk.trustworks.intranet.documentservice.model.enums.SharePointLocationType;
+import dk.trustworks.intranet.model.Company;
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingDocumentType;
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingUploadSubmission;
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingUploadToken;
+import dk.trustworks.intranet.recruitmentservice.model.RecruitmentCandidate;
+import dk.trustworks.intranet.recruitmentservice.notifications.RecruitmentHrSlackNotifier;
+import dk.trustworks.intranet.recruitmentservice.services.OnboardingSubmissionPersister;
+import dk.trustworks.intranet.recruitmentservice.services.RecruitmentS3StorageService;
+import dk.trustworks.intranet.sharepoint.dto.DriveItem;
+import dk.trustworks.intranet.sharepoint.service.SharePointService;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * REST contract tests for {@code POST /onboarding/tokens/{tokenUuid}/upload}.
+ *
+ * <p>The endpoint is the public-facing identity-document upload entry point used
+ * by the onboarding page. It is {@code @PermitAll} — token validity, expiry,
+ * type-allowed gates, MIME / size / magic-byte checks, and the
+ * {@code (token, type)} unique-key are the only defensive layers.
+ *
+ * <p>Storage collaborators ({@link RecruitmentS3StorageService},
+ * {@link SharePointService}, {@link RecruitmentHrSlackNotifier}) are mocked so
+ * the test never reaches out to S3 or Microsoft Graph. The DB integration is
+ * exercised against the real schema via {@link TestTransaction} so each test
+ * leaves no residue.</p>
+ *
+ * <p>The user-flow happy-path test depends on at least one user with a
+ * non-null active company and an {@code EMPLOYEE} SharePoint location for that
+ * company. The fixture is created inline; we use the persisted user's existing
+ * userstatus row as the company anchor.</p>
+ */
+@QuarkusTest
+@TestProfile(OnboardingUploadResourceTest.NoDevServicesProfile.class)
+class OnboardingUploadResourceTest {
+
+    public static class NoDevServicesProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.s3.devservices.enabled", "false",
+                    "cvtool.username", "test-placeholder",
+                    "cvtool.password", "test-placeholder"
+            );
+        }
+    }
+
+    @Inject EntityManager em;
+
+    @InjectMock RecruitmentS3StorageService recruitmentS3StorageService;
+    @InjectMock SharePointService sharePointService;
+    @InjectMock RecruitmentHrSlackNotifier recruitmentHrSlackNotifier;
+    @InjectMock OnboardingSubmissionPersister onboardingSubmissionPersister;
+
+    // ── Magic-byte fixtures ────────────────────────────────────────────────────
+
+    /** {@code %PDF-1.7} + a few payload bytes so length > 4 and magic-byte check passes. */
+    private static final byte[] PDF_BYTES = {
+            0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a, 0x25, (byte) 0xc4
+    };
+    /** {@code FF D8 FF E0 ...} JPEG SOI + APP0 marker. */
+    private static final byte[] JPEG_BYTES = {
+            (byte) 0xff, (byte) 0xd8, (byte) 0xff, (byte) 0xe0, 0x00, 0x10, 'J', 'F', 'I', 'F'
+    };
+
+    // ── Happy paths ────────────────────────────────────────────────────────────
+
+    /**
+     * Candidate flow: PDF upload routes to S3, audit row stores the file UUID
+     * with {@code storage_target='S3'}, and the response carries the updated
+     * submitted block.
+     */
+    @Test
+    @TestTransaction
+    void candidateFlow_validPdf_returns200_storesInS3_andPersistsAuditRow() throws IOException {
+        // Arrange: candidate token requesting drivers-license only.
+        String candidateUuid = createCandidate();
+        String tokenUuid = createCandidateToken(candidateUuid, true, false, false);
+
+        // Mock S3 storage to return a fixed file UUID so we can verify it is stored.
+        String fakeS3FileUuid = UUID.randomUUID().toString();
+        when(recruitmentS3StorageService.storeIdentityDocument(any(byte[].class), anyString(), any(UUID.class)))
+                .thenReturn(fakeS3FileUuid);
+        // Persister is mocked: capture and forward the row to a real persist so we can assert columns.
+        captureAndPersist();
+
+        File pdf = tempFileWithBytes(PDF_BYTES, "license.pdf");
+
+        // Act
+        given()
+                .multiPart("file", pdf, "application/pdf")
+                .formParam("documentType", "DRIVERS_LICENSE")
+                .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
+                .then().statusCode(200)
+                .body("submitted.driversLicense", equalTo(true))
+                .body("submitted.healthInsurance", equalTo(false))
+                .body("submitted.criminalRecord", equalTo(false));
+
+        // Assert: storage call once + audit row inserted with S3 metadata.
+        verify(recruitmentS3StorageService, times(1))
+                .storeIdentityDocument(any(byte[].class), anyString(), any(UUID.class));
+
+        OnboardingUploadSubmission row = OnboardingUploadSubmission
+                .find("tokenUuid = ?1 AND documentType = ?2",
+                        tokenUuid, OnboardingDocumentType.DRIVERS_LICENSE).firstResult();
+        assertNotNull(row, "audit row must exist after upload");
+        assertEquals(OnboardingUploadSubmission.StorageTarget.S3, row.getStorageTarget());
+        assertEquals(fakeS3FileUuid, row.getS3FileUuid());
+        assertEquals(candidateUuid, row.getCandidateUuid());
+    }
+
+    /**
+     * User flow: JPEG upload routes to SharePoint, audit row stores
+     * {@code drive_item_id} + {@code web_url}, and the upload-folder path
+     * matches {@code {locationFolder}/{username}/Onboarding}.
+     */
+    @Test
+    @TestTransaction
+    void userFlow_validJpeg_returns200_storesInSharePoint_andUsesUsernameFolder() throws IOException {
+        // Pick a real user from the DB that has an active company.
+        UserSeed seed = anyUserWithCompany();
+        if (seed == null) {
+            // No test-data — gracefully skip; the candidate flow above still covers
+            // resource wiring end-to-end.
+            return;
+        }
+        // Make sure an EMPLOYEE SharePointLocationEntity exists for the user's company.
+        ensureEmployeeLocation(seed.companyUuid);
+
+        String tokenUuid = createUserToken(seed.userUuid, false, true, false);
+
+        DriveItem driveItem = new DriveItem(
+                "driveitem-" + UUID.randomUUID(),
+                "card.jpg", 10L, null, null,
+                "https://sharepoint.example/item",
+                null, new DriveItem.File("image/jpeg", null), null, null);
+        when(sharePointService.uploadFile(anyString(), anyString(), anyString(), anyString(), any(byte[].class)))
+                .thenReturn(driveItem);
+        captureAndPersist();
+
+        File jpeg = tempFileWithBytes(JPEG_BYTES, "card.jpg");
+
+        given()
+                .multiPart("file", jpeg, "image/jpeg")
+                .formParam("documentType", "HEALTH_INSURANCE")
+                .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
+                .then().statusCode(200)
+                .body("submitted.healthInsurance", equalTo(true));
+
+        // Verify uploadFile called with a folder path that ends in "{username}/Onboarding".
+        ArgumentCaptor<String> folderPath = ArgumentCaptor.forClass(String.class);
+        verify(sharePointService, times(1))
+                .uploadFile(anyString(), anyString(), folderPath.capture(), anyString(), any(byte[].class));
+        assertTrue(folderPath.getValue().endsWith("/Onboarding") || folderPath.getValue().endsWith("Onboarding"),
+                "folder path should end in /Onboarding, got: " + folderPath.getValue());
+        assertTrue(folderPath.getValue().contains(seed.username),
+                "folder path should contain the username, got: " + folderPath.getValue());
+
+        OnboardingUploadSubmission row = OnboardingUploadSubmission
+                .find("tokenUuid = ?1 AND documentType = ?2",
+                        tokenUuid, OnboardingDocumentType.HEALTH_INSURANCE).firstResult();
+        assertNotNull(row);
+        assertEquals(OnboardingUploadSubmission.StorageTarget.SHAREPOINT, row.getStorageTarget());
+        assertEquals(driveItem.id(), row.getSharepointDriveItemId());
+        assertEquals(driveItem.webUrl(), row.getSharepointWebUrl());
+        assertEquals(seed.userUuid, row.getUserUuid());
+    }
+
+    // ── Silence rule ───────────────────────────────────────────────────────────
+
+    @Test
+    @TestTransaction
+    void expiredToken_returns403WithEmptyBody() throws IOException {
+        String candidateUuid = createCandidate();
+        OnboardingUploadToken token = new OnboardingUploadToken();
+        token.setCandidateUuid(candidateUuid);
+        token.setShowDriversLicense(true);
+        token.setShowHealthInsurance(false);
+        token.setShowCriminalRecord(false);
+        token.setExpiresAt(LocalDateTime.now().minusDays(1));        // expired
+        token.setCreatedByUseruuid(UUID.randomUUID().toString());
+        token.persist();
+
+        File pdf = tempFileWithBytes(PDF_BYTES, "license.pdf");
+
+        given()
+                .multiPart("file", pdf, "application/pdf")
+                .formParam("documentType", "DRIVERS_LICENSE")
+                .when().post("/onboarding/tokens/" + token.getUuid() + "/upload")
+                .then().statusCode(403)
+                .body(equalTo(""));
+
+        verify(recruitmentS3StorageService, never())
+                .storeIdentityDocument(any(byte[].class), anyString(), any(UUID.class));
+    }
+
+    // ── Idempotency: (token, type) twice ───────────────────────────────────────
+
+    @Test
+    @TestTransaction
+    void duplicateUpload_sameTokenAndType_returns409_andStoresOnlyOnce() throws IOException {
+        String candidateUuid = createCandidate();
+        String tokenUuid = createCandidateToken(candidateUuid, true, false, false);
+
+        when(recruitmentS3StorageService.storeIdentityDocument(any(byte[].class), anyString(), any(UUID.class)))
+                .thenReturn(UUID.randomUUID().toString());
+        captureAndPersist();
+
+        File pdf = tempFileWithBytes(PDF_BYTES, "license.pdf");
+
+        // First call → 200
+        given()
+                .multiPart("file", pdf, "application/pdf")
+                .formParam("documentType", "DRIVERS_LICENSE")
+                .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
+                .then().statusCode(200);
+
+        // Second call → 409 ALREADY_SUBMITTED. The service's pre-check sees the row
+        // and short-circuits — no additional storage call.
+        given()
+                .multiPart("file", pdf, "application/pdf")
+                .formParam("documentType", "DRIVERS_LICENSE")
+                .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
+                .then().statusCode(409)
+                .body(containsString("ALREADY_SUBMITTED"));
+
+        verify(recruitmentS3StorageService, times(1))
+                .storeIdentityDocument(any(byte[].class), anyString(), any(UUID.class));
+    }
+
+    // ── Type-allowed gate ──────────────────────────────────────────────────────
+
+    @Test
+    @TestTransaction
+    void documentTypeNotAllowedByToken_returns400() throws IOException {
+        String candidateUuid = createCandidate();
+        // Token only enables HEALTH_INSURANCE — DRIVERS_LICENSE must be rejected.
+        String tokenUuid = createCandidateToken(candidateUuid, false, true, false);
+
+        File pdf = tempFileWithBytes(PDF_BYTES, "license.pdf");
+
+        given()
+                .multiPart("file", pdf, "application/pdf")
+                .formParam("documentType", "DRIVERS_LICENSE")
+                .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
+                .then().statusCode(400)
+                .body(containsString("DOCUMENT_TYPE_NOT_ALLOWED"));
+
+        verify(recruitmentS3StorageService, never())
+                .storeIdentityDocument(any(byte[].class), anyString(), any(UUID.class));
+    }
+
+    // ── Size cap ───────────────────────────────────────────────────────────────
+
+    @Test
+    @TestTransaction
+    void fileLargerThan10MiB_returns400_FILE_TOO_LARGE() throws IOException {
+        String candidateUuid = createCandidate();
+        String tokenUuid = createCandidateToken(candidateUuid, true, false, false);
+
+        // 10 MiB + 1 byte — caught by the resource-layer pre-flight on file.size().
+        byte[] huge = new byte[10 * 1024 * 1024 + 1];
+        // Seed PDF magic bytes so any later magic check would still pass — but we expect
+        // the size check to fail first.
+        huge[0] = 0x25; huge[1] = 0x50; huge[2] = 0x44; huge[3] = 0x46;
+        File big = tempFileWithBytes(huge, "huge.pdf");
+
+        given()
+                .multiPart("file", big, "application/pdf")
+                .formParam("documentType", "DRIVERS_LICENSE")
+                .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
+                .then().statusCode(400)
+                .body(containsString("FILE_TOO_LARGE"));
+    }
+
+    // ── MIME allowlist ─────────────────────────────────────────────────────────
+
+    @Test
+    @TestTransaction
+    void unsupportedContentType_returns400_UNSUPPORTED_MEDIA_TYPE() throws IOException {
+        String candidateUuid = createCandidate();
+        String tokenUuid = createCandidateToken(candidateUuid, true, false, false);
+
+        File zip = tempFileWithBytes(new byte[]{ 'P', 'K', 0x03, 0x04, 0x14 }, "evil.zip");
+
+        given()
+                .multiPart("file", zip, "application/zip")
+                .formParam("documentType", "DRIVERS_LICENSE")
+                .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
+                .then().statusCode(400)
+                .body(containsString("UNSUPPORTED_MEDIA_TYPE"));
+
+        verify(recruitmentS3StorageService, never())
+                .storeIdentityDocument(any(byte[].class), anyString(), any(UUID.class));
+    }
+
+    // ── Magic-byte mismatch ────────────────────────────────────────────────────
+
+    @Test
+    @TestTransaction
+    void contentTypePdfButJpegMagicBytes_returns400_UNSUPPORTED_MEDIA_TYPE() throws IOException {
+        String candidateUuid = createCandidate();
+        String tokenUuid = createCandidateToken(candidateUuid, true, false, false);
+
+        // Asserts MIME = application/pdf but bytes are a JPEG.
+        File spoofed = tempFileWithBytes(JPEG_BYTES, "spoof.pdf");
+
+        given()
+                .multiPart("file", spoofed, "application/pdf")
+                .formParam("documentType", "DRIVERS_LICENSE")
+                .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
+                .then().statusCode(400)
+                .body(containsString("UNSUPPORTED_MEDIA_TYPE"));
+
+        verify(recruitmentS3StorageService, never())
+                .storeIdentityDocument(any(byte[].class), anyString(), any(UUID.class));
+    }
+
+    // ── Race compensation ─────────────────────────────────────────────────────
+
+    /**
+     * Simulate a concurrent racer winning the {@code uk_ous_token_doctype} unique
+     * key by stubbing the persister to throw a Hibernate-wrapped
+     * {@code ConstraintViolationException}. The service must:
+     * <ol>
+     *   <li>compensate the just-uploaded S3 object via {@code deleteGeneratedPdf};</li>
+     *   <li>translate to <b>409 ALREADY_SUBMITTED</b>.</li>
+     * </ol>
+     */
+    @Test
+    @TestTransaction
+    void persistThrowsConstraintViolation_returns409_andCompensatesS3Upload() throws IOException {
+        String candidateUuid = createCandidate();
+        String tokenUuid = createCandidateToken(candidateUuid, true, false, false);
+
+        String fakeS3FileUuid = UUID.randomUUID().toString();
+        when(recruitmentS3StorageService.storeIdentityDocument(any(byte[].class), anyString(), any(UUID.class)))
+                .thenReturn(fakeS3FileUuid);
+
+        // Hibernate's ConstraintViolationException is recognised by
+        // OnboardingUploadService.isUniqueViolation(...).
+        doThrow(new org.hibernate.exception.ConstraintViolationException(
+                "duplicate key uk_ous_token_doctype",
+                new java.sql.SQLIntegrityConstraintViolationException("dup"),
+                "uk_ous_token_doctype"))
+                .when(onboardingSubmissionPersister).persist(any(OnboardingUploadSubmission.class));
+
+        File pdf = tempFileWithBytes(PDF_BYTES, "license.pdf");
+
+        given()
+                .multiPart("file", pdf, "application/pdf")
+                .formParam("documentType", "DRIVERS_LICENSE")
+                .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
+                .then().statusCode(409)
+                .body(containsString("ALREADY_SUBMITTED"));
+
+        // Compensating delete must run for the S3 fileUuid that was just uploaded.
+        verify(recruitmentS3StorageService, atLeastOnce())
+                .deleteGeneratedPdf(eq(fakeS3FileUuid));
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    /**
+     * Build a minimal {@link RecruitmentCandidate} fixture and persist it. Returns
+     * the UUID. No dossier / no target-company linkage needed for the upload flow.
+     */
+    private String createCandidate() {
+        RecruitmentCandidate c = new RecruitmentCandidate();
+        c.setFirstName("Test");
+        c.setLastName("Candidate");
+        c.setEmail("test+" + UUID.randomUUID() + "@example.com");
+        // target_company_uuid is NOT NULL — pick any company UUID from the seeded DB.
+        String anyCompanyUuid = (String) em.createNativeQuery("SELECT uuid FROM company LIMIT 1").getSingleResult();
+        c.setTargetCompanyUuid(anyCompanyUuid);
+        c.setCreatedByUseruuid(UUID.randomUUID().toString());
+        c.persist();
+        return c.getUuid();
+    }
+
+    private String createCandidateToken(String candidateUuid,
+                                        boolean dl, boolean hi, boolean cr) {
+        OnboardingUploadToken token = new OnboardingUploadToken();
+        token.setCandidateUuid(candidateUuid);
+        token.setShowDriversLicense(dl);
+        token.setShowHealthInsurance(hi);
+        token.setShowCriminalRecord(cr);
+        token.setExpiresAt(LocalDateTime.now().plusDays(7));
+        token.setCreatedByUseruuid(UUID.randomUUID().toString());
+        token.persist();
+        return token.getUuid();
+    }
+
+    private String createUserToken(String userUuid, boolean dl, boolean hi, boolean cr) {
+        OnboardingUploadToken token = new OnboardingUploadToken();
+        token.setUserUuid(userUuid);
+        token.setShowDriversLicense(dl);
+        token.setShowHealthInsurance(hi);
+        token.setShowCriminalRecord(cr);
+        token.setExpiresAt(LocalDateTime.now().plusDays(7));
+        token.setCreatedByUseruuid(UUID.randomUUID().toString());
+        token.persist();
+        return token.getUuid();
+    }
+
+    /**
+     * Mockito stub: when the persister is invoked, run the actual
+     * {@code row.persist()} so the audit row lands in the DB and downstream
+     * assertions on the row work.
+     */
+    private void captureAndPersist() {
+        org.mockito.Mockito.doAnswer(inv -> {
+            OnboardingUploadSubmission row = inv.getArgument(0);
+            row.persist();
+            return null;
+        }).when(onboardingSubmissionPersister).persist(any(OnboardingUploadSubmission.class));
+    }
+
+    /**
+     * First user with a non-null active company in {@code userstatus}. Used as the
+     * anchor for the user-flow upload test.
+     */
+    @SuppressWarnings("unchecked")
+    private UserSeed anyUserWithCompany() {
+        List<Object[]> rows = em.createNativeQuery("""
+                SELECT us.useruuid, us.companyuuid, u.username
+                FROM userstatus us
+                JOIN user u ON u.uuid = us.useruuid
+                WHERE us.companyuuid IS NOT NULL
+                  AND us.statusdate <= CURRENT_DATE
+                  AND u.username IS NOT NULL
+                  AND u.username != ''
+                ORDER BY us.statusdate DESC
+                LIMIT 1
+                """).getResultList();
+        if (rows.isEmpty()) return null;
+        Object[] r = rows.get(0);
+        return new UserSeed((String) r[0], (String) r[1], (String) r[2]);
+    }
+
+    /**
+     * Ensure an {@code EMPLOYEE} SharePoint location exists for the given company so
+     * {@link dk.trustworks.intranet.recruitmentservice.services.OnboardingUploadService}
+     * can resolve a destination. Idempotent — looks up first, only inserts if absent.
+     */
+    private void ensureEmployeeLocation(String companyUuid) {
+        SharePointLocationEntity existing = SharePointLocationEntity.findByCompanyAndType(
+                companyUuid, SharePointLocationType.EMPLOYEE);
+        if (existing != null) return;
+        SharePointLocationEntity loc = new SharePointLocationEntity();
+        loc.setName("test-employee-loc-" + UUID.randomUUID());
+        loc.setSiteUrl("https://contoso.sharepoint.com/sites/Test");
+        loc.setDriveName("Documents");
+        loc.setFolderPath("Onboarding");
+        loc.setCompany(em.getReference(Company.class, companyUuid));
+        loc.setType(SharePointLocationType.EMPLOYEE);
+        loc.setIsActive(true);
+        loc.setDisplayOrder(1);
+        loc.persist();
+    }
+
+    private static File tempFileWithBytes(byte[] bytes, String filename) throws IOException {
+        File f = File.createTempFile("upload-test-", "-" + filename);
+        f.deleteOnExit();
+        Files.write(f.toPath(), bytes);
+        return f;
+    }
+
+    private record UserSeed(String userUuid, String companyUuid, String username) {}
+
+    // ── Hamcrest-light helpers — stay consistent with InternalInvoiceEndpointsTest ─
+
+    private static org.hamcrest.Matcher<Object> equalTo(Object expected) {
+        return org.hamcrest.Matchers.equalTo(expected);
+    }
+
+    private static org.hamcrest.Matcher<String> containsString(String substring) {
+        return org.hamcrest.Matchers.containsString(substring);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadServiceFilenameTest.java
+++ b/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadServiceFilenameTest.java
@@ -1,0 +1,144 @@
+package dk.trustworks.intranet.recruitmentservice.services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the package-private filename sanitiser used by the public
+ * onboarding upload endpoint. The endpoint is {@code @PermitAll} - the
+ * filename is therefore untrusted input and must be stripped of path
+ * separators, control characters, and {@code ..} traversal sequences
+ * before it can be embedded in an audit row, used as a SharePoint path
+ * leaf, or written to logs.
+ */
+class OnboardingUploadServiceFilenameTest {
+
+    @Test
+    void sanitise_null_returnsEmpty() {
+        assertEquals("", OnboardingUploadService.sanitiseFilename(null));
+    }
+
+    @Test
+    void sanitise_blank_returnsEmpty() {
+        assertEquals("", OnboardingUploadService.sanitiseFilename("   "));
+    }
+
+    @Test
+    void sanitise_stripsForwardSlashes() {
+        assertEquals("etcpasswd",
+                OnboardingUploadService.sanitiseFilename("/etc/passwd"));
+    }
+
+    @Test
+    void sanitise_stripsBackslashes() {
+        assertEquals("WindowsSystem32cmd.exe",
+                OnboardingUploadService.sanitiseFilename("Windows\\System32\\cmd.exe"));
+    }
+
+    @Test
+    void sanitise_collapsesDoubleDot() {
+        // Positive allowlist keeps `.` chars; multiple-dot run collapses to a
+        // single dot so `..etcpasswd` cannot resurface from unicode lookalikes.
+        assertEquals(".etcpasswd",
+                OnboardingUploadService.sanitiseFilename("../etc/passwd"));
+    }
+
+    @Test
+    void sanitise_collapsesAnyRunOfDots() {
+        assertEquals(".pdf",
+                OnboardingUploadService.sanitiseFilename("....pdf"));
+    }
+
+    @Test
+    void sanitise_dropsUnicodeLookalikes() {
+        // U+FF0F FULLWIDTH SOLIDUS / U+2024 ONE DOT LEADER must be stripped
+        // by the positive ASCII allowlist.
+        assertEquals("etcpasswd",
+                OnboardingUploadService.sanitiseFilename("／etc／passwd"));
+    }
+
+    @Test
+    void sanitise_stripsControlChars() {
+        // BEL (0x07) gets stripped; printable space is preserved.
+        String dirty = "helloworld.pdf";
+        assertEquals("helloworld.pdf",
+                OnboardingUploadService.sanitiseFilename(dirty));
+    }
+
+    @Test
+    void sanitise_keepsSpaces() {
+        assertEquals("Drivers License Front.jpg",
+                OnboardingUploadService.sanitiseFilename("Drivers License Front.jpg"));
+    }
+
+    @Test
+    void sanitise_keepsAsciiLettersDigitsHyphenUnderscore() {
+        // Positive allowlist: a-z A-Z 0-9 . _ - and space.
+        assertEquals("Korekort-aoa_2026.pdf",
+                OnboardingUploadService.sanitiseFilename("Korekort-aoa_2026.pdf"));
+    }
+
+    @Test
+    void sanitise_dropsNonAsciiLetters() {
+        // Allowlist is intentionally ASCII-only — Danish letters (æ ø å) get
+        // stripped. SharePoint/Graph would accept them, but tightening the
+        // surface here guards against unicode mischief.
+        assertEquals("Krekort.pdf",
+                OnboardingUploadService.sanitiseFilename("Kørekort.pdf"));
+    }
+
+    @Test
+    void sanitise_resultIsNeverNull() {
+        // Defensive: any input must yield a non-null String.
+        assertTrue(OnboardingUploadService.sanitiseFilename("...").isEmpty()
+                || !OnboardingUploadService.sanitiseFilename("...").isBlank());
+    }
+
+    @Test
+    void sanitisePathSegment_collapsesTraversal() {
+        assertEquals(".safeUser",
+                OnboardingUploadService.sanitisePathSegment("../safe/User"));
+    }
+
+    // ── magic-byte sniffing (defense against lying Content-Type) ──────────
+
+    @Test
+    void magic_pdf_matchesPDFHeader() {
+        byte[] bytes = {0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37};
+        assertTrue(OnboardingUploadService.magicMatches("application/pdf", bytes));
+    }
+
+    @Test
+    void magic_pdf_rejectsNonPDFBytes() {
+        byte[] bytes = {0x4d, 0x5a, (byte) 0x90, 0x00}; // PE/EXE header.
+        assertEquals(false, OnboardingUploadService.magicMatches("application/pdf", bytes));
+    }
+
+    @Test
+    void magic_jpeg_matchesJPEGHeader() {
+        byte[] bytes = {(byte) 0xff, (byte) 0xd8, (byte) 0xff, (byte) 0xe0};
+        assertTrue(OnboardingUploadService.magicMatches("image/jpeg", bytes));
+    }
+
+    @Test
+    void magic_png_matchesPNGHeader() {
+        byte[] bytes = {(byte) 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a};
+        assertTrue(OnboardingUploadService.magicMatches("image/png", bytes));
+    }
+
+    @Test
+    void magic_rejectsTooShortInput() {
+        assertEquals(false, OnboardingUploadService.magicMatches("application/pdf", new byte[]{0x25, 0x50}));
+        assertEquals(false, OnboardingUploadService.magicMatches("image/png", new byte[]{(byte) 0x89, 0x50, 0x4e, 0x47}));
+    }
+
+    @Test
+    void magic_unknownTypeReturnsFalse() {
+        // Defense in depth: even if the allowlist is bypassed elsewhere,
+        // an unrecognised type cannot pass the magic check.
+        assertEquals(false,
+                OnboardingUploadService.magicMatches("application/octet-stream", new byte[]{0x25, 0x50, 0x44, 0x46}));
+    }
+}


### PR DESCRIPTION
Promotes the public onboarding upload storage feature (PR #49) and its companion frontend (trustworks-intranet-v3 PR #48) from staging to production.

Includes:
- New POST /onboarding/tokens/{tokenUuid}/upload (PermitAll, multipart) routing to S3 (candidate flow) or SharePoint EMPLOYEE folder (user flow)
- V327 Flyway migration: onboarding_upload_submissions audit table
- Critical PR-review fixes: narrow @Transactional, compensating storage delete on race, 409 on unique-key violation, DATETIME(6), pre-resolved Slack notifier names

Staging deploy: green ([run 25554268532](https://github.com/dabster2000/intranetservices/actions/runs/25554268532)).