### PR TITLE
Onboarding document AI validation

### DIFF
--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/resources/OnboardingResource.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/resources/OnboardingResource.java
@@ -145,6 +145,9 @@ public class OnboardingResource {
                     .build();
         }
 
+        // AI_REJECTED arrives as a WebApplicationException(422) built in
+        // OnboardingUploadService.aiRejected(); Quarkus passes it through
+        // with the JSON body intact, so no explicit catch arm is needed.
         try {
             OnboardingValidateResponse response = onboardingUploadService.handleUpload(
                     tokenUuid,
@@ -156,14 +159,9 @@ public class OnboardingResource {
         } catch (ForbiddenException fe) {
             // Same silence rule as /validate — never leak token existence.
             return Response.status(Response.Status.FORBIDDEN).build();
-        }
-        // Note: AI_REJECTED arrives as a WebApplicationException with a
-        // 422 Response built in OnboardingUploadService.aiRejected();
-        // Quarkus passes it through with the body intact.
-        catch (BadRequestException bre) {
+        } catch (BadRequestException bre) {
             return bre.getResponse();
         }
-
     }
 
     // ── Protected lookup endpoints ─────────────────────────────────────────────

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/resources/OnboardingResource.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/resources/OnboardingResource.java
@@ -156,9 +156,14 @@ public class OnboardingResource {
         } catch (ForbiddenException fe) {
             // Same silence rule as /validate — never leak token existence.
             return Response.status(Response.Status.FORBIDDEN).build();
-        } catch (BadRequestException bre) {
+        }
+        // Note: AI_REJECTED arrives as a WebApplicationException with a
+        // 422 Response built in OnboardingUploadService.aiRejected();
+        // Quarkus passes it through with the body intact.
+        catch (BadRequestException bre) {
             return bre.getResponse();
         }
+
     }
 
     // ── Protected lookup endpoints ─────────────────────────────────────────────

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationService.java
@@ -1,0 +1,94 @@
+package dk.trustworks.intranet.recruitmentservice.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dk.trustworks.intranet.apis.openai.OpenAIService;
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingDocumentType;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.jbosslog.JBossLog;
+
+/**
+ * Synchronous AI validator for the public onboarding upload endpoint.
+ *
+ * <p>Each call sends one image to OpenAI's vision-capable model with a
+ * type-specific system prompt and a strict JSON schema. The schema asks for
+ * four boolean checks ({@code isCorrectDocumentType}, {@code isDanish},
+ * {@code isReadable}, {@code isValid}) plus a top-level {@code approved}
+ * boolean and a short {@code reason}. After parsing, we recompute
+ * {@code approved == AND(checks)} as a guardrail against the model
+ * approving despite a sub-check being false.</p>
+ *
+ * <p>Failure mode is "fail closed": any transport error, refusal, or
+ * unparsable response yields {@code approved=false} with a friendly reason
+ * — see {@link #FALLBACK_REJECTED_JSON}. The caller blocks the upload.</p>
+ */
+@JBossLog
+@ApplicationScoped
+public class OnboardingDocumentValidationService {
+
+    static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public record ValidationDecision(boolean approved, String reason) {}
+
+    /**
+     * Schema-conformant fallback returned when OpenAI refuses or fails.
+     * Hard-rejected with a user-facing reason that points at HR.
+     */
+    static final String FALLBACK_REJECTED_JSON = """
+        {
+          "approved": false,
+          "reason": "AI validation failed — please try again, or contact hr@trustworks.dk if it keeps failing.",
+          "checks": {
+            "isCorrectDocumentType": false,
+            "isDanish": false,
+            "isReadable": false,
+            "isValid": false
+          }
+        }
+        """;
+
+    @Inject
+    OpenAIService openAIService;
+
+    /**
+     * Build the strict JSON schema sent to OpenAI for all three document
+     * types. Shared across prompts so the parser has one shape to handle.
+     */
+    static ObjectNode buildSchema() {
+        ObjectNode schema = MAPPER.createObjectNode();
+        schema.put("type", "object");
+        schema.put("additionalProperties", false);
+
+        ObjectNode props = schema.putObject("properties");
+
+        props.putObject("approved").put("type", "boolean");
+
+        ObjectNode reason = props.putObject("reason");
+        reason.put("type", "string");
+        reason.put("minLength", 5);
+        reason.put("maxLength", 240);
+
+        ObjectNode checks = props.putObject("checks");
+        checks.put("type", "object");
+        checks.put("additionalProperties", false);
+        ObjectNode checksProps = checks.putObject("properties");
+        checksProps.putObject("isCorrectDocumentType").put("type", "boolean");
+        checksProps.putObject("isDanish").put("type", "boolean");
+        checksProps.putObject("isReadable").put("type", "boolean");
+        checksProps.putObject("isValid").put("type", "boolean");
+        ArrayNode checksRequired = checks.putArray("required");
+        checksRequired.add("isCorrectDocumentType");
+        checksRequired.add("isDanish");
+        checksRequired.add("isReadable");
+        checksRequired.add("isValid");
+
+        ArrayNode required = schema.putArray("required");
+        required.add("approved");
+        required.add("reason");
+        required.add("checks");
+
+        return schema;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationService.java
@@ -10,6 +10,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import lombok.extern.jbosslog.JBossLog;
 
+import java.util.Base64;
+
 /**
  * Synchronous AI validator for the public onboarding upload endpoint.
  *
@@ -30,6 +32,8 @@ import lombok.extern.jbosslog.JBossLog;
 public class OnboardingDocumentValidationService {
 
     static final ObjectMapper MAPPER = new ObjectMapper();
+
+    static final ObjectNode SCHEMA = buildSchema();
 
     public record ValidationDecision(boolean approved, String reason) {}
 
@@ -244,7 +248,7 @@ public class OnboardingDocumentValidationService {
         if (type == null || bytes == null || bytes.length == 0) {
             return new ValidationDecision(false, "No document provided to validate.");
         }
-        String base64 = java.util.Base64.getEncoder().encodeToString(bytes);
+        String base64 = Base64.getEncoder().encodeToString(bytes);
         String system = systemPromptFor(type);
         String raw;
         try {
@@ -253,7 +257,7 @@ public class OnboardingDocumentValidationService {
                     "Validate this image and return the JSON object specified by the schema.",
                     base64,
                     mimeType,
-                    buildSchema(),
+                    SCHEMA,
                     "OnboardingDocValidation",
                     FALLBACK_REJECTED_JSON);
         } catch (RuntimeException e) {

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationService.java
@@ -232,4 +232,38 @@ public class OnboardingDocumentValidationService {
         }
         return new ValidationDecision(approved, reason);
     }
+
+    /**
+     * Validate one uploaded document against the type-specific prompt.
+     *
+     * <p>Returns a rejected {@link ValidationDecision} on any failure path —
+     * transport error, refusal, malformed JSON, or guardrail mismatch. The
+     * caller never has to handle exceptions.</p>
+     */
+    public ValidationDecision validate(OnboardingDocumentType type, byte[] bytes, String mimeType) {
+        if (type == null || bytes == null || bytes.length == 0) {
+            return new ValidationDecision(false, "No document provided to validate.");
+        }
+        String base64 = java.util.Base64.getEncoder().encodeToString(bytes);
+        String system = systemPromptFor(type);
+        String raw;
+        try {
+            raw = openAIService.askWithSchemaAndImage(
+                    system,
+                    "Validate this image and return the JSON object specified by the schema.",
+                    base64,
+                    mimeType,
+                    buildSchema(),
+                    "OnboardingDocValidation",
+                    FALLBACK_REJECTED_JSON);
+        } catch (RuntimeException e) {
+            log.errorf(e, "[OnboardingValidate] OpenAI call failed for type=%s", type);
+            return new ValidationDecision(false,
+                    "AI validation failed — please try again, or contact hr@trustworks.dk if it keeps failing.");
+        }
+        ValidationDecision d = parseDecision(raw);
+        log.infof("[OnboardingValidate] type=%s approved=%s reasonLen=%d",
+                type, d.approved(), d.reason() == null ? 0 : d.reason().length());
+        return d;
+    }
 }

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationService.java
@@ -1,5 +1,6 @@
 package dk.trustworks.intranet.recruitmentservice.services;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -197,7 +198,7 @@ public class OnboardingDocumentValidationService {
         if (raw == null || raw.isBlank()) {
             return new ValidationDecision(false, "AI validation returned no response — please try again.");
         }
-        com.fasterxml.jackson.databind.JsonNode node;
+        JsonNode node;
         try {
             node = MAPPER.readTree(raw);
         } catch (Exception e) {
@@ -206,7 +207,7 @@ public class OnboardingDocumentValidationService {
             return new ValidationDecision(false,
                     "AI validation returned an unreadable response — please try again.");
         }
-        com.fasterxml.jackson.databind.JsonNode checks = node.path("checks");
+        JsonNode checks = node.path("checks");
         if (!checks.isObject()) {
             return new ValidationDecision(false,
                     "AI validation returned an incomplete response — please try again.");

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationService.java
@@ -182,4 +182,53 @@ public class OnboardingDocumentValidationService {
             case CRIMINAL_RECORD  -> SYSTEM_PROMPT_CRIMINAL_RECORD;
         };
     }
+
+    /**
+     * Parse a strict-JSON-Schema response from OpenAI into a
+     * {@link ValidationDecision}. Applies the guardrail
+     * {@code approved == AND(checks)} after parsing.
+     *
+     * <p>Any of: empty input, unparsable input, missing {@code checks}
+     * object, or {@code approved} disagreeing with the AND of its checks
+     * yields a rejected decision with a generic friendly reason. The
+     * caller never has to deal with malformed AI output.</p>
+     */
+    static ValidationDecision parseDecision(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return new ValidationDecision(false, "AI validation returned no response — please try again.");
+        }
+        com.fasterxml.jackson.databind.JsonNode node;
+        try {
+            node = MAPPER.readTree(raw);
+        } catch (Exception e) {
+            log.warnf("[OnboardingValidate] Could not parse AI response: %s",
+                    raw.length() > 200 ? raw.substring(0, 200) + "..." : raw);
+            return new ValidationDecision(false,
+                    "AI validation returned an unreadable response — please try again.");
+        }
+        com.fasterxml.jackson.databind.JsonNode checks = node.path("checks");
+        if (!checks.isObject()) {
+            return new ValidationDecision(false,
+                    "AI validation returned an incomplete response — please try again.");
+        }
+        boolean expected = checks.path("isCorrectDocumentType").asBoolean(false)
+                && checks.path("isDanish").asBoolean(false)
+                && checks.path("isReadable").asBoolean(false)
+                && checks.path("isValid").asBoolean(false);
+        boolean approved = node.path("approved").asBoolean(false);
+        String reason = node.path("reason").asText("");
+        if (reason == null || reason.isBlank()) {
+            reason = expected
+                    ? "Document accepted."
+                    : "Document could not be validated — please re-upload a clearer image.";
+        }
+        if (approved != expected) {
+            // Guardrail: trust the per-check booleans, not the top-level claim.
+            log.warnf("[OnboardingValidate] approved/checks mismatch: approved=%s expected=%s",
+                    approved, expected);
+            return new ValidationDecision(false,
+                    "Validation inconsistency — please re-upload the document.");
+        }
+        return new ValidationDecision(approved, reason);
+    }
 }

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationService.java
@@ -91,4 +91,95 @@ public class OnboardingDocumentValidationService {
 
         return schema;
     }
+
+    static final String SYSTEM_PROMPT_DRIVERS_LICENSE = """
+            You are validating a Danish driver's licence (kørekort) submitted as part of a hiring onboarding.
+
+            Decide whether the image can be accepted, by evaluating four checks. Set each boolean strictly:
+
+            - isCorrectDocumentType: true ONLY if the image clearly shows a driver's licence (a credit-card-sized
+              card with photo, name, date of birth, licence categories like A/B/C, and a licence number).
+              False for passports, ID cards, sundhedskort, or any other document.
+
+            - isDanish: true ONLY if the document is a Danish driver's licence. Indicators include the wording
+              "KØREKORT" / "DRIVING LICENCE" with a Danish issuing authority, the small "DK" country code in the
+              EU flag, or Danish category labels. Older paper Danish licences (pink folded paper) are also valid.
+
+            - isReadable: true ONLY if the photo is sharp enough that the name, date of birth, expiry date,
+              and licence number are all clearly legible without guessing. Reject blurry, dark, glare-covered,
+              rotated, or partially-cropped images.
+
+            - isValid: true ONLY if the licence has not expired. Compare the printed expiry date (field 4b) to
+              today's date. If the expiry date is unreadable, set isValid=false.
+
+            approved = all four booleans true.
+
+            reason: one short sentence (<=240 chars). If approved, say so plainly. If rejected, name the SINGLE
+            biggest issue and tell the user what to do next (e.g. "We could not read the expiry date — please
+            upload a sharper photo with all four corners visible"). Never expose internal field names.
+
+            Return ONLY the JSON object specified by the schema. No markdown, no commentary.
+            """;
+
+    static final String SYSTEM_PROMPT_HEALTH_INSURANCE = """
+            You are validating a Danish health-insurance card (sundhedskort, also known as the yellow card / det
+            gule sygesikringsbevis) submitted as part of a hiring onboarding.
+
+            - isCorrectDocumentType: true ONLY if the image shows a sundhedskort — a yellow plastic card showing
+              the holder's name, CPR number, address, and the assigned general practitioner (læge). False for
+              driver's licences, passports, EU health insurance cards (the blue EHIC), or anything else.
+
+            - isDanish: true ONLY if it is a Danish sundhedskort issued by a Danish kommune / Region. Look for
+              Danish text such as "Sundhedskort", a Danish address, and a 10-digit CPR number formatted DDMMYY-XXXX.
+              The blue EU EHIC (Det blå EU-sygesikringsbevis) is NOT acceptable here — set isDanish=false and
+              explain in the reason.
+
+            - isReadable: true ONLY if the holder's name, CPR number, address, and GP information are clearly
+              legible. Reject blurry, glare-covered, partly-cropped, or low-resolution photos.
+
+            - isValid: true unless the card itself shows an expiry/validity date that is in the past. Sundhedskort
+              do not normally print an expiry — in that case treat isValid=true if the card is otherwise legible.
+
+            approved = all four booleans true.
+
+            reason: one short sentence (<=240 chars). If rejected, name the SINGLE biggest issue and tell the
+            user what to do next. Never expose CPR digits in the reason.
+
+            Return ONLY the JSON object specified by the schema. No markdown, no commentary.
+            """;
+
+    static final String SYSTEM_PROMPT_CRIMINAL_RECORD = """
+            You are validating a Danish certificate of criminal record (straffeattest / privat straffeattest)
+            submitted as part of a hiring onboarding.
+
+            - isCorrectDocumentType: true ONLY if the document is a straffeattest issued by Danish police
+              (Politiet / Rigspolitiet). Indicators: the heading "Straffeattest" or "Privat straffeattest", the
+              named subject's full name and CPR, an issue date (udstedt), and a Politiet logo or letterhead.
+              False for course certificates, references, child-protection certificates (børneattest — that is
+              a different document), or any other paper.
+
+            - isDanish: true ONLY if it is issued by Danish Politiet/Rigspolitiet (Danish text, Danish authority).
+
+            - isReadable: true ONLY if the subject's name, the issue date, and the body text are clearly legible.
+              Reject blurry, partial, or rotated images. PDFs printed and re-photographed are fine if sharp.
+
+            - isValid: true ONLY if the issue date (udstedt) is no more than 3 calendar months before today.
+              If the issue date is unreadable, set isValid=false.
+
+            approved = all four booleans true.
+
+            reason: one short sentence (<=240 chars). If rejected, name the SINGLE biggest issue and tell the
+            user what to do (e.g. "Your straffeattest is more than 3 months old — please request a fresh one
+            from politi.dk and upload it"). Never expose CPR digits.
+
+            Return ONLY the JSON object specified by the schema. No markdown, no commentary.
+            """;
+
+    static String systemPromptFor(OnboardingDocumentType type) {
+        return switch (type) {
+            case DRIVERS_LICENSE  -> SYSTEM_PROMPT_DRIVERS_LICENSE;
+            case HEALTH_INSURANCE -> SYSTEM_PROMPT_HEALTH_INSURANCE;
+            case CRIMINAL_RECORD  -> SYSTEM_PROMPT_CRIMINAL_RECORD;
+        };
+    }
 }

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingErrorCodes.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingErrorCodes.java
@@ -1,0 +1,21 @@
+package dk.trustworks.intranet.recruitmentservice.services;
+
+/**
+ * Wire-contract error codes returned in the JSON body of upload-failure
+ * responses from {@code POST /onboarding/tokens/{token}/upload}.
+ *
+ * <p>The frontend (`uploadStateMachine.ts`) mirrors these strings. Renaming
+ * any of them is a public-API change — both repos must be updated together.</p>
+ */
+public final class OnboardingErrorCodes {
+
+    public static final String AI_REJECTED              = "AI_REJECTED";
+    public static final String ALREADY_SUBMITTED        = "ALREADY_SUBMITTED";
+    public static final String EMPTY_FILE               = "EMPTY_FILE";
+    public static final String FILE_TOO_LARGE           = "FILE_TOO_LARGE";
+    public static final String UNSUPPORTED_MEDIA_TYPE   = "UNSUPPORTED_MEDIA_TYPE";
+    public static final String INVALID_FILENAME        = "INVALID_FILENAME";
+    public static final String DOCUMENT_TYPE_NOT_ALLOWED = "DOCUMENT_TYPE_NOT_ALLOWED";
+
+    private OnboardingErrorCodes() {}
+}

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
@@ -134,7 +134,7 @@ public class OnboardingUploadService {
 
         // Token-flag gate: the type must be one the token explicitly asked for.
         if (!isTypeAllowedByToken(token, type)) {
-            throw badRequest("DOCUMENT_TYPE_NOT_ALLOWED");
+            throw badRequest(OnboardingErrorCodes.DOCUMENT_TYPE_NOT_ALLOWED);
         }
 
         // Single-shot per type — first-pass check (race-safe DB unique key
@@ -145,19 +145,19 @@ public class OnboardingUploadService {
 
         // Bytes / MIME / size sanity check.
         if (bytes == null || bytes.length == 0) {
-            throw badRequest("EMPTY_FILE");
+            throw badRequest(OnboardingErrorCodes.EMPTY_FILE);
         }
         if (bytes.length > MAX_BYTES) {
-            throw badRequest("FILE_TOO_LARGE");
+            throw badRequest(OnboardingErrorCodes.FILE_TOO_LARGE);
         }
         String normalisedContentType = normaliseContentType(contentType);
         if (!ALLOWED_MIME_TYPES.contains(normalisedContentType)) {
-            throw badRequest("UNSUPPORTED_MEDIA_TYPE");
+            throw badRequest(OnboardingErrorCodes.UNSUPPORTED_MEDIA_TYPE);
         }
         if (!magicMatches(normalisedContentType, bytes)) {
             // Asserted MIME and actual bytes disagree — refuse rather than
             // trust the public-facing Content-Type header.
-            throw badRequest("UNSUPPORTED_MEDIA_TYPE");
+            throw badRequest(OnboardingErrorCodes.UNSUPPORTED_MEDIA_TYPE);
         }
 
         // ── 1b. AI validation gate. Synchronous; fail-closed. ────────────
@@ -174,7 +174,7 @@ public class OnboardingUploadService {
         // Sanitise filename — never trust public input as a path component.
         String safeFilename = sanitiseFilename(filename);
         if (safeFilename.isBlank()) {
-            throw badRequest("INVALID_FILENAME");
+            throw badRequest(OnboardingErrorCodes.INVALID_FILENAME);
         }
 
         // Branch on token ownership (XOR enforced both at DB and here).
@@ -439,7 +439,7 @@ public class OnboardingUploadService {
     private static WebApplicationException alreadySubmitted() {
         return new WebApplicationException(
                 Response.status(Response.Status.CONFLICT)
-                        .entity("{\"error\":\"ALREADY_SUBMITTED\"}")
+                        .entity("{\"error\":\"" + OnboardingErrorCodes.ALREADY_SUBMITTED + "\"}")
                         .type(MediaType.APPLICATION_JSON)
                         .build());
     }
@@ -465,7 +465,7 @@ public class OnboardingUploadService {
         String safe = reason == null ? "" : reason
                 .replace("\\", "\\\\")
                 .replace("\"", "\\\"");
-        String body = "{\"error\":\"AI_REJECTED\",\"reason\":\"" + safe + "\"}";
+        String body = "{\"error\":\"" + OnboardingErrorCodes.AI_REJECTED + "\",\"reason\":\"" + safe + "\"}";
         return new WebApplicationException(
                 Response.status(422)
                         .entity(body)

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
@@ -97,6 +97,9 @@ public class OnboardingUploadService {
     @Inject
     OnboardingSubmissionPersister onboardingSubmissionPersister;
 
+    @Inject
+    OnboardingDocumentValidationService documentValidationService;
+
     @ConfigProperty(name = "recruitment.hr.slack.dossier-base-url",
             defaultValue = "https://intra.trustworks.dk/recruitment/candidates")
     String dossierBaseUrl;
@@ -148,6 +151,17 @@ public class OnboardingUploadService {
             // Asserted MIME and actual bytes disagree — refuse rather than
             // trust the public-facing Content-Type header.
             throw badRequest("UNSUPPORTED_MEDIA_TYPE");
+        }
+
+        // ── 1b. AI validation gate. Synchronous; fail-closed. ────────────
+        // Runs after structural checks but before any storage write so
+        // rejected documents never reach S3/SharePoint.
+        OnboardingDocumentValidationService.ValidationDecision aiDecision =
+                documentValidationService.validate(type, bytes, normalisedContentType);
+        if (!aiDecision.approved()) {
+            log.infof("Onboarding upload AI-rejected token=%s type=%s reasonLen=%d",
+                    tokenUuid, type, aiDecision.reason() == null ? 0 : aiDecision.reason().length());
+            throw aiRejected(sanitiseReasonForBody(aiDecision.reason()));
         }
 
         // Sanitise filename — never trust public input as a path component.
@@ -450,6 +464,19 @@ public class OnboardingUploadService {
                         .entity(body)
                         .type(MediaType.APPLICATION_JSON)
                         .build());
+    }
+
+    /**
+     * Strip ASCII control characters (U+0000–U+001F) from an AI-supplied
+     * reason before it is embedded into the JSON response body. The model
+     * is prompted for "one short sentence", but a misbehaving model could
+     * still emit a stray newline or tab, which would produce invalid JSON
+     * if pasted as-is into a string literal. Replace each control char
+     * with a space; collapse the result to a single line.
+     */
+    private static String sanitiseReasonForBody(String reason) {
+        if (reason == null) return "";
+        return reason.replaceAll("[\\x00-\\x1F]", " ").trim();
     }
 
     /**

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
@@ -40,12 +40,19 @@ import java.util.UUID;
  * keep the slow S3/SharePoint upload (1–5 s round trip) <i>outside</i> any
  * DB transaction so we don't hold a connection while waiting on a
  * remote HTTP API. The narrow audit-row insert runs in its own
- * transaction via {@link OnboardingSubmissionPersister}.</p>
+ * transaction via {@link OnboardingSubmissionPersister}. The AI vision
+ * call (3–8 s typical latency) likewise runs outside any transaction,
+ * for the same reason — we never hold a JDBC connection while waiting
+ * on a remote HTTP API.</p>
  *
  * <p><b>Order of operations:</b></p>
  * <ol>
  *   <li>Read-only validation (token lookup, expiry, type-allowed,
  *       existsForTokenAndType, MIME / size / magic-byte / filename) — no TX.</li>
+ *   <li>AI document validation gate — synchronous OpenAI vision call
+ *       against the type-specific prompt; fail-closed (rejection throws
+ *       <b>422 AI_REJECTED</b>); still no DB transaction, so the slow
+ *       remote call does not hold a connection.</li>
  *   <li>Pre-resolve display name + link URL for the eventual Slack message
  *       so the notifier needs no further DB reads.</li>
  *   <li>Upload bytes to S3 / SharePoint — <i>still no TX</i>.</li>

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
@@ -432,6 +432,27 @@ public class OnboardingUploadService {
     }
 
     /**
+     * Build a {@code 422 Unprocessable Entity} response carrying the AI
+     * validator's user-facing reason. Distinct from the existing 400/409
+     * codes so the frontend can render the AI reason in-zone rather than
+     * the generic "could not save" copy.
+     *
+     * <p>The reason is the model's own text. We escape JSON specials but
+     * never log it at WARN — the field is part of the public response body.</p>
+     */
+    private static WebApplicationException aiRejected(String reason) {
+        String safe = reason == null ? "" : reason
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"");
+        String body = "{\"error\":\"AI_REJECTED\",\"reason\":\"" + safe + "\"}";
+        return new WebApplicationException(
+                Response.status(422)
+                        .entity(body)
+                        .type(MediaType.APPLICATION_JSON)
+                        .build());
+    }
+
+    /**
      * Positive allowlist filename sanitiser: keep only ASCII alphanumerics,
      * dot, underscore, hyphen, and space. Collapses any run of dots so
      * "{@code ..}" cannot resurface from a unicode look-alike. Returns ""

--- a/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
+++ b/src/main/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadService.java
@@ -73,9 +73,11 @@ public class OnboardingUploadService {
      * in {@link #magicMatches} so a caller cannot bypass the format
      * restriction by lying about the type ({@code application/octet-stream}
      * is intentionally excluded).</p>
+     *
+     * <p>PDF was dropped when AI document validation landed — the vision
+     * API takes images only, and the client-side accept list now matches.</p>
      */
     private static final Set<String> ALLOWED_MIME_TYPES = Set.of(
-            "application/pdf",
             "image/jpeg",
             "image/png"
     );
@@ -464,7 +466,6 @@ public class OnboardingUploadService {
      * unintended file format past the allowlist.
      *
      * <ul>
-     *   <li>PDF: {@code 25 50 44 46} ("%PDF")</li>
      *   <li>JPEG: {@code FF D8 FF}</li>
      *   <li>PNG: {@code 89 50 4E 47 0D 0A 1A 0A}</li>
      * </ul>
@@ -472,8 +473,6 @@ public class OnboardingUploadService {
     static boolean magicMatches(String contentType, byte[] bytes) {
         if (bytes == null || bytes.length < 4) return false;
         return switch (contentType) {
-            case "application/pdf" ->
-                    bytes[0] == 0x25 && bytes[1] == 0x50 && bytes[2] == 0x44 && bytes[3] == 0x46;
             case "image/jpeg" ->
                     (bytes[0] & 0xff) == 0xff && (bytes[1] & 0xff) == 0xd8 && (bytes[2] & 0xff) == 0xff;
             case "image/png" -> bytes.length >= 8

--- a/src/test/java/dk/trustworks/intranet/recruitmentservice/resources/OnboardingUploadResourceTest.java
+++ b/src/test/java/dk/trustworks/intranet/recruitmentservice/resources/OnboardingUploadResourceTest.java
@@ -100,13 +100,13 @@ class OnboardingUploadResourceTest {
     // ── Happy paths ────────────────────────────────────────────────────────────
 
     /**
-     * Candidate flow: PDF upload routes to S3, audit row stores the file UUID
+     * Candidate flow: JPEG upload routes to S3, audit row stores the file UUID
      * with {@code storage_target='S3'}, and the response carries the updated
      * submitted block.
      */
     @Test
     @TestTransaction
-    void candidateFlow_validPdf_returns200_storesInS3_andPersistsAuditRow() throws IOException {
+    void candidateFlow_validJpeg_returns200_storesInS3_andPersistsAuditRow() throws IOException {
         // Arrange: candidate token requesting drivers-license only.
         String candidateUuid = createCandidate();
         String tokenUuid = createCandidateToken(candidateUuid, true, false, false);
@@ -118,11 +118,11 @@ class OnboardingUploadResourceTest {
         // Persister is mocked: capture and forward the row to a real persist so we can assert columns.
         captureAndPersist();
 
-        File pdf = tempFileWithBytes(PDF_BYTES, "license.pdf");
+        File jpeg = tempFileWithBytes(JPEG_BYTES, "license.jpg");
 
         // Act
         given()
-                .multiPart("file", pdf, "application/pdf")
+                .multiPart("file", jpeg, "image/jpeg")
                 .formParam("documentType", "DRIVERS_LICENSE")
                 .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
                 .then().statusCode(200)
@@ -215,10 +215,10 @@ class OnboardingUploadResourceTest {
         token.setCreatedByUseruuid(UUID.randomUUID().toString());
         token.persist();
 
-        File pdf = tempFileWithBytes(PDF_BYTES, "license.pdf");
+        File jpeg = tempFileWithBytes(JPEG_BYTES, "license.jpg");
 
         given()
-                .multiPart("file", pdf, "application/pdf")
+                .multiPart("file", jpeg, "image/jpeg")
                 .formParam("documentType", "DRIVERS_LICENSE")
                 .when().post("/onboarding/tokens/" + token.getUuid() + "/upload")
                 .then().statusCode(403)
@@ -240,11 +240,11 @@ class OnboardingUploadResourceTest {
                 .thenReturn(UUID.randomUUID().toString());
         captureAndPersist();
 
-        File pdf = tempFileWithBytes(PDF_BYTES, "license.pdf");
+        File jpeg = tempFileWithBytes(JPEG_BYTES, "license.jpg");
 
         // First call → 200
         given()
-                .multiPart("file", pdf, "application/pdf")
+                .multiPart("file", jpeg, "image/jpeg")
                 .formParam("documentType", "DRIVERS_LICENSE")
                 .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
                 .then().statusCode(200);
@@ -252,7 +252,7 @@ class OnboardingUploadResourceTest {
         // Second call → 409 ALREADY_SUBMITTED. The service's pre-check sees the row
         // and short-circuits — no additional storage call.
         given()
-                .multiPart("file", pdf, "application/pdf")
+                .multiPart("file", jpeg, "image/jpeg")
                 .formParam("documentType", "DRIVERS_LICENSE")
                 .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
                 .then().statusCode(409)
@@ -271,10 +271,10 @@ class OnboardingUploadResourceTest {
         // Token only enables HEALTH_INSURANCE — DRIVERS_LICENSE must be rejected.
         String tokenUuid = createCandidateToken(candidateUuid, false, true, false);
 
-        File pdf = tempFileWithBytes(PDF_BYTES, "license.pdf");
+        File jpeg = tempFileWithBytes(JPEG_BYTES, "license.jpg");
 
         given()
-                .multiPart("file", pdf, "application/pdf")
+                .multiPart("file", jpeg, "image/jpeg")
                 .formParam("documentType", "DRIVERS_LICENSE")
                 .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
                 .then().statusCode(400)
@@ -294,13 +294,13 @@ class OnboardingUploadResourceTest {
 
         // 10 MiB + 1 byte — caught by the resource-layer pre-flight on file.size().
         byte[] huge = new byte[10 * 1024 * 1024 + 1];
-        // Seed PDF magic bytes so any later magic check would still pass — but we expect
+        // Seed JPEG magic bytes so any later magic check would still pass — but we expect
         // the size check to fail first.
-        huge[0] = 0x25; huge[1] = 0x50; huge[2] = 0x44; huge[3] = 0x46;
-        File big = tempFileWithBytes(huge, "huge.pdf");
+        huge[0] = (byte) 0xff; huge[1] = (byte) 0xd8; huge[2] = (byte) 0xff; huge[3] = (byte) 0xe0;
+        File big = tempFileWithBytes(huge, "huge.jpg");
 
         given()
-                .multiPart("file", big, "application/pdf")
+                .multiPart("file", big, "image/jpeg")
                 .formParam("documentType", "DRIVERS_LICENSE")
                 .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
                 .then().statusCode(400)
@@ -328,19 +328,54 @@ class OnboardingUploadResourceTest {
                 .storeIdentityDocument(any(byte[].class), anyString(), any(UUID.class));
     }
 
-    // ── Magic-byte mismatch ────────────────────────────────────────────────────
+    // ── PDF no longer in allow-list ────────────────────────────────────────────
 
+    /**
+     * Following the move to an image-only allow-list, {@code application/pdf}
+     * is no longer accepted by the onboarding upload endpoint regardless of
+     * whether the bytes are a real PDF. The MIME allow-list gate must reject
+     * the request with {@code 400 UNSUPPORTED_MEDIA_TYPE} before any storage
+     * call is made.
+     */
     @Test
     @TestTransaction
-    void contentTypePdfButJpegMagicBytes_returns400_UNSUPPORTED_MEDIA_TYPE() throws IOException {
+    void pdfUpload_returns400_UNSUPPORTED_MEDIA_TYPE() throws IOException {
         String candidateUuid = createCandidate();
         String tokenUuid = createCandidateToken(candidateUuid, true, false, false);
 
-        // Asserts MIME = application/pdf but bytes are a JPEG.
-        File spoofed = tempFileWithBytes(JPEG_BYTES, "spoof.pdf");
+        // Real PDF bytes + application/pdf content type — the allow-list must reject it.
+        File pdf = tempFileWithBytes(PDF_BYTES, "license.pdf");
 
         given()
-                .multiPart("file", spoofed, "application/pdf")
+                .multiPart("file", pdf, "application/pdf")
+                .formParam("documentType", "DRIVERS_LICENSE")
+                .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
+                .then().statusCode(400)
+                .body(containsString("UNSUPPORTED_MEDIA_TYPE"));
+
+        verify(recruitmentS3StorageService, never())
+                .storeIdentityDocument(any(byte[].class), anyString(), any(UUID.class));
+    }
+
+    // ── Magic-byte mismatch (regression guard for the magic-bytes gate) ───────
+
+    /**
+     * Even with an allow-listed MIME type, the request must be rejected when
+     * the file's magic bytes do not match the declared content type. Posts
+     * JPEG-magic bytes with {@code image/png} → expect
+     * {@code 400 UNSUPPORTED_MEDIA_TYPE}.
+     */
+    @Test
+    @TestTransaction
+    void mimeMismatchPngContentTypeButJpegMagicBytes_returns400_UNSUPPORTED_MEDIA_TYPE() throws IOException {
+        String candidateUuid = createCandidate();
+        String tokenUuid = createCandidateToken(candidateUuid, true, false, false);
+
+        // Declared as PNG but bytes are a JPEG — magic-byte gate must catch it.
+        File spoofed = tempFileWithBytes(JPEG_BYTES, "spoof.png");
+
+        given()
+                .multiPart("file", spoofed, "image/png")
                 .formParam("documentType", "DRIVERS_LICENSE")
                 .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
                 .then().statusCode(400)
@@ -379,10 +414,10 @@ class OnboardingUploadResourceTest {
                 "uk_ous_token_doctype"))
                 .when(onboardingSubmissionPersister).persist(any(OnboardingUploadSubmission.class));
 
-        File pdf = tempFileWithBytes(PDF_BYTES, "license.pdf");
+        File jpeg = tempFileWithBytes(JPEG_BYTES, "license.jpg");
 
         given()
-                .multiPart("file", pdf, "application/pdf")
+                .multiPart("file", jpeg, "image/jpeg")
                 .formParam("documentType", "DRIVERS_LICENSE")
                 .when().post("/onboarding/tokens/" + tokenUuid + "/upload")
                 .then().statusCode(409)

--- a/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationSchemaTest.java
+++ b/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationSchemaTest.java
@@ -1,0 +1,63 @@
+package dk.trustworks.intranet.recruitmentservice.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure unit tests for the package-private statics in
+ * {@link OnboardingDocumentValidationService}. Mockito cannot mock the
+ * injected {@code OpenAIService}'s static-Panache dependencies and the
+ * local dev env lacks the OpenAI key — so we test only the deterministic
+ * helpers here. End-to-end behaviour is verified by manual staging smoke.
+ */
+class OnboardingDocumentValidationSchemaTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void schema_hasExpectedTopLevelShape() {
+        ObjectNode schema = OnboardingDocumentValidationService.buildSchema();
+        assertEquals("object", schema.path("type").asText());
+        assertEquals(false, schema.path("additionalProperties").asBoolean(true));
+        JsonNode required = schema.path("required");
+        assertTrue(required.isArray());
+        assertEquals(3, required.size());
+    }
+
+    @Test
+    void schema_includesAllFourBooleanChecks() {
+        ObjectNode schema = OnboardingDocumentValidationService.buildSchema();
+        JsonNode checks = schema.path("properties").path("checks").path("properties");
+        assertEquals("boolean", checks.path("isCorrectDocumentType").path("type").asText());
+        assertEquals("boolean", checks.path("isDanish").path("type").asText());
+        assertEquals("boolean", checks.path("isReadable").path("type").asText());
+        assertEquals("boolean", checks.path("isValid").path("type").asText());
+    }
+
+    @Test
+    void schema_reasonHasLengthBounds() {
+        ObjectNode schema = OnboardingDocumentValidationService.buildSchema();
+        JsonNode reason = schema.path("properties").path("reason");
+        assertEquals("string", reason.path("type").asText());
+        assertEquals(5, reason.path("minLength").asInt());
+        assertEquals(240, reason.path("maxLength").asInt());
+    }
+
+    @Test
+    void fallbackJson_isSchemaConformantAndRejected() throws Exception {
+        JsonNode fallback = MAPPER.readTree(
+                OnboardingDocumentValidationService.FALLBACK_REJECTED_JSON);
+        assertEquals(false, fallback.path("approved").asBoolean(true));
+        assertTrue(fallback.path("reason").asText().length() >= 5);
+        JsonNode checks = fallback.path("checks");
+        assertEquals(false, checks.path("isCorrectDocumentType").asBoolean(true));
+        assertEquals(false, checks.path("isDanish").asBoolean(true));
+        assertEquals(false, checks.path("isReadable").asBoolean(true));
+        assertEquals(false, checks.path("isValid").asBoolean(true));
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationSchemaTest.java
+++ b/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationSchemaTest.java
@@ -194,4 +194,13 @@ class OnboardingDocumentValidationSchemaTest {
         assertEquals(false, d.approved());
         assertTrue(d.reason().length() >= 5);
     }
+
+    @Test
+    void validate_publicMethodExistsWithExpectedSignature() throws Exception {
+        java.lang.reflect.Method m = OnboardingDocumentValidationService.class
+                .getMethod("validate", OnboardingDocumentType.class, byte[].class, String.class);
+        assertEquals(
+                OnboardingDocumentValidationService.ValidationDecision.class,
+                m.getReturnType());
+    }
 }

--- a/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationSchemaTest.java
+++ b/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationSchemaTest.java
@@ -3,6 +3,7 @@ package dk.trustworks.intranet.recruitmentservice.services;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import dk.trustworks.intranet.recruitmentservice.model.OnboardingDocumentType;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -59,5 +60,44 @@ class OnboardingDocumentValidationSchemaTest {
         assertEquals(false, checks.path("isDanish").asBoolean(true));
         assertEquals(false, checks.path("isReadable").asBoolean(true));
         assertEquals(false, checks.path("isValid").asBoolean(true));
+    }
+
+    @Test
+    void prompt_driversLicense_mentionsKorekort() {
+        String p = OnboardingDocumentValidationService.systemPromptFor(
+                OnboardingDocumentType.DRIVERS_LICENSE);
+        assertTrue(p.toLowerCase().contains("kørekort") || p.toLowerCase().contains("korekort")
+                || p.toLowerCase().contains("driver"));
+        assertTrue(p.contains("isCorrectDocumentType"));
+        assertTrue(p.contains("isDanish"));
+        assertTrue(p.contains("isReadable"));
+        assertTrue(p.contains("isValid"));
+    }
+
+    @Test
+    void prompt_healthInsurance_mentionsSundhedskort() {
+        String p = OnboardingDocumentValidationService.systemPromptFor(
+                OnboardingDocumentType.HEALTH_INSURANCE);
+        assertTrue(p.toLowerCase().contains("sundhedskort"));
+        assertTrue(p.toLowerCase().contains("ehic") || p.toLowerCase().contains("blue"));
+    }
+
+    @Test
+    void prompt_criminalRecord_mentionsStraffeattest() {
+        String p = OnboardingDocumentValidationService.systemPromptFor(
+                OnboardingDocumentType.CRIMINAL_RECORD);
+        assertTrue(p.toLowerCase().contains("straffeattest"));
+        assertTrue(p.toLowerCase().contains("3 month") || p.contains("3 calendar months"));
+    }
+
+    @Test
+    void prompt_allTypesAreDistinct() {
+        String dl = OnboardingDocumentValidationService.systemPromptFor(
+                OnboardingDocumentType.DRIVERS_LICENSE);
+        String hi = OnboardingDocumentValidationService.systemPromptFor(
+                OnboardingDocumentType.HEALTH_INSURANCE);
+        String cr = OnboardingDocumentValidationService.systemPromptFor(
+                OnboardingDocumentType.CRIMINAL_RECORD);
+        assertTrue(!dl.equals(hi) && !hi.equals(cr) && !dl.equals(cr));
     }
 }

--- a/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationSchemaTest.java
+++ b/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingDocumentValidationSchemaTest.java
@@ -100,4 +100,98 @@ class OnboardingDocumentValidationSchemaTest {
                 OnboardingDocumentType.CRIMINAL_RECORD);
         assertTrue(!dl.equals(hi) && !hi.equals(cr) && !dl.equals(cr));
     }
+
+    @Test
+    void parse_validApprovedResponse() {
+        String raw = """
+            {
+              "approved": true,
+              "reason": "Document looks good.",
+              "checks": {
+                "isCorrectDocumentType": true,
+                "isDanish": true,
+                "isReadable": true,
+                "isValid": true
+              }
+            }
+            """;
+        var d = OnboardingDocumentValidationService.parseDecision(raw);
+        assertTrue(d.approved());
+        assertEquals("Document looks good.", d.reason());
+    }
+
+    @Test
+    void parse_validRejectedResponse() {
+        String raw = """
+            {
+              "approved": false,
+              "reason": "Image is too blurry to read the expiry date.",
+              "checks": {
+                "isCorrectDocumentType": true,
+                "isDanish": true,
+                "isReadable": false,
+                "isValid": true
+              }
+            }
+            """;
+        var d = OnboardingDocumentValidationService.parseDecision(raw);
+        assertEquals(false, d.approved());
+        assertEquals("Image is too blurry to read the expiry date.", d.reason());
+    }
+
+    @Test
+    void parse_guardrail_flipsApprovedToFalseWhenCheckFails() {
+        // Model claims approved=true but isReadable=false. Guardrail forces rejection.
+        String raw = """
+            {
+              "approved": true,
+              "reason": "Looks fine.",
+              "checks": {
+                "isCorrectDocumentType": true,
+                "isDanish": true,
+                "isReadable": false,
+                "isValid": true
+              }
+            }
+            """;
+        var d = OnboardingDocumentValidationService.parseDecision(raw);
+        assertEquals(false, d.approved());
+        assertTrue(d.reason().toLowerCase().contains("inconsistency")
+                || d.reason().toLowerCase().contains("re-upload"));
+    }
+
+    @Test
+    void parse_emptyOrGarbage_returnsRejected() {
+        var empty = OnboardingDocumentValidationService.parseDecision("");
+        assertEquals(false, empty.approved());
+        var garbage = OnboardingDocumentValidationService.parseDecision("not json at all");
+        assertEquals(false, garbage.approved());
+    }
+
+    @Test
+    void parse_missingChecks_returnsRejected() {
+        String raw = """
+            { "approved": true, "reason": "All good" }
+            """;
+        var d = OnboardingDocumentValidationService.parseDecision(raw);
+        assertEquals(false, d.approved());
+    }
+
+    @Test
+    void parse_reasonMissing_usesGenericFallback() {
+        String raw = """
+            {
+              "approved": false,
+              "checks": {
+                "isCorrectDocumentType": false,
+                "isDanish": false,
+                "isReadable": false,
+                "isValid": false
+              }
+            }
+            """;
+        var d = OnboardingDocumentValidationService.parseDecision(raw);
+        assertEquals(false, d.approved());
+        assertTrue(d.reason().length() >= 5);
+    }
 }

--- a/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadServiceFilenameTest.java
+++ b/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadServiceFilenameTest.java
@@ -136,4 +136,20 @@ class OnboardingUploadServiceFilenameTest {
         assertEquals(false,
                 OnboardingUploadService.magicMatches("application/octet-stream", new byte[]{0x25, 0x50, 0x44, 0x46}));
     }
+
+    @Test
+    void aiRejected_returns422WithStructuredBody() throws Exception {
+        // Reflection because aiRejected is private; we still want to verify
+        // the response shape is consistent across maintenance.
+        java.lang.reflect.Method m = OnboardingUploadService.class
+                .getDeclaredMethod("aiRejected", String.class);
+        m.setAccessible(true);
+        jakarta.ws.rs.WebApplicationException ex = (jakarta.ws.rs.WebApplicationException) m.invoke(
+                null, "test reason");
+        jakarta.ws.rs.core.Response r = ex.getResponse();
+        assertEquals(422, r.getStatus());
+        String body = (String) r.getEntity();
+        assertTrue(body.contains("\"AI_REJECTED\""));
+        assertTrue(body.contains("\"test reason\""));
+    }
 }

--- a/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadServiceFilenameTest.java
+++ b/src/test/java/dk/trustworks/intranet/recruitmentservice/services/OnboardingUploadServiceFilenameTest.java
@@ -105,14 +105,10 @@ class OnboardingUploadServiceFilenameTest {
     // ── magic-byte sniffing (defense against lying Content-Type) ──────────
 
     @Test
-    void magic_pdf_matchesPDFHeader() {
+    void magic_pdf_isNoLongerAccepted() {
+        // PDF support was deliberately removed when AI document validation
+        // landed — the vision API takes images only.
         byte[] bytes = {0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37};
-        assertTrue(OnboardingUploadService.magicMatches("application/pdf", bytes));
-    }
-
-    @Test
-    void magic_pdf_rejectsNonPDFBytes() {
-        byte[] bytes = {0x4d, 0x5a, (byte) 0x90, 0x00}; // PE/EXE header.
         assertEquals(false, OnboardingUploadService.magicMatches("application/pdf", bytes));
     }
 
@@ -130,7 +126,6 @@ class OnboardingUploadServiceFilenameTest {
 
     @Test
     void magic_rejectsTooShortInput() {
-        assertEquals(false, OnboardingUploadService.magicMatches("application/pdf", new byte[]{0x25, 0x50}));
         assertEquals(false, OnboardingUploadService.magicMatches("image/png", new byte[]{(byte) 0x89, 0x50, 0x4e, 0x47}));
     }
 


### PR DESCRIPTION
## Summary

Adds synchronous OpenAI vision validation to the public onboarding upload endpoint. Three Danish documents (kørekort, sundhedskort, straffeattest) are validated via type-specific prompts before storage. Hard rejection on AI fail; fail-closed on transport errors.

- New `OnboardingDocumentValidationService` with strict JSON schema, three Danish-aware system prompts, `parseDecision` with `approved == AND(checks)` guardrail, and a `validate(type, bytes, mime)` orchestrator wrapping `OpenAIService.askWithSchemaAndImage`
- `OnboardingUploadService.handleUpload()` gates on AI validation between magic-byte check and storage write — rejection throws `422 { error: "AI_REJECTED", reason }`
- PDF dropped from `ALLOWED_MIME_TYPES` and `magicMatches` (vision API takes images only)
- `sanitiseReasonForBody` strips control chars before JSON embedding (defends against malformed model output)
- Class Javadoc on `OnboardingUploadService` updated to reflect the new flow

## Spec / plan

- Spec: `docs/superpowers/specs/2026-05-09-onboarding-document-ai-validation-design.md`
- Plan: `docs/superpowers/plans/2026-05-09-onboarding-document-ai-validation.md`

## API contract change

`POST /onboarding/tokens/{token}/upload` adds one new error case:
```
422 Unprocessable Entity
{ "error": "AI_REJECTED", "reason": "<short user-facing message>" }
```
All other status codes unchanged.

## Tests

- 15 pure unit tests in `OnboardingDocumentValidationSchemaTest` (schema, three prompts, parser+guardrail, validate signature)
- 19 tests in `OnboardingUploadServiceFilenameTest` (PDF rejection, aiRejected helper, existing magic-bytes/filename checks)
- `OnboardingUploadResourceTest` rewritten for image-only allow-list — could not run locally without MariaDB; will exercise on staging

## Deploy ordering

**Frontend should ship first** (paired PR: trustworksdk/trustworks-intranet-v3#NEW). Frontend tightens accept list to JPG/PNG only; once propagated, this PR can land safely. Reverse order would let cached old frontends pick a PDF, get \`400 UNSUPPORTED_MEDIA_TYPE\`, and see misleading error copy.

## Test plan

- [ ] Staging post-deploy: \`/q/health\` returns 200
- [ ] Staging: upload a real Danish driver's license JPEG via a real candidate token → 200, document stored
- [ ] Staging: upload a screenshot / wrong document type → 422 \`AI_REJECTED\` with non-empty \`reason\`
- [ ] Staging: upload a real PDF with \`application/pdf\` → 400 \`UNSUPPORTED_MEDIA_TYPE\`
- [ ] Staging: re-upload an already-stored type → 409 \`ALREADY_SUBMITTED\` (frontend self-heals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)