### PR TITLE
chore(bi): fix FTE divisor + discount unit, drop sp_aggregate_monthly

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/accounting/services/IntercompanyCalcService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/accounting/services/IntercompanyCalcService.java
@@ -242,14 +242,14 @@ public class IntercompanyCalcService {
                    a.avg_salary * (CAST(b.days_in_company AS DECIMAL(18,6)) / CAST(c.days_total AS DECIMAL(18,6))) AS weighted_avg
             FROM (
                 SELECT useruuid, AVG(COALESCE(salary,0)) AS avg_salary
-                FROM bi_data_per_day
+                FROM fact_user_day
                 WHERE year = :year AND month = :month
                   AND consultant_type = 'STAFF'
                 GROUP BY useruuid
             ) a
             JOIN (
                 SELECT useruuid, companyuuid, COUNT(DISTINCT day) AS days_in_company
-                FROM bi_data_per_day
+                FROM fact_user_day
                 WHERE year = :year AND month = :month
                   AND consultant_type = 'STAFF'
                   AND companyuuid IS NOT NULL
@@ -257,7 +257,7 @@ public class IntercompanyCalcService {
             ) b ON a.useruuid = b.useruuid
             JOIN (
                 SELECT useruuid, COUNT(DISTINCT day) AS days_total
-                FROM bi_data_per_day
+                FROM fact_user_day
                 WHERE year = :year AND month = :month
                   AND consultant_type = 'STAFF'
                 GROUP BY useruuid

--- a/src/main/java/dk/trustworks/intranet/aggregates/bidata/jobs/ChangeLogRetentionBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/bidata/jobs/ChangeLogRetentionBatchlet.java
@@ -1,0 +1,66 @@
+package dk.trustworks.intranet.aggregates.bidata.jobs;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import lombok.extern.jbosslog.JBossLog;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * Daily reaper for {@code fact_change_log} — prunes processed entries older
+ * than {@link #retentionDays} so the queue table does not grow unbounded.
+ * Runs at 02:15 UTC; idempotent and self-recovering.
+ */
+@JBossLog
+@ApplicationScoped
+public class ChangeLogRetentionBatchlet {
+
+    static final int DELETE_CHUNK_SIZE = 100_000;
+
+    @Inject
+    EntityManager em;
+
+    @ConfigProperty(name = "factChangeLog.retention.days", defaultValue = "30")
+    int retentionDays;
+
+    @Scheduled(cron = "0 15 2 * * ?", identity = "fact-change-log-retention")
+    public void scheduledRun() {
+        try {
+            long deleted = run();
+            log.infof("ChangeLogRetentionBatchlet: deleted %d rows older than %d days",
+                    deleted, retentionDays);
+        } catch (RuntimeException e) {
+            log.errorf(e, "ChangeLogRetentionBatchlet failed");
+        }
+    }
+
+    long run() {
+        long totalDeleted = 0L;
+        int deletedInChunk;
+        do {
+            deletedInChunk = deleteOneChunkInOwnTransaction();
+            totalDeleted += deletedInChunk;
+        } while (deletedInChunk == DELETE_CHUNK_SIZE);
+        return totalDeleted;
+    }
+
+    // Each chunk runs in its own transaction so a mid-loop failure does not
+    // roll back work already committed. Test seam: package-private + non-final
+    // so Mockito.spy() can substitute a direct call to deleteOneChunk() and
+    // skip the JTA round-trip in unit tests.
+    int deleteOneChunkInOwnTransaction() {
+        return QuarkusTransaction.requiringNew().call(this::deleteOneChunk);
+    }
+
+    int deleteOneChunk() {
+        return em.createNativeQuery(
+                "DELETE FROM fact_change_log " +
+                "WHERE processed_at IS NOT NULL " +
+                "  AND processed_at < DATE_SUB(NOW(), INTERVAL :days DAY) " +
+                "LIMIT " + DELETE_CHUNK_SIZE)
+                .setParameter("days", retentionDays)
+                .executeUpdate();
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/bidata/jobs/FactChangeLogBacklogAlertBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/bidata/jobs/FactChangeLogBacklogAlertBatchlet.java
@@ -1,0 +1,105 @@
+package dk.trustworks.intranet.aggregates.bidata.jobs;
+
+import dk.trustworks.intranet.communicationsservice.services.SlackService;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import lombok.extern.jbosslog.JBossLog;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Watchdog for {@code fact_change_log} — fires a Slack alert when the
+ * unprocessed backlog grows unhealthy (typically because
+ * {@code sp_incremental_bi_refresh()} has stalled). Runs every 5 minutes.
+ *
+ * <p>Repeat-suppression: while a breach is firing continuously, the channel
+ * receives at most one message per {@link #ALERT_REPEAT_INTERVAL}. The window
+ * resets the moment the breach clears, so a flap re-alerts immediately.
+ */
+@JBossLog
+@ApplicationScoped
+public class FactChangeLogBacklogAlertBatchlet {
+
+    static final Duration ALERT_REPEAT_INTERVAL = Duration.ofMinutes(60);
+
+    @Inject
+    EntityManager em;
+
+    @Inject
+    SlackService slackService;
+
+    @ConfigProperty(name = "slack.opsAlertChannel", defaultValue = "C0B2VQ2CFU1")
+    String opsAlertChannel;
+
+    @ConfigProperty(name = "factChangeLog.backlogAlert.maxPending", defaultValue = "500")
+    long maxPending;
+
+    @ConfigProperty(name = "factChangeLog.backlogAlert.maxOldestPendingMinutes", defaultValue = "30")
+    long maxOldestPendingMinutes;
+
+    // null encodes "no alert in flight" — drives the immediate re-alert on
+    // a breach that flaps. Atomic so overlapping scheduler invocations don't
+    // race on the rate-limit window.
+    private final AtomicReference<Instant> lastAlertSent = new AtomicReference<>(null);
+
+    @Scheduled(cron = "0 */5 * * * ?", identity = "fact-change-log-backlog-alert")
+    public void scheduledRun() {
+        try {
+            checkBacklog();
+        } catch (RuntimeException e) {
+            log.errorf(e, "FactChangeLogBacklogAlertBatchlet failed");
+        }
+    }
+
+    void checkBacklog() {
+        Object[] row = (Object[]) em.createNativeQuery(
+                "SELECT COUNT(*), TIMESTAMPDIFF(MINUTE, MIN(created_at), NOW()) " +
+                "FROM fact_change_log WHERE processed_at IS NULL")
+                .getSingleResult();
+        long pending = ((Number) row[0]).longValue();
+        Long oldestPendingMinutes = row[1] == null ? null : ((Number) row[1]).longValue();
+
+        boolean alert = pending > maxPending
+                || (oldestPendingMinutes != null && oldestPendingMinutes > maxOldestPendingMinutes);
+
+        log.debugf("fact_change_log backlog check — pending=%d oldestMinutes=%s alert=%s",
+                Long.valueOf(pending), oldestPendingMinutes, Boolean.valueOf(alert));
+
+        if (!alert) {
+            lastAlertSent.set(null);
+            return;
+        }
+
+        Instant now = Instant.now();
+        Instant previous = lastAlertSent.get();
+        boolean withinSuppressionWindow = previous != null
+                && Duration.between(previous, now).compareTo(ALERT_REPEAT_INTERVAL) < 0;
+
+        if (withinSuppressionWindow) {
+            log.debugf("fact_change_log backlog still breached — suppressing duplicate alert (last sent %s)", previous);
+            return;
+        }
+
+        String message = buildMessage(pending, oldestPendingMinutes);
+        log.warnf("fact_change_log backlog alert firing — pending=%d oldestMinutes=%s",
+                Long.valueOf(pending), oldestPendingMinutes);
+        slackService.sendMessage(opsAlertChannel, message, "mother");
+        lastAlertSent.set(now);
+    }
+
+    private String buildMessage(long pending, Long oldestPendingMinutes) {
+        String oldest = oldestPendingMinutes == null ? "n/a" : oldestPendingMinutes.toString();
+        return ":rotating_light: *fact_change_log backlog alert*\n"
+                + "• pending events: " + pending + "\n"
+                + "• oldest pending: " + oldest + " minutes\n"
+                + "• threshold: pending > " + maxPending
+                + " OR oldest > " + maxOldestPendingMinutes + " min\n"
+                + "Cron `ev_bi_incremental_refresh` may be stalled. "
+                + "Check `sp_incremental_bi_refresh()` execution log and DB advisory lock `bi_refresh`.";
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/bidata/repositories/BiDataPerDayRepository.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/bidata/repositories/BiDataPerDayRepository.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 public class BiDataPerDayRepository implements PanacheRepository<BiDataPerDay> {
 
     public void insertOrUpdateSalary(String userUuid, LocalDate documentDate, int year, int month, int day, int salary) {
-        String sql = "INSERT INTO bi_data_per_day (useruuid, document_date, year, month, day, salary, last_update) " +
+        String sql = "INSERT INTO fact_user_day (useruuid, document_date, year, month, day, salary, last_update) " +
                      "VALUES (:useruuid, :documentDate, :year, :month, :day, :salary, NOW()) " +
                      "ON DUPLICATE KEY UPDATE salary = VALUES(salary), last_update = NOW()";
 
@@ -28,7 +28,7 @@ public class BiDataPerDayRepository implements PanacheRepository<BiDataPerDay> {
     }
 
     public void insertOrUpdateWork(String userUuid, LocalDate documentDate, int year, int month, int day, double workHours) {
-        String sql = "INSERT INTO bi_data_per_day (useruuid, document_date, year, month, day, registered_billable_hours, last_update) " +
+        String sql = "INSERT INTO fact_user_day (useruuid, document_date, year, month, day, registered_billable_hours, last_update) " +
                      "VALUES (:useruuid, :documentDate, :year, :month, :day, :workHours, NOW()) " +
                      "ON DUPLICATE KEY UPDATE registered_billable_hours = VALUES(registered_billable_hours), last_update = NOW()";
 
@@ -44,7 +44,7 @@ public class BiDataPerDayRepository implements PanacheRepository<BiDataPerDay> {
     }
 
     public void insertOrUpdateRevenue(String userUuid, LocalDate registeredDate, int year, int monthValue, int dayOfMonth, double revenue) {
-        String sql = "INSERT INTO bi_data_per_day (" +
+        String sql = "INSERT INTO fact_user_day (" +
                 "useruuid, document_date, year, month, day, registered_amount, last_update) " +
                 "VALUES (:useruuid, :documentDate, :year, :month, :day, :revenue, NOW()) " +
                 "ON DUPLICATE KEY UPDATE " +
@@ -67,7 +67,7 @@ public class BiDataPerDayRepository implements PanacheRepository<BiDataPerDay> {
                                    BigDecimal sickHours, BigDecimal maternityLeaveHours, BigDecimal nonPaydLeaveHours,
                                    BigDecimal paidLeaveHours, String consultantType, String statusType, boolean isTwBonusEligible) {
 
-        String sql = "INSERT INTO bi_data_per_day (" +
+        String sql = "INSERT INTO fact_user_day (" +
                 "useruuid, document_date, year, month, day, " +
                 "companyuuid, gross_available_hours, unavailable_hours, vacation_hours, " +
                 "sick_hours, maternity_leave_hours, non_payd_leave_hours, paid_leave_hours, " +
@@ -107,25 +107,6 @@ public class BiDataPerDayRepository implements PanacheRepository<BiDataPerDay> {
         query.setParameter("consultantType", consultantType);
         query.setParameter("statusType", statusType);
         query.setParameter("isTwBonusEligible", isTwBonusEligible);
-
-        query.executeUpdate();
-    }
-
-    public void insertOrUpdateBudgetHours(String userUuid, String documentDate, int year, int month, int day, BigDecimal budgetHours) {
-        String sql = "INSERT INTO bi_data_per_day (" +
-                "useruuid, document_date, year, month, day, budget_hours, last_update) " +
-                "VALUES (:useruuid, :documentDate, :year, :month, :day, :budgetHours, NOW()) " +
-                "ON DUPLICATE KEY UPDATE " +
-                "budget_hours = VALUES(budget_hours), " +
-                "last_update = NOW()";
-
-        Query query = getEntityManager().createNativeQuery(sql);
-        query.setParameter("useruuid", userUuid);
-        query.setParameter("documentDate", documentDate);
-        query.setParameter("year", year);
-        query.setParameter("month", month);
-        query.setParameter("day", day);
-        query.setParameter("budgetHours", budgetHours);
 
         query.executeUpdate();
     }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
@@ -3236,7 +3236,7 @@ public class CxoFinanceService {
 
     /**
      * Query prior period utilization data from source tables (historical actuals).
-     * Uses work_full for billable hours and bi_data_per_day for available hours.
+     * Uses work_full for billable hours and fact_user_day for available hours.
      */
     private Map<String, Double> queryPriorUtilizationData(
             LocalDate fromDate, LocalDate toDate,
@@ -3285,7 +3285,7 @@ public class CxoFinanceService {
         // Available hours unchanged
         StringBuilder availableSql = new StringBuilder(
                 "SELECT COALESCE(SUM(b.gross_available_hours - COALESCE(b.unavailable_hours, 0)), 0.0) AS total_available_hours " +
-                        "FROM bi_data_per_day b " +
+                        "FROM fact_user_day b " +
                         "WHERE b.document_date >= :fromDate " +
                         "  AND b.document_date <= :toDate " +
                         "  AND b.consultant_type = 'CONSULTANT' " +
@@ -5765,7 +5765,7 @@ public class CxoFinanceService {
     /**
      * Absence waterfall: monthly breakdown of how gross capacity is reduced.
      * Replaces BFF route /api/cxo/delivery/absence-waterfall.
-     * Queries fact_user_utilization view which aggregates from bi_data_per_day.
+     * Queries fact_user_utilization view which aggregates from fact_user_day.
      *
      * @param fromDate   Start date (inclusive, uses year/month for filtering)
      * @param toDate     End date (inclusive, uses year/month for filtering)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -249,6 +249,22 @@ slack:
   slackApi: https://slack.com/api
   motherSlackBotToken: ${MOTHERSLACKBOTTOKEN:xx}
   adminSlackBotToken: ${ADMINSLACKBOTTOKEN:xx}
+  # Operations alert channel (#ops-alert) — destination for pipeline-health
+  # alerts emitted by FactChangeLogBacklogAlertBatchlet. Override per
+  # environment if a separate test channel is desired.
+  opsAlertChannel: ${SLACK_OPS_ALERT_CHANNEL:C0B2VQ2CFU1}
+factChangeLog:
+  # Daily retention window (in days) for processed change-log rows. Used by
+  # ChangeLogRetentionBatchlet — rows whose processed_at is older than this
+  # cutoff are deleted in chunks at 02:15 UTC each day.
+  retention:
+    days: ${FACT_CHANGE_LOG_RETENTION_DAYS:30}
+  # Backlog-alert thresholds for FactChangeLogBacklogAlertBatchlet (every 5
+  # minutes). Either threshold being breached triggers a Slack message to
+  # slack.opsAlertChannel.
+  backlogAlert:
+    maxPending: ${FACT_CHANGE_LOG_BACKLOG_MAX_PENDING:500}
+    maxOldestPendingMinutes: ${FACT_CHANGE_LOG_BACKLOG_MAX_OLDEST_MINUTES:30}
 e-conomics:
   xAppSecretToken: ${XAPPSERCREETTOKEN:none}
   xAgreementGrantToken: ${XAGREEMENTGRANTTOKEN:none}

--- a/src/main/resources/db/migration/V330__Drop_bi_data_per_day_view_and_migrate_consumers.sql
+++ b/src/main/resources/db/migration/V330__Drop_bi_data_per_day_view_and_migrate_consumers.sql
@@ -1,0 +1,1392 @@
+-- ============================================================================
+-- V330: Drop bi_data_per_day view and migrate consumers to fact_user_day
+-- ============================================================================
+-- Purpose
+--   `bi_data_per_day` has been a backwards-compatibility VIEW (not a table)
+--   over the renamed physical table `fact_user_day` since migration V168.
+--   The view definition in production is a 1:1 column-for-column projection
+--   over fact_user_day (verified via SHOW CREATE VIEW). It serves no purpose
+--   beyond preserving callers that still reference the old name.
+--
+--   Five DB objects still read from the view (production inventory queries
+--   on 2026-05-10):
+--     - VIEW fact_employee_monthly       (4 references)
+--     - VIEW turnover_by_company         (4 references)
+--     - PROCEDURE refresh_fact_employee_monthly_mv (3 references)
+--     - PROCEDURE sp_refresh_fact_tables (2 references in Block 4)
+--     - PROCEDURE sp_nightly_bi_refresh  (1 comment-only reference -- unchanged)
+--
+--   Application-side migration (BiDataPerDayRepository, IntercompanyCalcService,
+--   CxoFinanceService) ships in the same release before this migration runs.
+--
+-- This migration
+--   1. Recreates `fact_employee_monthly` with `bi_data_per_day` rewritten to
+--      `fact_user_day` via CREATE OR REPLACE (atomic — no window where the
+--      view is missing for the 5-min ev_bi_incremental_refresh consumer).
+--      Definition is otherwise byte-identical to V310.
+--   2. Recreates `turnover_by_company` with the same substitution, also via
+--      CREATE OR REPLACE. The view has no in-repo definition; the body below
+--      is captured verbatim from production (SHOW CREATE VIEW
+--      turnover_by_company on 2026-05-10) and becomes the canonical
+--      definition going forward. Reformatted from a single-line MariaDB
+--      dump for readability; logic is identical.
+--   3. Recreates `refresh_fact_employee_monthly_mv` with mechanical rename
+--      only. NOTE: this procedure is currently called by event
+--      `ev_refresh_facts_daily`, which is DISABLED in production. The body
+--      preserves the existing `u.primaryskilltype` column reference even
+--      though V213 renamed the column to `u.practice` (the procedure is
+--      already broken for that reason, but is unused, and fixing it is out
+--      of scope for this migration). The body also preserves the two
+--      correlated subqueries on bi_data_per_day for joiners/leavers; these
+--      are flagged as obsolete optimization candidates but rewriting them
+--      requires the full V310/V275-style `user_date_bounds` CTE pattern,
+--      which is a behavioural-equivalent but non-mechanical change. Left
+--      in place to keep this migration purely a name substitution.
+--   4. Recreates `sp_refresh_fact_tables` from V275's body, with the two
+--      `bi_data_per_day` references in Block 4 (CTE `user_date_bounds` and
+--      CTE `daily_employee_data`) rewritten to `fact_user_day`. The comment
+--      on line 571 of the production capture (referencing
+--      "bi_data_per_day + work_full + join") is also updated to drop the
+--      stale name. All other blocks unchanged.
+--   5. Drops the `bi_data_per_day` view as the final step.
+--
+-- History
+--   V168 (2025): renamed bi_data_per_day TABLE to fact_user_day, created
+--                bi_data_per_day VIEW for backwards compatibility.
+--   V310 (2026): optimized fact_employee_monthly view (correlated subquery
+--                elimination); body is the source of truth for that view
+--                in this migration.
+--   V275 (2026): latest in-repo version of sp_refresh_fact_tables.
+--
+-- Idempotency
+--   - DROP ... IF EXISTS guards every object so the migration is re-runnable
+--     in dev. In production it runs exactly once.
+--
+-- Rollback
+--   The view alone can be re-created with one statement using the body from
+--   the production SHOW CREATE captured before this migration:
+--     CREATE VIEW bi_data_per_day AS SELECT id, companyuuid, document_date,
+--       year, month, day, useruuid, gross_available_hours, unavailable_hours,
+--       vacation_hours, sick_hours, maternity_leave_hours, non_payd_leave_hours,
+--       paid_leave_hours, net_available_hours, budget_hours, consultant_type,
+--       status_type, registered_billable_hours, registered_amount, salary,
+--       last_update, is_tw_bonus_eligible FROM fact_user_day;
+--   The recreated views/procedures revert to their previous bodies by
+--   re-running V275/V310 (or applying the captured production bodies stored
+--   in the deployment runbook).
+-- ============================================================================
+
+
+-- ----------------------------------------------------------------------------
+-- 1. fact_employee_monthly  -- source from fact_user_day
+-- ----------------------------------------------------------------------------
+-- CREATE OR REPLACE swaps the view atomically. Avoids the brief window
+-- where a concurrent reader (the 5-min ev_bi_incremental_refresh event)
+-- could see the view missing if we did DROP+CREATE.
+CREATE OR REPLACE
+    ALGORITHM = UNDEFINED
+    DEFINER = `admin`@`%`
+    SQL SECURITY DEFINER
+VIEW `fact_employee_monthly` AS
+WITH
+    user_date_bounds AS (
+        SELECT
+            useruuid,
+            MIN(document_date) AS first_date,
+            MAX(document_date) AS last_date
+        FROM fact_user_day
+        WHERE gross_available_hours > 0
+          AND status_type != 'TERMINATED'
+          AND consultant_type IN ('CONSULTANT', 'STAFF')
+        GROUP BY useruuid
+    ),
+
+    daily_employee_data AS (
+        SELECT
+            b.companyuuid,
+            b.document_date,
+            b.year AS year_val,
+            b.month AS month_val,
+            b.useruuid,
+            b.gross_available_hours,
+            b.consultant_type,
+            b.status_type,
+            COALESCE(u.practice, 'UD') AS practice_id,
+            CASE
+                WHEN b.consultant_type = 'CONSULTANT'
+                    AND b.status_type IN ('ACTIVE', 'PROBATION')
+                    THEN 'BILLABLE'
+                ELSE 'NON_BILLABLE'
+            END AS role_type,
+            COALESCE(b.gross_available_hours, 0) / 8.0 AS daily_fte,
+            udb.first_date,
+            udb.last_date
+        FROM fact_user_day b
+        INNER JOIN `user` u ON b.useruuid = u.uuid
+        INNER JOIN user_date_bounds udb ON udb.useruuid = b.useruuid
+        WHERE b.gross_available_hours > 0
+          AND b.status_type != 'TERMINATED'
+          AND b.consultant_type IN ('CONSULTANT', 'STAFF')
+    ),
+
+    month_boundaries AS (
+        SELECT
+            companyuuid,
+            year_val,
+            month_val,
+            practice_id,
+            role_type,
+            COUNT(DISTINCT CASE
+                WHEN DAYOFMONTH(document_date) = 1 THEN useruuid
+            END) AS headcount_start,
+            COUNT(DISTINCT CASE
+                WHEN document_date = LAST_DAY(document_date) THEN useruuid
+            END) AS headcount_end
+        FROM daily_employee_data
+        GROUP BY companyuuid, year_val, month_val, practice_id, role_type
+    ),
+
+    monthly_fte AS (
+        SELECT
+            companyuuid,
+            year_val,
+            month_val,
+            practice_id,
+            role_type,
+            COUNT(DISTINCT useruuid) AS distinct_employees,
+            SUM(daily_fte) / COUNT(DISTINCT document_date) AS avg_monthly_fte,
+            COUNT(DISTINCT CASE WHEN role_type = 'BILLABLE' THEN useruuid END) AS billable_headcount,
+            COUNT(DISTINCT CASE WHEN role_type = 'NON_BILLABLE' THEN useruuid END) AS non_billable_headcount,
+            SUM(CASE WHEN role_type = 'BILLABLE' THEN daily_fte ELSE 0 END) / COUNT(DISTINCT document_date) AS fte_billable,
+            SUM(CASE WHEN role_type = 'NON_BILLABLE' THEN daily_fte ELSE 0 END) / COUNT(DISTINCT document_date) AS fte_non_billable
+        FROM daily_employee_data
+        GROUP BY companyuuid, year_val, month_val, practice_id, role_type
+    ),
+
+    joiners_leavers AS (
+        SELECT
+            companyuuid,
+            year_val,
+            month_val,
+            practice_id,
+            role_type,
+            COUNT(DISTINCT CASE
+                WHEN document_date = first_date THEN useruuid
+            END) AS joiners_count,
+            COUNT(DISTINCT CASE
+                WHEN document_date = last_date AND document_date < CURDATE()
+                    THEN useruuid
+            END) AS leavers_count
+        FROM daily_employee_data
+        GROUP BY companyuuid, year_val, month_val, practice_id, role_type
+    )
+
+SELECT
+    CONCAT(mf.companyuuid, '-', mf.practice_id, '-', mf.role_type, '-',
+           CONCAT(LPAD(mf.year_val, 4, '0'), LPAD(mf.month_val, 2, '0'))
+    ) AS employee_month_id,
+    mf.companyuuid AS company_id,
+    mf.practice_id,
+    mf.role_type,
+    NULL AS cost_center_id,
+    CONCAT(LPAD(mf.year_val, 4, '0'), LPAD(mf.month_val, 2, '0')) AS month_key,
+    mf.year_val AS year,
+    mf.month_val AS month_number,
+    CASE WHEN mf.month_val >= 7 THEN mf.year_val ELSE mf.year_val - 1 END AS fiscal_year,
+    CASE WHEN mf.month_val >= 7 THEN mf.month_val - 6 ELSE mf.month_val + 6 END AS fiscal_month_number,
+    COALESCE(mb.headcount_start, 0) AS headcount_start,
+    COALESCE(mb.headcount_end, 0) AS headcount_end,
+    ROUND((COALESCE(mb.headcount_start, 0) + COALESCE(mb.headcount_end, 0)) / 2.0, 2) AS average_headcount,
+    COALESCE(mf.billable_headcount, 0) AS billable_headcount,
+    COALESCE(mf.non_billable_headcount, 0) AS non_billable_headcount,
+    ROUND(COALESCE(mf.avg_monthly_fte, 0), 2) AS fte_total,
+    ROUND(COALESCE(mf.fte_billable, 0), 2) AS fte_billable,
+    ROUND(COALESCE(mf.fte_non_billable, 0), 2) AS fte_non_billable,
+    COALESCE(jl.joiners_count, 0) AS joiners_count,
+    COALESCE(jl.leavers_count, 0) AS leavers_count,
+    0 AS voluntary_leavers_count,
+    'HR_SYSTEM' AS data_source
+FROM monthly_fte mf
+LEFT JOIN month_boundaries mb
+    ON mf.companyuuid = mb.companyuuid
+    AND mf.year_val = mb.year_val
+    AND mf.month_val = mb.month_val
+    AND mf.practice_id = mb.practice_id
+    AND mf.role_type = mb.role_type
+LEFT JOIN joiners_leavers jl
+    ON mf.companyuuid = jl.companyuuid
+    AND mf.year_val = jl.year_val
+    AND mf.month_val = jl.month_val
+    AND mf.practice_id = jl.practice_id
+    AND mf.role_type = jl.role_type
+ORDER BY mf.year_val DESC, mf.month_val DESC, mf.companyuuid, mf.practice_id, mf.role_type;
+
+
+-- ----------------------------------------------------------------------------
+-- 2. turnover_by_company  -- source from fact_user_day
+--
+-- Body captured from production SHOW CREATE VIEW turnover_by_company on
+-- 2026-05-10 and reformatted; this is the canonical definition going forward.
+-- CREATE OR REPLACE for atomic swap (see note on fact_employee_monthly above).
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE
+    ALGORITHM = UNDEFINED
+    DEFINER = `admin`@`%`
+    SQL SECURITY DEFINER
+VIEW `turnover_by_company` AS
+WITH RECURSIVE all_months AS (
+    SELECT
+        DATE_FORMAT('2014-01-01', '%Y-%m-01') AS month_start,
+        fact_user_day.companyuuid             AS companyuuid
+    FROM fact_user_day
+    WHERE fact_user_day.document_date >= '2014-01-01'
+      AND fact_user_day.document_date <= CURDATE()
+    GROUP BY fact_user_day.companyuuid
+    UNION ALL
+    SELECT
+        all_months.month_start + INTERVAL 1 MONTH AS month_start,
+        all_months.companyuuid                    AS companyuuid
+    FROM all_months
+    WHERE all_months.month_start < '2026-12-01'
+),
+termination_counts AS (
+    SELECT
+        DATE_FORMAT(sub.document_date, '%Y-%m-01') AS month_start,
+        sub.companyuuid                            AS companyuuid,
+        COUNT(0)                                   AS terminated_count,
+        GROUP_CONCAT(DISTINCT CONCAT(u.firstname, ' ', u.lastname)
+                     ORDER BY u.firstname ASC, u.lastname ASC SEPARATOR ';') AS terminated_users
+    FROM (
+        SELECT
+            fact_user_day.companyuuid                                                       AS companyuuid,
+            fact_user_day.useruuid                                                          AS useruuid,
+            fact_user_day.document_date                                                     AS document_date,
+            fact_user_day.status_type                                                       AS status_type,
+            LAG(fact_user_day.status_type, 1) OVER (
+                PARTITION BY fact_user_day.useruuid
+                ORDER BY fact_user_day.document_date
+            )                                                                               AS previous_status_type
+        FROM fact_user_day
+        WHERE fact_user_day.document_date BETWEEN '2014-02-01' AND CURDATE()
+          AND fact_user_day.consultant_type = 'CONSULTANT'
+    ) sub
+    JOIN `user` u ON sub.useruuid = u.uuid
+    WHERE sub.status_type = 'TERMINATED'
+      AND (sub.previous_status_type IS NULL OR sub.previous_status_type <> 'TERMINATED')
+    GROUP BY DATE_FORMAT(sub.document_date, '%Y-%m-01'), sub.companyuuid
+),
+active_counts AS (
+    SELECT
+        DATE_FORMAT(fact_user_day.document_date, '%Y-%m-01') AS month_start,
+        fact_user_day.companyuuid                            AS companyuuid,
+        COUNT(DISTINCT fact_user_day.useruuid)               AS active_employee_count
+    FROM fact_user_day
+    WHERE fact_user_day.day = 1
+      AND fact_user_day.status_type <> 'TERMINATED'
+      AND fact_user_day.consultant_type = 'CONSULTANT'
+      AND fact_user_day.document_date BETWEEN '2014-02-01' AND CURDATE()
+    GROUP BY DATE_FORMAT(fact_user_day.document_date, '%Y-%m-01'), fact_user_day.companyuuid
+),
+rolling_termination_totals AS (
+    SELECT
+        am.month_start AS month_start,
+        am.companyuuid AS companyuuid,
+        SUM(COALESCE(tc.terminated_count, 0)) OVER (
+            PARTITION BY am.companyuuid
+            ORDER BY am.month_start
+            ROWS BETWEEN 11 PRECEDING AND CURRENT ROW
+        ) AS terminations_last_12_months
+    FROM (
+        SELECT DISTINCT all_months.month_start AS month_start,
+                        all_months.companyuuid AS companyuuid
+        FROM all_months
+    ) am
+    LEFT JOIN termination_counts tc
+        ON am.month_start = tc.month_start
+       AND am.companyuuid = tc.companyuuid
+),
+rolling_average_active AS (
+    SELECT
+        am.month_start AS month_start,
+        am.companyuuid AS companyuuid,
+        AVG(COALESCE(ac.active_employee_count, 0)) OVER (
+            PARTITION BY am.companyuuid
+            ORDER BY am.month_start
+            ROWS BETWEEN 11 PRECEDING AND CURRENT ROW
+        ) AS avg_active_employees_last_12_months
+    FROM (
+        SELECT DISTINCT all_months.month_start AS month_start,
+                        all_months.companyuuid AS companyuuid
+        FROM all_months
+    ) am
+    LEFT JOIN active_counts ac
+        ON am.month_start = ac.month_start
+       AND am.companyuuid = ac.companyuuid
+)
+SELECT
+    YEAR(am.month_start)  AS year,
+    MONTH(am.month_start) AS month,
+    am.companyuuid        AS companyuuid,
+    COALESCE(tc.terminated_count, 0)            AS terminated_count_current_month,
+    COALESCE(rt.terminations_last_12_months, 0) AS terminations_last_12_months,
+    ROUND(
+        COALESCE(rt.terminations_last_12_months, 0)
+        / NULLIF(COALESCE(ra.avg_active_employees_last_12_months, 0), 0)
+        * 100,
+        2
+    ) AS turnover_rate_percentage_last_12_months,
+    COALESCE(tc.terminated_users, '') AS terminated_users_current_month
+FROM (
+    SELECT DISTINCT
+        DATE_FORMAT(bdd.document_date, '%Y-%m-01') AS month_start,
+        bdd.companyuuid                            AS companyuuid
+    FROM fact_user_day bdd
+    WHERE bdd.document_date BETWEEN '2014-02-01' AND CURDATE()
+) am
+LEFT JOIN termination_counts tc
+    ON am.month_start = tc.month_start
+   AND am.companyuuid = tc.companyuuid
+LEFT JOIN rolling_termination_totals rt
+    ON am.month_start = rt.month_start
+   AND am.companyuuid = rt.companyuuid
+LEFT JOIN rolling_average_active ra
+    ON am.month_start = ra.month_start
+   AND am.companyuuid = ra.companyuuid
+ORDER BY am.companyuuid, YEAR(am.month_start), MONTH(am.month_start);
+
+
+-- ----------------------------------------------------------------------------
+-- 3. refresh_fact_employee_monthly_mv  -- source from fact_user_day
+--
+-- Mechanical rename only. Body captured verbatim from production
+-- (SHOW CREATE PROCEDURE on 2026-05-10) with the three `bi_data_per_day`
+-- references rewritten to `fact_user_day`. All other elements preserved:
+--   - `COALESCE(u.primaryskilltype, 'UD')` is left as-is even though V213
+--     renamed the column to `u.practice` (procedure is unused; called only
+--     by event ev_refresh_facts_daily which is DISABLED in production).
+--   - The two correlated subqueries computing joiners_count / leavers_count
+--     are preserved; the V310/V275-style `user_date_bounds` CTE rewrite
+--     would change behaviour scope-wise (it's an optimization pattern used
+--     in the modern view body) and is outside the scope of a mechanical
+--     rename. Filed as follow-up if/when the procedure is re-enabled.
+-- ----------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS refresh_fact_employee_monthly_mv;
+
+DELIMITER //
+
+CREATE PROCEDURE refresh_fact_employee_monthly_mv()
+BEGIN
+    TRUNCATE TABLE fact_employee_monthly_mv;
+
+    INSERT INTO fact_employee_monthly_mv
+    WITH daily_employee_data AS (
+        SELECT
+            b.companyuuid             AS companyuuid,
+            b.document_date           AS document_date,
+            b.year                    AS year_val,
+            b.month                   AS month_val,
+            b.useruuid                AS useruuid,
+            b.gross_available_hours   AS gross_available_hours,
+            b.consultant_type         AS consultant_type,
+            b.status_type             AS status_type,
+            COALESCE(u.primaryskilltype, 'UD') AS practice_id,
+            CASE
+                WHEN b.consultant_type = 'CONSULTANT'
+                 AND b.status_type IN ('ACTIVE', 'PROBATION')
+                THEN 'BILLABLE'
+                ELSE 'NON_BILLABLE'
+            END AS role_type,
+            COALESCE(b.gross_available_hours, 0) / 8.0 AS daily_fte
+        FROM fact_user_day b
+        JOIN `user` u ON b.useruuid = u.uuid
+        WHERE b.gross_available_hours > 0
+          AND b.status_type <> 'TERMINATED'
+          AND b.consultant_type IN ('CONSULTANT', 'STAFF')
+    ),
+    month_boundaries AS (
+        SELECT
+            d.companyuuid  AS companyuuid,
+            d.year_val     AS year_val,
+            d.month_val    AS month_val,
+            d.practice_id  AS practice_id,
+            d.role_type    AS role_type,
+            COUNT(DISTINCT CASE
+                WHEN DAYOFMONTH(d.document_date) = 1
+                THEN d.useruuid END
+            ) AS headcount_start,
+            COUNT(DISTINCT CASE
+                WHEN d.document_date = LAST_DAY(d.document_date)
+                THEN d.useruuid END
+            ) AS headcount_end
+        FROM daily_employee_data d
+        GROUP BY
+            d.companyuuid,
+            d.year_val,
+            d.month_val,
+            d.practice_id,
+            d.role_type
+    ),
+    monthly_fte AS (
+        SELECT
+            d.companyuuid AS companyuuid,
+            d.year_val    AS year_val,
+            d.month_val   AS month_val,
+            d.practice_id AS practice_id,
+            d.role_type   AS role_type,
+            COUNT(DISTINCT d.useruuid)                           AS distinct_employees,
+            SUM(d.daily_fte) / COUNT(DISTINCT d.document_date)   AS avg_monthly_fte,
+            COUNT(DISTINCT CASE WHEN d.role_type = 'BILLABLE'     THEN d.useruuid END) AS billable_headcount,
+            COUNT(DISTINCT CASE WHEN d.role_type = 'NON_BILLABLE' THEN d.useruuid END) AS non_billable_headcount,
+            SUM(CASE WHEN d.role_type = 'BILLABLE'     THEN d.daily_fte ELSE 0 END)
+                / COUNT(DISTINCT d.document_date)                AS fte_billable,
+            SUM(CASE WHEN d.role_type = 'NON_BILLABLE' THEN d.daily_fte ELSE 0 END)
+                / COUNT(DISTINCT d.document_date)                AS fte_non_billable
+        FROM daily_employee_data d
+        GROUP BY
+            d.companyuuid,
+            d.year_val,
+            d.month_val,
+            d.practice_id,
+            d.role_type
+    ),
+    joiners_leavers AS (
+        SELECT
+            d.companyuuid AS companyuuid,
+            d.year_val    AS year_val,
+            d.month_val   AS month_val,
+            d.practice_id AS practice_id,
+            d.role_type   AS role_type,
+            COUNT(DISTINCT CASE
+                WHEN d.document_date = (
+                    SELECT MIN(b2.document_date)
+                    FROM fact_user_day b2
+                    WHERE b2.useruuid = d.useruuid
+                ) THEN d.useruuid END
+            ) AS joiners_count,
+            COUNT(DISTINCT CASE
+                WHEN d.document_date = (
+                    SELECT MAX(b3.document_date)
+                    FROM fact_user_day b3
+                    WHERE b3.useruuid = d.useruuid
+                )
+                 AND d.document_date < CURDATE()
+                THEN d.useruuid END
+            ) AS leavers_count
+        FROM daily_employee_data d
+        GROUP BY
+            d.companyuuid,
+            d.year_val,
+            d.month_val,
+            d.practice_id,
+            d.role_type
+    )
+    SELECT
+        CONCAT(
+            mf.companyuuid, '-', mf.practice_id, '-', mf.role_type, '-',
+            CONCAT(LPAD(mf.year_val, 4, '0'), LPAD(mf.month_val, 2, '0'))
+        ) AS employee_month_id,
+        mf.companyuuid AS company_id,
+        mf.practice_id AS practice_id,
+        mf.role_type   AS role_type,
+        NULL           AS cost_center_id,
+        CONCAT(LPAD(mf.year_val, 4, '0'), LPAD(mf.month_val, 2, '0')) AS month_key,
+        mf.year_val    AS year,
+        mf.month_val   AS month_number,
+        CASE
+            WHEN mf.month_val >= 7 THEN mf.year_val
+            ELSE mf.year_val - 1
+        END AS fiscal_year,
+        CASE
+            WHEN mf.month_val >= 7 THEN mf.month_val - 6
+            ELSE mf.month_val + 6
+        END AS fiscal_month_number,
+        COALESCE(mb.headcount_start, 0) AS headcount_start,
+        COALESCE(mb.headcount_end,   0) AS headcount_end,
+        ROUND(
+            (COALESCE(mb.headcount_start, 0) + COALESCE(mb.headcount_end, 0)) / 2.0,
+            2
+        ) AS average_headcount,
+        COALESCE(mf.billable_headcount,      0) AS billable_headcount,
+        COALESCE(mf.non_billable_headcount,  0) AS non_billable_headcount,
+        ROUND(COALESCE(mf.avg_monthly_fte,   0), 2) AS fte_total,
+        ROUND(COALESCE(mf.fte_billable,      0), 2) AS fte_billable,
+        ROUND(COALESCE(mf.fte_non_billable,  0), 2) AS fte_non_billable,
+        COALESCE(jl.joiners_count, 0) AS joiners_count,
+        COALESCE(jl.leavers_count, 0) AS leavers_count,
+        0           AS voluntary_leavers_count,
+        'HR_SYSTEM' AS data_source
+    FROM monthly_fte mf
+    LEFT JOIN month_boundaries mb
+        ON  mf.companyuuid = mb.companyuuid
+        AND mf.year_val    = mb.year_val
+        AND mf.month_val   = mb.month_val
+        AND mf.practice_id = mb.practice_id
+        AND mf.role_type   = mb.role_type
+    LEFT JOIN joiners_leavers jl
+        ON  mf.companyuuid = jl.companyuuid
+        AND mf.year_val    = jl.year_val
+        AND mf.month_val   = jl.month_val
+        AND mf.practice_id = jl.practice_id
+        AND mf.role_type   = jl.role_type;
+END //
+
+DELIMITER ;
+
+
+-- ----------------------------------------------------------------------------
+-- 4. sp_refresh_fact_tables  -- Block 4 reads from fact_user_day
+--
+-- Body identical to V275 except:
+--   - Block 4 (`fact_employee_monthly_mat`) CTE `user_date_bounds` reads
+--     `FROM fact_user_day` instead of `FROM bi_data_per_day`.
+--   - Block 4 CTE `daily_employee_data` reads `FROM fact_user_day b` instead
+--     of `FROM bi_data_per_day b`.
+--   - Block 10 comment updated: drops the stale "bi_data_per_day +" prefix.
+-- All other blocks (1-3, 5-13) unchanged.
+-- ----------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS sp_refresh_fact_tables;
+
+DELIMITER //
+
+CREATE PROCEDURE sp_refresh_fact_tables()
+BEGIN
+    -- 1. fact_revenue_budget_mat  (was Block 2)
+    TRUNCATE TABLE fact_revenue_budget_mat;
+    INSERT IGNORE INTO fact_revenue_budget_mat
+        (revenue_budget_id, company_id, service_line_id, sector_id,
+         contract_type_id, month_key, year, month_number,
+         fiscal_year, fiscal_month_number, fiscal_month_key,
+         budget_scenario, budget_revenue_dkk, budget_hours,
+         contract_count, consultant_count)
+    SELECT
+        revenue_budget_id, company_id, service_line_id, sector_id,
+        contract_type_id, month_key, year, month_number,
+        fiscal_year, fiscal_month_number, fiscal_month_key,
+        budget_scenario, budget_revenue_dkk, budget_hours,
+        contract_count, consultant_count
+    FROM fact_revenue_budget;
+
+    -- 2. fact_project_financials_mat  (was Block 3)
+    TRUNCATE TABLE fact_project_financials_mat;
+    INSERT IGNORE INTO fact_project_financials_mat
+        (project_financial_id, project_id, client_id, companyuuid,
+         sector_id, service_line_id, contract_type_id,
+         month_key, year, month_number,
+         recognized_revenue_dkk, employee_salary_cost_dkk,
+         external_consultant_cost_dkk, project_expense_cost_dkk,
+         direct_delivery_cost_dkk, total_hours, consultant_count,
+         data_source)
+    SELECT
+        project_financial_id, project_id, client_id, companyuuid,
+        sector_id, service_line_id, contract_type_id,
+        month_key, year, month_number,
+        recognized_revenue_dkk, employee_salary_cost_dkk,
+        external_consultant_cost_dkk, project_expense_cost_dkk,
+        direct_delivery_cost_dkk, total_hours, consultant_count,
+        data_source
+    FROM fact_project_financials;
+
+    -- 3. fact_opex_mat  (was Block 4, FIXED in V224: cost_type restored)
+    TRUNCATE TABLE fact_opex_mat;
+    INSERT IGNORE INTO fact_opex_mat
+        (opex_id, company_id, cost_center_id, expense_category_id,
+         expense_subcategory_id, practice_id, sector_id,
+         month_key, year, month_number,
+         fiscal_year, fiscal_month_number, fiscal_month_key,
+         opex_amount_dkk, invoice_count, is_payroll_flag,
+         cost_type,
+         data_source)
+    SELECT
+        opex_id, company_id, cost_center_id, expense_category_id,
+        expense_subcategory_id, practice_id, sector_id,
+        month_key, year, month_number,
+        fiscal_year, fiscal_month_number, fiscal_month_key,
+        opex_amount_dkk, invoice_count, is_payroll_flag,
+        cost_type,
+        data_source
+    FROM fact_opex;
+
+    -- =========================================================================
+    -- 4. fact_employee_monthly_mat  (was Block 5, OPTIMIZED -- no correlated subqueries)
+    --
+    -- V330: source switched from bi_data_per_day (compatibility view)
+    -- to fact_user_day (the underlying physical table).
+    -- =========================================================================
+    TRUNCATE TABLE fact_employee_monthly_mat;
+    INSERT IGNORE INTO fact_employee_monthly_mat
+        (employee_month_id, company_id, practice_id, role_type,
+         month_key, year, month_number,
+         fiscal_year, fiscal_month_number,
+         headcount_start, headcount_end, average_headcount,
+         billable_headcount, non_billable_headcount,
+         fte_total, fte_billable, fte_non_billable,
+         joiners_count, leavers_count,
+         voluntary_leavers_count, data_source)
+    WITH
+        user_date_bounds AS (
+            SELECT
+                useruuid,
+                MIN(document_date) AS first_date,
+                MAX(document_date) AS last_date
+            FROM fact_user_day
+            WHERE gross_available_hours > 0
+              AND status_type != 'TERMINATED'
+              AND consultant_type IN ('CONSULTANT', 'STAFF')
+            GROUP BY useruuid
+        ),
+
+        daily_employee_data AS (
+            SELECT
+                b.companyuuid,
+                b.document_date,
+                b.year AS year_val,
+                b.month AS month_val,
+                b.useruuid,
+                b.gross_available_hours,
+                b.consultant_type,
+                b.status_type,
+                COALESCE(u.practice, 'UD') AS practice_id,
+                CASE
+                    WHEN b.consultant_type = 'CONSULTANT'
+                        AND b.status_type IN ('ACTIVE', 'PROBATION')
+                        THEN 'BILLABLE'
+                    ELSE 'NON_BILLABLE'
+                END AS role_type,
+                COALESCE(b.gross_available_hours, 0) / 8.0 AS daily_fte,
+                udb.first_date,
+                udb.last_date
+            FROM fact_user_day b
+            INNER JOIN user u ON b.useruuid = u.uuid
+            INNER JOIN user_date_bounds udb ON udb.useruuid = b.useruuid
+            WHERE b.gross_available_hours > 0
+              AND b.status_type != 'TERMINATED'
+              AND b.consultant_type IN ('CONSULTANT', 'STAFF')
+        ),
+
+        month_boundaries AS (
+            SELECT
+                companyuuid,
+                year_val,
+                month_val,
+                practice_id,
+                role_type,
+                COUNT(DISTINCT CASE
+                    WHEN DAY(document_date) = 1
+                        THEN useruuid
+                END) AS headcount_start,
+                COUNT(DISTINCT CASE
+                    WHEN document_date = LAST_DAY(document_date)
+                        THEN useruuid
+                END) AS headcount_end
+            FROM daily_employee_data
+            GROUP BY companyuuid, year_val, month_val, practice_id, role_type
+        ),
+
+        monthly_fte AS (
+            SELECT
+                companyuuid,
+                year_val,
+                month_val,
+                practice_id,
+                role_type,
+                COUNT(DISTINCT useruuid) AS distinct_employees,
+                SUM(daily_fte) / COUNT(DISTINCT document_date) AS avg_monthly_fte,
+                COUNT(DISTINCT CASE WHEN role_type = 'BILLABLE' THEN useruuid END) AS billable_headcount,
+                COUNT(DISTINCT CASE WHEN role_type = 'NON_BILLABLE' THEN useruuid END) AS non_billable_headcount,
+                SUM(CASE WHEN role_type = 'BILLABLE' THEN daily_fte ELSE 0 END) / COUNT(DISTINCT document_date) AS fte_billable,
+                SUM(CASE WHEN role_type = 'NON_BILLABLE' THEN daily_fte ELSE 0 END) / COUNT(DISTINCT document_date) AS fte_non_billable
+            FROM daily_employee_data
+            GROUP BY companyuuid, year_val, month_val, practice_id, role_type
+        ),
+
+        joiners_leavers AS (
+            SELECT
+                companyuuid,
+                year_val,
+                month_val,
+                practice_id,
+                role_type,
+                COUNT(DISTINCT CASE
+                    WHEN document_date = first_date THEN useruuid
+                END) AS joiners_count,
+                COUNT(DISTINCT CASE
+                    WHEN document_date = last_date AND document_date < CURDATE()
+                        THEN useruuid
+                END) AS leavers_count
+            FROM daily_employee_data
+            GROUP BY companyuuid, year_val, month_val, practice_id, role_type
+        )
+
+    SELECT
+        CONCAT(mf.companyuuid, '-', mf.practice_id, '-', mf.role_type, '-',
+               CONCAT(LPAD(mf.year_val, 4, '0'), LPAD(mf.month_val, 2, '0'))
+        ) AS employee_month_id,
+        mf.companyuuid AS company_id,
+        mf.practice_id,
+        mf.role_type,
+        CONCAT(LPAD(mf.year_val, 4, '0'), LPAD(mf.month_val, 2, '0')) AS month_key,
+        mf.year_val AS year,
+        mf.month_val AS month_number,
+        CASE WHEN mf.month_val >= 7 THEN mf.year_val ELSE mf.year_val - 1 END AS fiscal_year,
+        CASE WHEN mf.month_val >= 7 THEN mf.month_val - 6 ELSE mf.month_val + 6 END AS fiscal_month_number,
+        COALESCE(mb.headcount_start, 0) AS headcount_start,
+        COALESCE(mb.headcount_end, 0) AS headcount_end,
+        ROUND((COALESCE(mb.headcount_start, 0) + COALESCE(mb.headcount_end, 0)) / 2.0, 2) AS average_headcount,
+        COALESCE(mf.billable_headcount, 0) AS billable_headcount,
+        COALESCE(mf.non_billable_headcount, 0) AS non_billable_headcount,
+        ROUND(COALESCE(mf.avg_monthly_fte, 0), 2) AS fte_total,
+        ROUND(COALESCE(mf.fte_billable, 0), 2) AS fte_billable,
+        ROUND(COALESCE(mf.fte_non_billable, 0), 2) AS fte_non_billable,
+        COALESCE(jl.joiners_count, 0) AS joiners_count,
+        COALESCE(jl.leavers_count, 0) AS leavers_count,
+        0 AS voluntary_leavers_count,
+        'HR_SYSTEM' AS data_source
+    FROM monthly_fte mf
+    LEFT JOIN month_boundaries mb
+        ON mf.companyuuid = mb.companyuuid
+        AND mf.year_val = mb.year_val
+        AND mf.month_val = mb.month_val
+        AND mf.practice_id = mb.practice_id
+        AND mf.role_type = mb.role_type
+    LEFT JOIN joiners_leavers jl
+        ON mf.companyuuid = jl.companyuuid
+        AND mf.year_val = jl.year_val
+        AND mf.month_val = jl.month_val
+        AND mf.practice_id = jl.practice_id
+        AND mf.role_type = jl.role_type;
+
+    -- 5. fact_tw_bonus_monthly_mat  (was Block 6)
+    TRUNCATE TABLE fact_tw_bonus_monthly_mat;
+    INSERT IGNORE INTO fact_tw_bonus_monthly_mat
+        (useruuid, companyuuid, year, month,
+         days_in_month, total_days, eligible_days,
+         eligible_share, avg_salary, weighted_avg_salary,
+         fiscal_year)
+    SELECT
+        useruuid, companyuuid, year, month,
+        days_in_month, total_days, eligible_days,
+        eligible_share, avg_salary, weighted_avg_salary,
+        fiscal_year
+    FROM fact_tw_bonus_monthly;
+
+    -- 6. fact_tw_bonus_annual_mat  (was Block 7)
+    TRUNCATE TABLE fact_tw_bonus_annual_mat;
+    INSERT IGNORE INTO fact_tw_bonus_annual_mat
+        (useruuid, companyuuid, fiscal_year,
+         weight_sum, eligible_months, total_eligible_days,
+         avg_monthly_salary)
+    SELECT
+        useruuid, companyuuid, fiscal_year,
+        weight_sum, eligible_months, total_eligible_days,
+        avg_monthly_salary
+    FROM fact_tw_bonus_annual;
+
+    -- 7. fact_client_revenue_mat  (was Block 8)
+    TRUNCATE TABLE fact_client_revenue_mat;
+    INSERT IGNORE INTO fact_client_revenue_mat
+        (client_revenue_id, client_id, company_id,
+         month_key, year, month_number,
+         fiscal_year, fiscal_month_number,
+         invoice_phantom_dkk, internal_dkk,
+         credit_note_dkk, net_revenue_dkk)
+    SELECT
+        client_revenue_id, client_id, company_id,
+        month_key, year, month_number,
+        fiscal_year, fiscal_month_number,
+        invoice_phantom_dkk, internal_dkk,
+        credit_note_dkk, net_revenue_dkk
+    FROM fact_client_revenue;
+
+    -- 8. fact_operating_cost_distribution_mat  (was Block 9)
+    TRUNCATE TABLE fact_operating_cost_distribution_mat;
+    INSERT IGNORE INTO fact_operating_cost_distribution_mat
+        (distribution_id, origin_company, payer_company,
+         account_code, category_uuid, shared, salary,
+         year_val, month_val, month_key,
+         fiscal_year, fiscal_month_number,
+         origin_gl_amount, payer_ratio, payer_consultants,
+         allocated_amount, intercompany_owe)
+    SELECT
+        distribution_id, origin_company, payer_company,
+        account_code, category_uuid, shared, salary,
+        year_val, month_val, month_key,
+        fiscal_year, fiscal_month_number,
+        origin_gl_amount, payer_ratio, payer_consultants,
+        allocated_amount, intercompany_owe
+    FROM fact_operating_cost_distribution;
+
+    -- 9. fact_intercompany_settlement_mat  (was Block 10)
+    TRUNCATE TABLE fact_intercompany_settlement_mat;
+    INSERT IGNORE INTO fact_intercompany_settlement_mat
+        (settlement_id, payer_company, receiver_company,
+         year_val, month_val, month_key,
+         fiscal_year, fiscal_month_number,
+         expected_amount, actual_amount, settlement_gap,
+         invoice_count, settlement_status)
+    SELECT
+        CONCAT(payer_company, '-', receiver_company, '-', month_key),
+        payer_company, receiver_company,
+        year_val, month_val, month_key,
+        fiscal_year, fiscal_month_number,
+        expected_amount, actual_amount, settlement_gap,
+        invoice_count, settlement_status
+    FROM fact_intercompany_settlement;
+
+    -- =========================================================================
+    -- 10. fact_minimum_viable_rate_mat  (was Block 11, OPTIMIZED -- uses _mat tables)
+    --
+    -- FIXED in V237: Added min_monthly_salary_dkk, max_monthly_salary_dkk
+    -- FIXED in V272: utilization_stats CTE now reads from fact_user_day +
+    --   work_full directly (replacing dropped fact_user_utilization_mat).
+    -- =========================================================================
+    TRUNCATE TABLE fact_minimum_viable_rate_mat;
+    INSERT IGNORE INTO fact_minimum_viable_rate_mat
+        (rate_id, company_id, company_name, career_level,
+         consultant_count, avg_monthly_salary_dkk,
+         min_monthly_salary_dkk, max_monthly_salary_dkk,
+         employer_pension_pct, employer_pension_dkk,
+         atp_per_person_dkk, am_bidrag_per_person_dkk,
+         benefit_per_person_dkk, staff_allocation_dkk,
+         overhead_allocation_dkk, total_monthly_cost_dkk,
+         avg_net_available_hours, actual_utilization_ratio,
+         actual_billable_hours, utilization_post_first_billing,
+         target_utilization_ratio,
+         target_billable_hours, break_even_rate_actual,
+         break_even_rate_target, min_rate_15pct_margin,
+         min_rate_20pct_margin, avg_actual_billing_rate,
+         rate_buffer_dkk, data_source,
+         break_even_utilization_pct, break_even_utilization_15pct,
+         break_even_utilization_20pct)
+    WITH
+        ttm_range AS (
+            SELECT
+                DATE_FORMAT(DATE_SUB(CURDATE(), INTERVAL 12 MONTH), '%Y%m') AS start_month_key,
+                DATE_FORMAT(CURDATE(), '%Y%m') AS end_month_key,
+                DATE_SUB(CURDATE(), INTERVAL 12 MONTH) AS start_date,
+                CURDATE() AS end_date
+        ),
+
+        current_career_level AS (
+            SELECT
+                ucl.useruuid,
+                ucl.career_track,
+                ucl.career_level
+            FROM user_career_level ucl
+            INNER JOIN (
+                SELECT useruuid, MAX(active_from) AS max_active_from
+                FROM user_career_level
+                WHERE active_from <= CURDATE()
+                GROUP BY useruuid
+            ) latest ON ucl.useruuid = latest.useruuid AND ucl.active_from = latest.max_active_from
+        ),
+
+        active_consultants AS (
+            SELECT
+                us.companyuuid AS company_id,
+                ccl.career_level,
+                COUNT(DISTINCT u.uuid) AS consultant_count
+            FROM user u
+            INNER JOIN userstatus us ON us.useruuid = u.uuid
+            INNER JOIN current_career_level ccl ON ccl.useruuid = u.uuid
+            WHERE u.type = 'USER'
+              AND us.type = 'CONSULTANT'
+              AND us.status = 'ACTIVE'
+              AND us.statusdate = (
+                  SELECT MAX(us2.statusdate)
+                  FROM userstatus us2
+                  WHERE us2.useruuid = u.uuid
+                    AND us2.statusdate <= CURDATE()
+              )
+            GROUP BY us.companyuuid, ccl.career_level
+        ),
+
+        avg_salary AS (
+            SELECT
+                us.companyuuid AS company_id,
+                ccl.career_level,
+                AVG(s.salary) AS avg_monthly_salary,
+                MIN(s.salary) AS min_monthly_salary,
+                MAX(s.salary) AS max_monthly_salary
+            FROM user u
+            INNER JOIN userstatus us ON us.useruuid = u.uuid
+            INNER JOIN salary s ON s.useruuid = u.uuid
+            INNER JOIN current_career_level ccl ON ccl.useruuid = u.uuid
+            WHERE u.type = 'USER'
+              AND us.type = 'CONSULTANT'
+              AND us.status = 'ACTIVE'
+              AND us.statusdate = (
+                  SELECT MAX(us2.statusdate)
+                  FROM userstatus us2
+                  WHERE us2.useruuid = u.uuid
+                    AND us2.statusdate <= CURDATE()
+              )
+              AND s.activefrom = (
+                  SELECT MAX(s2.activefrom)
+                  FROM salary s2
+                  WHERE s2.useruuid = u.uuid
+                    AND s2.activefrom <= CURDATE()
+              )
+            GROUP BY us.companyuuid, ccl.career_level
+        ),
+
+        gl_statutory_costs AS (
+            SELECT
+                fd.companyuuid AS company_id,
+                SUM(CASE
+                    WHEN fd.companyuuid = 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 3502 THEN ABS(fd.amount)
+                    WHEN fd.companyuuid != 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 2210 THEN ABS(fd.amount)
+                    ELSE 0
+                END) AS total_salary,
+                SUM(CASE
+                    WHEN fd.companyuuid = 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 3510 THEN ABS(fd.amount)
+                    WHEN fd.companyuuid != 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 2215 THEN ABS(fd.amount)
+                    ELSE 0
+                END) AS total_pension,
+                SUM(CASE
+                    WHEN fd.companyuuid = 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 3580 THEN ABS(fd.amount)
+                    WHEN fd.companyuuid != 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 2222 THEN ABS(fd.amount)
+                    ELSE 0
+                END) AS total_atp,
+                SUM(CASE
+                    WHEN fd.companyuuid = 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 3578 THEN ABS(fd.amount)
+                    WHEN fd.companyuuid != 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 2223 THEN ABS(fd.amount)
+                    ELSE 0
+                END) AS total_am_bidrag
+            FROM finance_details fd
+            CROSS JOIN ttm_range tr
+            WHERE fd.expensedate >= tr.start_date
+              AND fd.expensedate <= tr.end_date
+              AND fd.expensedate IS NOT NULL
+              AND fd.amount != 0
+              AND (
+                  (fd.companyuuid = 'd8894494-2fb4-4f72-9e05-e6032e6dd691'
+                      AND fd.accountnumber IN (3502, 3510, 3580, 3578))
+                  OR
+                  (fd.companyuuid != 'd8894494-2fb4-4f72-9e05-e6032e6dd691'
+                      AND fd.accountnumber IN (2210, 2215, 2222, 2223))
+              )
+            GROUP BY fd.companyuuid
+        ),
+
+        gl_benefit_costs AS (
+            SELECT
+                fd.companyuuid AS company_id,
+                SUM(ABS(fd.amount)) AS total_benefit_costs
+            FROM finance_details fd
+            CROSS JOIN ttm_range tr
+            WHERE fd.expensedate >= tr.start_date
+              AND fd.expensedate <= tr.end_date
+              AND fd.expensedate IS NOT NULL
+              AND fd.amount != 0
+              AND (
+                  (fd.companyuuid = 'd8894494-2fb4-4f72-9e05-e6032e6dd691'
+                      AND fd.accountnumber IN (3570, 3585, 3593, 3565))
+                  OR
+                  (fd.companyuuid != 'd8894494-2fb4-4f72-9e05-e6032e6dd691'
+                      AND fd.accountnumber IN (2245, 2250, 2255, 2242))
+              )
+            GROUP BY fd.companyuuid
+        ),
+
+        company_headcount AS (
+            SELECT
+                us.companyuuid AS company_id,
+                COUNT(DISTINCT us.useruuid) AS total_active_users,
+                SUM(CASE WHEN us.type = 'CONSULTANT' AND u.type = 'USER' THEN 1 ELSE 0 END) AS billable_consultant_count
+            FROM userstatus us
+            INNER JOIN user u ON u.uuid = us.useruuid
+            WHERE us.status = 'ACTIVE'
+              AND us.statusdate = (
+                  SELECT MAX(us2.statusdate)
+                  FROM userstatus us2
+                  WHERE us2.useruuid = us.useruuid
+                    AND us2.statusdate <= CURDATE()
+              )
+            GROUP BY us.companyuuid
+        ),
+
+        statutory_ratios AS (
+            SELECT
+                sc.company_id,
+                CASE WHEN sc.total_salary > 0
+                    THEN sc.total_pension / sc.total_salary
+                    ELSE 0
+                END AS pension_pct,
+                CASE WHEN ch.total_active_users > 0
+                    THEN sc.total_atp / 12.0 / ch.total_active_users
+                    ELSE 0
+                END AS atp_per_person_monthly,
+                CASE WHEN ch.total_active_users > 0
+                    THEN sc.total_am_bidrag / 12.0 / ch.total_active_users
+                    ELSE 0
+                END AS am_per_person_monthly
+            FROM gl_statutory_costs sc
+            INNER JOIN company_headcount ch ON ch.company_id = sc.company_id
+        ),
+
+        benefit_per_person AS (
+            SELECT
+                bc.company_id,
+                CASE WHEN ch.total_active_users > 0
+                    THEN bc.total_benefit_costs / 12.0 / ch.total_active_users
+                    ELSE 0
+                END AS benefit_per_person_monthly
+            FROM gl_benefit_costs bc
+            INNER JOIN company_headcount ch ON ch.company_id = bc.company_id
+        ),
+
+        staff_costs AS (
+            SELECT
+                us.companyuuid AS company_id,
+                SUM(s.salary) AS total_staff_monthly_salary
+            FROM userstatus us
+            INNER JOIN user u ON u.uuid = us.useruuid
+            INNER JOIN salary s ON s.useruuid = u.uuid
+            WHERE us.status = 'ACTIVE'
+              AND us.type = 'STAFF'
+              AND u.type = 'USER'
+              AND us.statusdate = (
+                  SELECT MAX(us2.statusdate)
+                  FROM userstatus us2
+                  WHERE us2.useruuid = us.useruuid
+                    AND us2.statusdate <= CURDATE()
+              )
+              AND s.activefrom = (
+                  SELECT MAX(s2.activefrom)
+                  FROM salary s2
+                  WHERE s2.useruuid = u.uuid
+                    AND s2.activefrom <= CURDATE()
+              )
+            GROUP BY us.companyuuid
+        ),
+
+        staff_allocation AS (
+            SELECT
+                ch.company_id,
+                CASE WHEN ch.billable_consultant_count > 0
+                    THEN COALESCE(sc.total_staff_monthly_salary, 0) / ch.billable_consultant_count
+                    ELSE 0
+                END AS staff_per_consultant_monthly
+            FROM company_headcount ch
+            LEFT JOIN staff_costs sc ON sc.company_id = ch.company_id
+        ),
+
+        -- OPTIMIZED: reads from fact_opex_mat instead of fact_opex view
+        group_opex AS (
+            SELECT
+                SUM(CASE WHEN fo.is_payroll_flag = 0 THEN fo.opex_amount_dkk ELSE 0 END) AS total_non_payroll_opex
+            FROM fact_opex_mat fo
+            CROSS JOIN ttm_range tr
+            WHERE CAST(fo.month_key AS CHAR CHARACTER SET utf8mb4) >= tr.start_month_key
+              AND CAST(fo.month_key AS CHAR CHARACTER SET utf8mb4) <= tr.end_month_key
+        ),
+
+        -- OPTIMIZED: reads from fact_employee_monthly_mat instead of fact_employee_monthly view
+        fte_weights AS (
+            SELECT
+                fem.company_id,
+                AVG(fem.fte_billable) AS avg_billable_fte,
+                AVG(fem.fte_total) AS avg_total_fte
+            FROM fact_employee_monthly_mat fem
+            CROSS JOIN ttm_range tr
+            WHERE CAST(fem.month_key AS CHAR CHARACTER SET utf8mb4) >= tr.start_month_key
+              AND CAST(fem.month_key AS CHAR CHARACTER SET utf8mb4) <= tr.end_month_key
+            GROUP BY fem.company_id
+        ),
+
+        total_fte AS (
+            SELECT SUM(avg_billable_fte) AS group_billable_fte
+            FROM fte_weights
+        ),
+
+        overhead_allocation AS (
+            SELECT
+                fw.company_id,
+                CASE WHEN tf.group_billable_fte > 0 AND ch.billable_consultant_count > 0
+                    THEN (go.total_non_payroll_opex * (fw.avg_billable_fte / tf.group_billable_fte))
+                         / 12.0
+                         / ch.billable_consultant_count
+                    ELSE 0
+                END AS overhead_per_consultant_monthly
+            FROM fte_weights fw
+            CROSS JOIN group_opex go
+            CROSS JOIN total_fte tf
+            INNER JOIN company_headcount ch ON ch.company_id = fw.company_id
+        ),
+
+        -- V275: Simplified utilization from fact_user_day (aligns with V272 convention).
+        -- fact_user_day already has pre-computed registered_billable_hours and
+        -- net_available_hours per user per day, refreshed every 5 minutes.
+        -- Replaces the previous 3-CTE approach (work_full + join).
+
+        first_billing_date AS (
+            SELECT useruuid, MIN(document_date) AS first_date
+            FROM fact_user_day
+            WHERE registered_billable_hours > 0
+              AND consultant_type = 'CONSULTANT'
+            GROUP BY useruuid
+        ),
+
+        utilization_stats AS (
+            SELECT
+                fud.companyuuid AS company_id,
+                ccl.career_level,
+                AVG(monthly_available) AS avg_net_available_hours,
+                AVG(monthly_billable) AS avg_billable_hours,
+                CASE WHEN SUM(monthly_available) > 0
+                     THEN SUM(monthly_billable) / SUM(monthly_available)
+                     ELSE 0
+                END AS avg_utilization_ratio,
+                CASE WHEN SUM(monthly_available_post_billing) > 0
+                     THEN SUM(monthly_billable_post_billing) / SUM(monthly_available_post_billing)
+                     ELSE 0
+                END AS utilization_post_first_billing
+            FROM (
+                SELECT
+                    fud.companyuuid, fud.useruuid, fud.year, fud.month,
+                    SUM(fud.net_available_hours) AS monthly_available,
+                    SUM(fud.registered_billable_hours) AS monthly_billable,
+                    SUM(CASE WHEN fb.first_date IS NOT NULL AND fud.document_date >= fb.first_date
+                             THEN fud.net_available_hours ELSE 0 END) AS monthly_available_post_billing,
+                    SUM(CASE WHEN fb.first_date IS NOT NULL AND fud.document_date >= fb.first_date
+                             THEN fud.registered_billable_hours ELSE 0 END) AS monthly_billable_post_billing
+                FROM fact_user_day fud
+                LEFT JOIN first_billing_date fb ON fb.useruuid = fud.useruuid
+                CROSS JOIN ttm_range tr
+                WHERE fud.consultant_type = 'CONSULTANT'
+                  AND fud.status_type = 'ACTIVE'
+                  AND fud.document_date >= tr.start_date
+                  AND fud.document_date <= tr.end_date
+                GROUP BY fud.companyuuid, fud.useruuid, fud.year, fud.month
+            ) fud
+            INNER JOIN current_career_level ccl ON ccl.useruuid = fud.useruuid
+            GROUP BY fud.companyuuid, ccl.career_level
+        ),
+
+        actual_rates AS (
+            SELECT
+                wf.consultant_company_uuid AS company_id,
+                ccl.career_level,
+                AVG(wf.rate) AS avg_billing_rate
+            FROM work_full wf
+            INNER JOIN user u ON u.uuid = wf.useruuid
+            INNER JOIN current_career_level ccl ON ccl.useruuid = u.uuid
+            CROSS JOIN ttm_range tr
+            WHERE wf.registered >= tr.start_date
+              AND wf.registered <= tr.end_date
+              AND wf.rate > 0
+            GROUP BY wf.consultant_company_uuid, ccl.career_level
+        )
+
+    SELECT
+        CONCAT(ac.company_id, '-', ac.career_level) AS rate_id,
+        ac.company_id,
+        CASE ac.company_id
+            WHEN 'd8894494-2fb4-4f72-9e05-e6032e6dd691' THEN 'Trustworks A/S'
+            WHEN '44592d3b-2be5-4b29-bfaf-4fafc60b0fa3' THEN 'Trustworks Technology ApS'
+            WHEN 'e4b0a2a4-0963-4153-b0a2-a409637153a2' THEN 'Trustworks Cyber Security ApS'
+            ELSE 'Unknown'
+        END AS company_name,
+        ac.career_level,
+        ac.consultant_count,
+        ROUND(asl.avg_monthly_salary, 2) AS avg_monthly_salary_dkk,
+        ROUND(asl.min_monthly_salary, 0) AS min_monthly_salary_dkk,
+        ROUND(asl.max_monthly_salary, 0) AS max_monthly_salary_dkk,
+        ROUND(COALESCE(sr.pension_pct, 0), 4) AS employer_pension_pct,
+        ROUND(COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary, 2) AS employer_pension_dkk,
+        ROUND(COALESCE(sr.atp_per_person_monthly, 0), 2) AS atp_per_person_dkk,
+        ROUND(COALESCE(sr.am_per_person_monthly, 0), 2) AS am_bidrag_per_person_dkk,
+        ROUND(COALESCE(bp.benefit_per_person_monthly, 0), 2) AS benefit_per_person_dkk,
+        ROUND(COALESCE(sa.staff_per_consultant_monthly, 0), 2) AS staff_allocation_dkk,
+        ROUND(COALESCE(oa.overhead_per_consultant_monthly, 0), 2) AS overhead_allocation_dkk,
+        ROUND(
+            asl.avg_monthly_salary
+            + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+            + COALESCE(sr.atp_per_person_monthly, 0)
+            + COALESCE(sr.am_per_person_monthly, 0)
+            + COALESCE(bp.benefit_per_person_monthly, 0)
+            + COALESCE(sa.staff_per_consultant_monthly, 0)
+            + COALESCE(oa.overhead_per_consultant_monthly, 0)
+        , 2) AS total_monthly_cost_dkk,
+        ROUND(COALESCE(us2.avg_net_available_hours, 0), 2) AS avg_net_available_hours,
+        ROUND(COALESCE(us2.avg_utilization_ratio, 0), 4) AS actual_utilization_ratio,
+        ROUND(COALESCE(us2.avg_billable_hours, 0), 2) AS actual_billable_hours,
+        ROUND(COALESCE(us2.utilization_post_first_billing, 0), 4) AS utilization_post_first_billing,
+        0.75 AS target_utilization_ratio,
+        ROUND(COALESCE(us2.avg_net_available_hours, 0) * 0.75, 2) AS target_billable_hours,
+        CASE WHEN COALESCE(us2.avg_billable_hours, 0) > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / us2.avg_billable_hours
+            , 2)
+            ELSE NULL
+        END AS break_even_rate_actual,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) * 0.75 > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / (us2.avg_net_available_hours * 0.75)
+            , 2)
+            ELSE NULL
+        END AS break_even_rate_target,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) * 0.75 > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / (us2.avg_net_available_hours * 0.75)
+                / 0.85
+            , 2)
+            ELSE NULL
+        END AS min_rate_15pct_margin,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) * 0.75 > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / (us2.avg_net_available_hours * 0.75)
+                / 0.80
+            , 2)
+            ELSE NULL
+        END AS min_rate_20pct_margin,
+        ROUND(COALESCE(ar.avg_billing_rate, 0), 2) AS avg_actual_billing_rate,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) * 0.75 > 0 AND COALESCE(ar.avg_billing_rate, 0) > 0
+            THEN ROUND(
+                ar.avg_billing_rate
+                - (asl.avg_monthly_salary
+                   + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                   + COALESCE(sr.atp_per_person_monthly, 0)
+                   + COALESCE(sr.am_per_person_monthly, 0)
+                   + COALESCE(bp.benefit_per_person_monthly, 0)
+                   + COALESCE(sa.staff_per_consultant_monthly, 0)
+                   + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                  / (us2.avg_net_available_hours * 0.75)
+            , 2)
+            ELSE NULL
+        END AS rate_buffer_dkk,
+        'OPERATIONAL' AS data_source,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) > 0 AND COALESCE(ar.avg_billing_rate, 0) > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / (us2.avg_net_available_hours * ar.avg_billing_rate)
+            , 4)
+            ELSE NULL
+        END AS break_even_utilization_pct,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) > 0 AND COALESCE(ar.avg_billing_rate, 0) > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / (0.85 * us2.avg_net_available_hours * ar.avg_billing_rate)
+            , 4)
+            ELSE NULL
+        END AS break_even_utilization_15pct,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) > 0 AND COALESCE(ar.avg_billing_rate, 0) > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / (0.80 * us2.avg_net_available_hours * ar.avg_billing_rate)
+            , 4)
+            ELSE NULL
+        END AS break_even_utilization_20pct
+
+    FROM active_consultants ac
+    INNER JOIN avg_salary asl ON asl.company_id = ac.company_id AND asl.career_level = ac.career_level
+    LEFT JOIN statutory_ratios sr ON sr.company_id = ac.company_id
+    LEFT JOIN benefit_per_person bp ON bp.company_id = ac.company_id
+    LEFT JOIN staff_allocation sa ON sa.company_id = ac.company_id
+    LEFT JOIN overhead_allocation oa ON oa.company_id = ac.company_id
+    LEFT JOIN utilization_stats us2 ON us2.company_id = ac.company_id AND us2.career_level = ac.career_level
+    LEFT JOIN actual_rates ar ON ar.company_id = ac.company_id AND ar.career_level = ac.career_level
+    ORDER BY ac.company_id, ac.career_level;
+
+    -- =========================================================================
+    -- 11. fact_company_revenue_mat  (was Block 12, RESTORED in V263)
+    -- =========================================================================
+    TRUNCATE TABLE fact_company_revenue_mat;
+    INSERT IGNORE INTO fact_company_revenue_mat
+        (revenue_id, company_id, month_key, year, month_number,
+         fiscal_year, fiscal_month_number,
+         invoice_phantom_dkk, internal_dkk, credit_note_dkk,
+         net_revenue_dkk)
+    SELECT
+        revenue_id, company_id, month_key, year, month_number,
+        fiscal_year, fiscal_month_number,
+        invoice_phantom_dkk, internal_dkk, credit_note_dkk,
+        net_revenue_dkk
+    FROM fact_company_revenue;
+
+    -- =========================================================================
+    -- 12. fact_internal_invoice_cost_mat  (was Block 13, RESTORED in V263)
+    -- =========================================================================
+    TRUNCATE TABLE fact_internal_invoice_cost_mat;
+    INSERT IGNORE INTO fact_internal_invoice_cost_mat
+        (internal_invoice_cost_id, company_id, month_key, year, month_number,
+         fiscal_year, fiscal_month_number,
+         internal_invoice_cost_dkk, queued_cost_dkk, created_cost_dkk,
+         entry_count, data_sources)
+    SELECT
+        internal_invoice_cost_id, company_id, month_key, year, month_number,
+        fiscal_year, fiscal_month_number,
+        internal_invoice_cost_dkk, queued_cost_dkk, created_cost_dkk,
+        entry_count, data_sources
+    FROM fact_internal_invoice_cost;
+
+    -- =========================================================================
+    -- 13. fact_sick_day_rolling_mat  (was Block 14, NEW in V264)
+    --
+    -- Unlike blocks 1-12 which truncate+insert from views, this block
+    -- delegates to sp_refresh_sick_day_rolling() which handles the full
+    -- computation pipeline (base values -> bridging -> rolling window).
+    -- The procedure internally truncates the table.
+    -- =========================================================================
+    CALL sp_refresh_sick_day_rolling();
+
+END //
+
+DELIMITER ;
+
+
+-- ----------------------------------------------------------------------------
+-- 5. Drop the bi_data_per_day compatibility view
+--
+-- All five DB consumers (the four objects recreated above plus the comment
+-- in sp_nightly_bi_refresh) and the application-side callers
+-- (BiDataPerDayRepository, IntercompanyCalcService, CxoFinanceService) have
+-- been migrated to fact_user_day. Safe to drop.
+-- ----------------------------------------------------------------------------
+DROP VIEW IF EXISTS bi_data_per_day;

--- a/src/main/resources/db/migration/V332__fact_change_log_retention_index.sql
+++ b/src/main/resources/db/migration/V332__fact_change_log_retention_index.sql
@@ -1,0 +1,34 @@
+-- ============================================================================
+-- V332: Add retention index on fact_change_log
+-- ============================================================================
+-- Purpose
+--   Support the daily retention DELETE issued by ChangeLogRetentionBatchlet
+--   (`processed_at IS NOT NULL AND processed_at < DATE_SUB(NOW(), INTERVAL :days DAY)`).
+--
+--   The existing idx_unprocessed (processed_at, affected_date, useruuid) helps
+--   the IS NOT NULL predicate as a leading-column scan, but does not cover
+--   created_at and is wider than necessary for the prune path. The new index
+--   (processed_at, created_at) is narrower and covering for the retention
+--   query — the optimizer can use it to range-scan rows whose processed_at
+--   falls below the cutoff without touching the heap.
+--
+-- Background
+--   fact_change_log was renamed from bi_change_log in V168. The change-log
+--   queue is drained every 5 minutes by sp_incremental_bi_refresh() but never
+--   pruned, so the table grows unbounded until this batchlet starts running.
+--
+-- Idempotency
+--   Online DDL (ALGORITHM=INPLACE, LOCK=NONE) so concurrent reads/writes are
+--   not blocked. Safe to re-apply after a failed migration: MariaDB will
+--   error out cleanly if the index already exists.
+--
+-- Related Java
+--   - dk.trustworks.intranet.aggregates.bidata.jobs.ChangeLogRetentionBatchlet
+--     (daily 02:15 UTC retention DELETE; uses this index)
+--   - dk.trustworks.intranet.aggregates.bidata.jobs.FactChangeLogBacklogAlertBatchlet
+--     (5-minute backlog monitor; uses idx_unprocessed for pending counts)
+-- ============================================================================
+
+ALTER TABLE fact_change_log
+    ADD INDEX idx_processed_for_deletion (processed_at, created_at),
+    ALGORITHM=INPLACE, LOCK=NONE;

--- a/src/main/resources/db/migration/V333__Fix_fact_employee_monthly_fte_and_probation.sql
+++ b/src/main/resources/db/migration/V333__Fix_fact_employee_monthly_fte_and_probation.sql
@@ -1,0 +1,1101 @@
+-- ============================================================================
+-- V333: Fix fact_employee_monthly FTE basis and remove PROBATION dead code
+-- ============================================================================
+-- Purpose
+--   Two corrections to the FTE / billable-classification logic that lives
+--   duplicated in both `fact_employee_monthly` (the view) and
+--   `sp_refresh_fact_tables` block 4 (the materialized table populator):
+--
+--     1. FTE divisor changes from 8.0 to 7.4. The Trustworks full-time
+--        consultant day is 7.4 hours, not the generic 8.0 hours that the
+--        formula was originally calibrated for. The view's daily_fte CTE
+--        column was producing systematically low FTE numbers (FTE_actual
+--        = FTE_reported * 8.0 / 7.4 ≈ 1.081 × reported). All downstream
+--        consumers of `fte_total`, `fte_billable`, `fte_non_billable` will
+--        rise by exactly +8.108% in lockstep at the next BI refresh.
+--
+--     2. The BILLABLE classification predicate
+--        `b.status_type IN ('ACTIVE', 'PROBATION')` is reduced to
+--        `b.status_type = 'ACTIVE'`. The userstatus enum has never had a
+--        PROBATION value (verified: 0 rows in production), so the second
+--        branch is dead code. Removing it eliminates a misleading hint for
+--        future contributors and shortens the predicate.
+--
+--   Both corrections must land together in the same migration: the view
+--   and the materialized-table CTE share an identical body. If only one
+--   side were fixed, the view (`fact_employee_monthly`) and the table
+--   (`fact_employee_monthly_mat`) would compute different FTE numbers
+--   for the same month — a drift that would surface as inconsistencies
+--   across executive dashboards, finance dashboards, and CXO reports.
+--
+-- Affected objects
+--   - VIEW fact_employee_monthly             (recreated; CTE updated)
+--   - PROCEDURE sp_refresh_fact_tables        (recreated; block 4 updated)
+--
+-- Scope of body changes
+--   View `fact_employee_monthly`:
+--     - daily_employee_data CTE:
+--         BEFORE: AND b.status_type IN ('ACTIVE', 'PROBATION')
+--         AFTER:  AND b.status_type IN ('ACTIVE')
+--         BEFORE: COALESCE(b.gross_available_hours, 0) / 8.0 AS daily_fte
+--         AFTER:  COALESCE(b.gross_available_hours, 0) / 7.4 AS daily_fte
+--   Procedure `sp_refresh_fact_tables`:
+--     - Block 4 (`fact_employee_monthly_mat`) daily_employee_data CTE:
+--         identical two edits, mirroring the view.
+--   All other 12 blocks of the procedure are unchanged byte-for-byte from
+--   the V330 body.
+--
+-- Background
+--   - The view was last touched in V330 (atomic rename to read from
+--     fact_user_day instead of bi_data_per_day; behaviour preserved).
+--   - The procedure was last touched in V330 (same rename for block 4).
+--   - V310 introduced the optimised CTE form for the view (eliminated
+--     correlated subqueries); the body is the source of truth.
+--   - The 8.0 divisor and the PROBATION predicate predate V310 and were
+--     copied forward unchanged across V275, V310, V330. This migration
+--     is the first behavioural correction to either field.
+--
+-- Idempotency
+--   DROP ... IF EXISTS guards both objects so the migration is re-runnable
+--   in dev. In production it runs exactly once.
+--
+-- Rollback
+--   Re-apply V330 verbatim (the view body and the procedure body are
+--   complete in that file). Both objects are recreated in their entirety
+--   in this migration, so a rollback is a single-shot replay of V330.
+--
+-- Verification (run after deploy)
+--   -- 1. View FTE matches /7.4 convention. For a single ACTIVE billable
+--   --    consultant on 2026-05-08:
+--   SELECT useruuid, gross_available_hours,
+--          ROUND(gross_available_hours / 7.4, 4) AS expected_fte
+--   FROM fact_user_day
+--   WHERE document_date = '2026-05-08'
+--     AND status_type = 'ACTIVE'
+--     AND consultant_type = 'CONSULTANT'
+--   LIMIT 5;
+--
+--   -- 2. fact_employee_monthly_mat FTE for May 2026 should be ~+8.1%
+--   --    higher than before deploy.
+--   CALL sp_refresh_fact_tables();
+--   SELECT company_id, practice_id, role_type, fte_total, fte_billable
+--   FROM fact_employee_monthly_mat
+--   WHERE year = 2026 AND month_number = 5
+--   ORDER BY company_id, practice_id, role_type;
+--
+--   -- 3. PROBATION dead code is gone -- no row should have
+--   --    billable_headcount = 0 alongside fte_billable > 0.
+--   SELECT COUNT(*) FROM fact_employee_monthly_mat
+--   WHERE billable_headcount = 0 AND fte_billable > 0;
+--   -- expected: 0
+--
+--   -- 4. View and materialized table agree on FTE for current month.
+--   SELECT
+--       v.company_id, v.practice_id, v.role_type,
+--       v.fte_total AS view_fte_total, m.fte_total AS mat_fte_total,
+--       v.fte_billable AS view_fte_billable, m.fte_billable AS mat_fte_billable
+--   FROM fact_employee_monthly v
+--   JOIN fact_employee_monthly_mat m
+--     ON v.company_id = m.company_id
+--    AND v.practice_id = m.practice_id
+--    AND v.role_type = m.role_type
+--    AND v.month_key = m.month_key
+--   WHERE v.year = 2026 AND v.month_number = 5
+--     AND (ABS(v.fte_total - m.fte_total) > 0.01
+--      OR  ABS(v.fte_billable - m.fte_billable) > 0.01);
+--   -- expected: 0 rows (view and mat agree to 2 decimal places)
+-- ============================================================================
+
+
+-- ----------------------------------------------------------------------------
+-- 1. fact_employee_monthly  -- /7.4 divisor; ACTIVE-only billable predicate
+-- ----------------------------------------------------------------------------
+-- CREATE OR REPLACE swaps the view atomically. Avoids the brief window
+-- where a concurrent reader (the 5-min ev_bi_incremental_refresh event)
+-- could see the view missing if we did DROP+CREATE.
+CREATE OR REPLACE
+    ALGORITHM = UNDEFINED
+    DEFINER = `admin`@`%`
+    SQL SECURITY DEFINER
+VIEW `fact_employee_monthly` AS
+WITH
+    user_date_bounds AS (
+        SELECT
+            useruuid,
+            MIN(document_date) AS first_date,
+            MAX(document_date) AS last_date
+        FROM fact_user_day
+        WHERE gross_available_hours > 0
+          AND status_type != 'TERMINATED'
+          AND consultant_type IN ('CONSULTANT', 'STAFF')
+        GROUP BY useruuid
+    ),
+
+    daily_employee_data AS (
+        SELECT
+            b.companyuuid,
+            b.document_date,
+            b.year AS year_val,
+            b.month AS month_val,
+            b.useruuid,
+            b.gross_available_hours,
+            b.consultant_type,
+            b.status_type,
+            COALESCE(u.practice, 'UD') AS practice_id,
+            CASE
+                WHEN b.consultant_type = 'CONSULTANT'
+                    AND b.status_type IN ('ACTIVE')
+                    THEN 'BILLABLE'
+                ELSE 'NON_BILLABLE'
+            END AS role_type,
+            COALESCE(b.gross_available_hours, 0) / 7.4 AS daily_fte,
+            udb.first_date,
+            udb.last_date
+        FROM fact_user_day b
+        INNER JOIN `user` u ON b.useruuid = u.uuid
+        INNER JOIN user_date_bounds udb ON udb.useruuid = b.useruuid
+        WHERE b.gross_available_hours > 0
+          AND b.status_type != 'TERMINATED'
+          AND b.consultant_type IN ('CONSULTANT', 'STAFF')
+    ),
+
+    month_boundaries AS (
+        SELECT
+            companyuuid,
+            year_val,
+            month_val,
+            practice_id,
+            role_type,
+            COUNT(DISTINCT CASE
+                WHEN DAYOFMONTH(document_date) = 1 THEN useruuid
+            END) AS headcount_start,
+            COUNT(DISTINCT CASE
+                WHEN document_date = LAST_DAY(document_date) THEN useruuid
+            END) AS headcount_end
+        FROM daily_employee_data
+        GROUP BY companyuuid, year_val, month_val, practice_id, role_type
+    ),
+
+    monthly_fte AS (
+        SELECT
+            companyuuid,
+            year_val,
+            month_val,
+            practice_id,
+            role_type,
+            COUNT(DISTINCT useruuid) AS distinct_employees,
+            SUM(daily_fte) / COUNT(DISTINCT document_date) AS avg_monthly_fte,
+            COUNT(DISTINCT CASE WHEN role_type = 'BILLABLE' THEN useruuid END) AS billable_headcount,
+            COUNT(DISTINCT CASE WHEN role_type = 'NON_BILLABLE' THEN useruuid END) AS non_billable_headcount,
+            SUM(CASE WHEN role_type = 'BILLABLE' THEN daily_fte ELSE 0 END) / COUNT(DISTINCT document_date) AS fte_billable,
+            SUM(CASE WHEN role_type = 'NON_BILLABLE' THEN daily_fte ELSE 0 END) / COUNT(DISTINCT document_date) AS fte_non_billable
+        FROM daily_employee_data
+        GROUP BY companyuuid, year_val, month_val, practice_id, role_type
+    ),
+
+    joiners_leavers AS (
+        SELECT
+            companyuuid,
+            year_val,
+            month_val,
+            practice_id,
+            role_type,
+            COUNT(DISTINCT CASE
+                WHEN document_date = first_date THEN useruuid
+            END) AS joiners_count,
+            COUNT(DISTINCT CASE
+                WHEN document_date = last_date AND document_date < CURDATE()
+                    THEN useruuid
+            END) AS leavers_count
+        FROM daily_employee_data
+        GROUP BY companyuuid, year_val, month_val, practice_id, role_type
+    )
+
+SELECT
+    CONCAT(mf.companyuuid, '-', mf.practice_id, '-', mf.role_type, '-',
+           CONCAT(LPAD(mf.year_val, 4, '0'), LPAD(mf.month_val, 2, '0'))
+    ) AS employee_month_id,
+    mf.companyuuid AS company_id,
+    mf.practice_id,
+    mf.role_type,
+    NULL AS cost_center_id,
+    CONCAT(LPAD(mf.year_val, 4, '0'), LPAD(mf.month_val, 2, '0')) AS month_key,
+    mf.year_val AS year,
+    mf.month_val AS month_number,
+    CASE WHEN mf.month_val >= 7 THEN mf.year_val ELSE mf.year_val - 1 END AS fiscal_year,
+    CASE WHEN mf.month_val >= 7 THEN mf.month_val - 6 ELSE mf.month_val + 6 END AS fiscal_month_number,
+    COALESCE(mb.headcount_start, 0) AS headcount_start,
+    COALESCE(mb.headcount_end, 0) AS headcount_end,
+    ROUND((COALESCE(mb.headcount_start, 0) + COALESCE(mb.headcount_end, 0)) / 2.0, 2) AS average_headcount,
+    COALESCE(mf.billable_headcount, 0) AS billable_headcount,
+    COALESCE(mf.non_billable_headcount, 0) AS non_billable_headcount,
+    ROUND(COALESCE(mf.avg_monthly_fte, 0), 2) AS fte_total,
+    ROUND(COALESCE(mf.fte_billable, 0), 2) AS fte_billable,
+    ROUND(COALESCE(mf.fte_non_billable, 0), 2) AS fte_non_billable,
+    COALESCE(jl.joiners_count, 0) AS joiners_count,
+    COALESCE(jl.leavers_count, 0) AS leavers_count,
+    0 AS voluntary_leavers_count,
+    'HR_SYSTEM' AS data_source
+FROM monthly_fte mf
+LEFT JOIN month_boundaries mb
+    ON mf.companyuuid = mb.companyuuid
+    AND mf.year_val = mb.year_val
+    AND mf.month_val = mb.month_val
+    AND mf.practice_id = mb.practice_id
+    AND mf.role_type = mb.role_type
+LEFT JOIN joiners_leavers jl
+    ON mf.companyuuid = jl.companyuuid
+    AND mf.year_val = jl.year_val
+    AND mf.month_val = jl.month_val
+    AND mf.practice_id = jl.practice_id
+    AND mf.role_type = jl.role_type
+ORDER BY mf.year_val DESC, mf.month_val DESC, mf.companyuuid, mf.practice_id, mf.role_type;
+
+
+-- ----------------------------------------------------------------------------
+-- 2. sp_refresh_fact_tables  -- block 4 mirrors the view edits
+--
+-- The procedure body is V330's body verbatim with two surgical edits in
+-- block 4 (the `daily_employee_data` CTE):
+--   - daily_fte divisor 8.0 -> 7.4
+--   - BILLABLE predicate IN ('ACTIVE', 'PROBATION') -> IN ('ACTIVE')
+-- All other 12 blocks (1-3, 5-13) are byte-identical to V330's body.
+-- ----------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS sp_refresh_fact_tables;
+
+DELIMITER //
+
+CREATE PROCEDURE sp_refresh_fact_tables()
+BEGIN
+    -- 1. fact_revenue_budget_mat  (was Block 2)
+    TRUNCATE TABLE fact_revenue_budget_mat;
+    INSERT IGNORE INTO fact_revenue_budget_mat
+        (revenue_budget_id, company_id, service_line_id, sector_id,
+         contract_type_id, month_key, year, month_number,
+         fiscal_year, fiscal_month_number, fiscal_month_key,
+         budget_scenario, budget_revenue_dkk, budget_hours,
+         contract_count, consultant_count)
+    SELECT
+        revenue_budget_id, company_id, service_line_id, sector_id,
+        contract_type_id, month_key, year, month_number,
+        fiscal_year, fiscal_month_number, fiscal_month_key,
+        budget_scenario, budget_revenue_dkk, budget_hours,
+        contract_count, consultant_count
+    FROM fact_revenue_budget;
+
+    -- 2. fact_project_financials_mat  (was Block 3)
+    TRUNCATE TABLE fact_project_financials_mat;
+    INSERT IGNORE INTO fact_project_financials_mat
+        (project_financial_id, project_id, client_id, companyuuid,
+         sector_id, service_line_id, contract_type_id,
+         month_key, year, month_number,
+         recognized_revenue_dkk, employee_salary_cost_dkk,
+         external_consultant_cost_dkk, project_expense_cost_dkk,
+         direct_delivery_cost_dkk, total_hours, consultant_count,
+         data_source)
+    SELECT
+        project_financial_id, project_id, client_id, companyuuid,
+        sector_id, service_line_id, contract_type_id,
+        month_key, year, month_number,
+        recognized_revenue_dkk, employee_salary_cost_dkk,
+        external_consultant_cost_dkk, project_expense_cost_dkk,
+        direct_delivery_cost_dkk, total_hours, consultant_count,
+        data_source
+    FROM fact_project_financials;
+
+    -- 3. fact_opex_mat  (was Block 4, FIXED in V224: cost_type restored)
+    TRUNCATE TABLE fact_opex_mat;
+    INSERT IGNORE INTO fact_opex_mat
+        (opex_id, company_id, cost_center_id, expense_category_id,
+         expense_subcategory_id, practice_id, sector_id,
+         month_key, year, month_number,
+         fiscal_year, fiscal_month_number, fiscal_month_key,
+         opex_amount_dkk, invoice_count, is_payroll_flag,
+         cost_type,
+         data_source)
+    SELECT
+        opex_id, company_id, cost_center_id, expense_category_id,
+        expense_subcategory_id, practice_id, sector_id,
+        month_key, year, month_number,
+        fiscal_year, fiscal_month_number, fiscal_month_key,
+        opex_amount_dkk, invoice_count, is_payroll_flag,
+        cost_type,
+        data_source
+    FROM fact_opex;
+
+    -- =========================================================================
+    -- 4. fact_employee_monthly_mat  (was Block 5, OPTIMIZED -- no correlated subqueries)
+    --
+    -- V330: source switched from bi_data_per_day (compatibility view)
+    -- to fact_user_day (the underlying physical table).
+    -- V333: daily_fte divisor 8.0 -> 7.4 (Trustworks full-time day);
+    --       billable predicate IN ('ACTIVE', 'PROBATION') -> IN ('ACTIVE')
+    --       (PROBATION never appears in userstatus, dead code removed).
+    -- =========================================================================
+    TRUNCATE TABLE fact_employee_monthly_mat;
+    INSERT IGNORE INTO fact_employee_monthly_mat
+        (employee_month_id, company_id, practice_id, role_type,
+         month_key, year, month_number,
+         fiscal_year, fiscal_month_number,
+         headcount_start, headcount_end, average_headcount,
+         billable_headcount, non_billable_headcount,
+         fte_total, fte_billable, fte_non_billable,
+         joiners_count, leavers_count,
+         voluntary_leavers_count, data_source)
+    WITH
+        user_date_bounds AS (
+            SELECT
+                useruuid,
+                MIN(document_date) AS first_date,
+                MAX(document_date) AS last_date
+            FROM fact_user_day
+            WHERE gross_available_hours > 0
+              AND status_type != 'TERMINATED'
+              AND consultant_type IN ('CONSULTANT', 'STAFF')
+            GROUP BY useruuid
+        ),
+
+        daily_employee_data AS (
+            SELECT
+                b.companyuuid,
+                b.document_date,
+                b.year AS year_val,
+                b.month AS month_val,
+                b.useruuid,
+                b.gross_available_hours,
+                b.consultant_type,
+                b.status_type,
+                COALESCE(u.practice, 'UD') AS practice_id,
+                CASE
+                    WHEN b.consultant_type = 'CONSULTANT'
+                        AND b.status_type IN ('ACTIVE')
+                        THEN 'BILLABLE'
+                    ELSE 'NON_BILLABLE'
+                END AS role_type,
+                COALESCE(b.gross_available_hours, 0) / 7.4 AS daily_fte,
+                udb.first_date,
+                udb.last_date
+            FROM fact_user_day b
+            INNER JOIN user u ON b.useruuid = u.uuid
+            INNER JOIN user_date_bounds udb ON udb.useruuid = b.useruuid
+            WHERE b.gross_available_hours > 0
+              AND b.status_type != 'TERMINATED'
+              AND b.consultant_type IN ('CONSULTANT', 'STAFF')
+        ),
+
+        month_boundaries AS (
+            SELECT
+                companyuuid,
+                year_val,
+                month_val,
+                practice_id,
+                role_type,
+                COUNT(DISTINCT CASE
+                    WHEN DAY(document_date) = 1
+                        THEN useruuid
+                END) AS headcount_start,
+                COUNT(DISTINCT CASE
+                    WHEN document_date = LAST_DAY(document_date)
+                        THEN useruuid
+                END) AS headcount_end
+            FROM daily_employee_data
+            GROUP BY companyuuid, year_val, month_val, practice_id, role_type
+        ),
+
+        monthly_fte AS (
+            SELECT
+                companyuuid,
+                year_val,
+                month_val,
+                practice_id,
+                role_type,
+                COUNT(DISTINCT useruuid) AS distinct_employees,
+                SUM(daily_fte) / COUNT(DISTINCT document_date) AS avg_monthly_fte,
+                COUNT(DISTINCT CASE WHEN role_type = 'BILLABLE' THEN useruuid END) AS billable_headcount,
+                COUNT(DISTINCT CASE WHEN role_type = 'NON_BILLABLE' THEN useruuid END) AS non_billable_headcount,
+                SUM(CASE WHEN role_type = 'BILLABLE' THEN daily_fte ELSE 0 END) / COUNT(DISTINCT document_date) AS fte_billable,
+                SUM(CASE WHEN role_type = 'NON_BILLABLE' THEN daily_fte ELSE 0 END) / COUNT(DISTINCT document_date) AS fte_non_billable
+            FROM daily_employee_data
+            GROUP BY companyuuid, year_val, month_val, practice_id, role_type
+        ),
+
+        joiners_leavers AS (
+            SELECT
+                companyuuid,
+                year_val,
+                month_val,
+                practice_id,
+                role_type,
+                COUNT(DISTINCT CASE
+                    WHEN document_date = first_date THEN useruuid
+                END) AS joiners_count,
+                COUNT(DISTINCT CASE
+                    WHEN document_date = last_date AND document_date < CURDATE()
+                        THEN useruuid
+                END) AS leavers_count
+            FROM daily_employee_data
+            GROUP BY companyuuid, year_val, month_val, practice_id, role_type
+        )
+
+    SELECT
+        CONCAT(mf.companyuuid, '-', mf.practice_id, '-', mf.role_type, '-',
+               CONCAT(LPAD(mf.year_val, 4, '0'), LPAD(mf.month_val, 2, '0'))
+        ) AS employee_month_id,
+        mf.companyuuid AS company_id,
+        mf.practice_id,
+        mf.role_type,
+        CONCAT(LPAD(mf.year_val, 4, '0'), LPAD(mf.month_val, 2, '0')) AS month_key,
+        mf.year_val AS year,
+        mf.month_val AS month_number,
+        CASE WHEN mf.month_val >= 7 THEN mf.year_val ELSE mf.year_val - 1 END AS fiscal_year,
+        CASE WHEN mf.month_val >= 7 THEN mf.month_val - 6 ELSE mf.month_val + 6 END AS fiscal_month_number,
+        COALESCE(mb.headcount_start, 0) AS headcount_start,
+        COALESCE(mb.headcount_end, 0) AS headcount_end,
+        ROUND((COALESCE(mb.headcount_start, 0) + COALESCE(mb.headcount_end, 0)) / 2.0, 2) AS average_headcount,
+        COALESCE(mf.billable_headcount, 0) AS billable_headcount,
+        COALESCE(mf.non_billable_headcount, 0) AS non_billable_headcount,
+        ROUND(COALESCE(mf.avg_monthly_fte, 0), 2) AS fte_total,
+        ROUND(COALESCE(mf.fte_billable, 0), 2) AS fte_billable,
+        ROUND(COALESCE(mf.fte_non_billable, 0), 2) AS fte_non_billable,
+        COALESCE(jl.joiners_count, 0) AS joiners_count,
+        COALESCE(jl.leavers_count, 0) AS leavers_count,
+        0 AS voluntary_leavers_count,
+        'HR_SYSTEM' AS data_source
+    FROM monthly_fte mf
+    LEFT JOIN month_boundaries mb
+        ON mf.companyuuid = mb.companyuuid
+        AND mf.year_val = mb.year_val
+        AND mf.month_val = mb.month_val
+        AND mf.practice_id = mb.practice_id
+        AND mf.role_type = mb.role_type
+    LEFT JOIN joiners_leavers jl
+        ON mf.companyuuid = jl.companyuuid
+        AND mf.year_val = jl.year_val
+        AND mf.month_val = jl.month_val
+        AND mf.practice_id = jl.practice_id
+        AND mf.role_type = jl.role_type;
+
+    -- 5. fact_tw_bonus_monthly_mat  (was Block 6)
+    TRUNCATE TABLE fact_tw_bonus_monthly_mat;
+    INSERT IGNORE INTO fact_tw_bonus_monthly_mat
+        (useruuid, companyuuid, year, month,
+         days_in_month, total_days, eligible_days,
+         eligible_share, avg_salary, weighted_avg_salary,
+         fiscal_year)
+    SELECT
+        useruuid, companyuuid, year, month,
+        days_in_month, total_days, eligible_days,
+        eligible_share, avg_salary, weighted_avg_salary,
+        fiscal_year
+    FROM fact_tw_bonus_monthly;
+
+    -- 6. fact_tw_bonus_annual_mat  (was Block 7)
+    TRUNCATE TABLE fact_tw_bonus_annual_mat;
+    INSERT IGNORE INTO fact_tw_bonus_annual_mat
+        (useruuid, companyuuid, fiscal_year,
+         weight_sum, eligible_months, total_eligible_days,
+         avg_monthly_salary)
+    SELECT
+        useruuid, companyuuid, fiscal_year,
+        weight_sum, eligible_months, total_eligible_days,
+        avg_monthly_salary
+    FROM fact_tw_bonus_annual;
+
+    -- 7. fact_client_revenue_mat  (was Block 8)
+    TRUNCATE TABLE fact_client_revenue_mat;
+    INSERT IGNORE INTO fact_client_revenue_mat
+        (client_revenue_id, client_id, company_id,
+         month_key, year, month_number,
+         fiscal_year, fiscal_month_number,
+         invoice_phantom_dkk, internal_dkk,
+         credit_note_dkk, net_revenue_dkk)
+    SELECT
+        client_revenue_id, client_id, company_id,
+        month_key, year, month_number,
+        fiscal_year, fiscal_month_number,
+        invoice_phantom_dkk, internal_dkk,
+        credit_note_dkk, net_revenue_dkk
+    FROM fact_client_revenue;
+
+    -- 8. fact_operating_cost_distribution_mat  (was Block 9)
+    TRUNCATE TABLE fact_operating_cost_distribution_mat;
+    INSERT IGNORE INTO fact_operating_cost_distribution_mat
+        (distribution_id, origin_company, payer_company,
+         account_code, category_uuid, shared, salary,
+         year_val, month_val, month_key,
+         fiscal_year, fiscal_month_number,
+         origin_gl_amount, payer_ratio, payer_consultants,
+         allocated_amount, intercompany_owe)
+    SELECT
+        distribution_id, origin_company, payer_company,
+        account_code, category_uuid, shared, salary,
+        year_val, month_val, month_key,
+        fiscal_year, fiscal_month_number,
+        origin_gl_amount, payer_ratio, payer_consultants,
+        allocated_amount, intercompany_owe
+    FROM fact_operating_cost_distribution;
+
+    -- 9. fact_intercompany_settlement_mat  (was Block 10)
+    TRUNCATE TABLE fact_intercompany_settlement_mat;
+    INSERT IGNORE INTO fact_intercompany_settlement_mat
+        (settlement_id, payer_company, receiver_company,
+         year_val, month_val, month_key,
+         fiscal_year, fiscal_month_number,
+         expected_amount, actual_amount, settlement_gap,
+         invoice_count, settlement_status)
+    SELECT
+        CONCAT(payer_company, '-', receiver_company, '-', month_key),
+        payer_company, receiver_company,
+        year_val, month_val, month_key,
+        fiscal_year, fiscal_month_number,
+        expected_amount, actual_amount, settlement_gap,
+        invoice_count, settlement_status
+    FROM fact_intercompany_settlement;
+
+    -- =========================================================================
+    -- 10. fact_minimum_viable_rate_mat  (was Block 11, OPTIMIZED -- uses _mat tables)
+    --
+    -- FIXED in V237: Added min_monthly_salary_dkk, max_monthly_salary_dkk
+    -- FIXED in V272: utilization_stats CTE now reads from fact_user_day +
+    --   work_full directly (replacing dropped fact_user_utilization_mat).
+    -- =========================================================================
+    TRUNCATE TABLE fact_minimum_viable_rate_mat;
+    INSERT IGNORE INTO fact_minimum_viable_rate_mat
+        (rate_id, company_id, company_name, career_level,
+         consultant_count, avg_monthly_salary_dkk,
+         min_monthly_salary_dkk, max_monthly_salary_dkk,
+         employer_pension_pct, employer_pension_dkk,
+         atp_per_person_dkk, am_bidrag_per_person_dkk,
+         benefit_per_person_dkk, staff_allocation_dkk,
+         overhead_allocation_dkk, total_monthly_cost_dkk,
+         avg_net_available_hours, actual_utilization_ratio,
+         actual_billable_hours, utilization_post_first_billing,
+         target_utilization_ratio,
+         target_billable_hours, break_even_rate_actual,
+         break_even_rate_target, min_rate_15pct_margin,
+         min_rate_20pct_margin, avg_actual_billing_rate,
+         rate_buffer_dkk, data_source,
+         break_even_utilization_pct, break_even_utilization_15pct,
+         break_even_utilization_20pct)
+    WITH
+        ttm_range AS (
+            SELECT
+                DATE_FORMAT(DATE_SUB(CURDATE(), INTERVAL 12 MONTH), '%Y%m') AS start_month_key,
+                DATE_FORMAT(CURDATE(), '%Y%m') AS end_month_key,
+                DATE_SUB(CURDATE(), INTERVAL 12 MONTH) AS start_date,
+                CURDATE() AS end_date
+        ),
+
+        current_career_level AS (
+            SELECT
+                ucl.useruuid,
+                ucl.career_track,
+                ucl.career_level
+            FROM user_career_level ucl
+            INNER JOIN (
+                SELECT useruuid, MAX(active_from) AS max_active_from
+                FROM user_career_level
+                WHERE active_from <= CURDATE()
+                GROUP BY useruuid
+            ) latest ON ucl.useruuid = latest.useruuid AND ucl.active_from = latest.max_active_from
+        ),
+
+        active_consultants AS (
+            SELECT
+                us.companyuuid AS company_id,
+                ccl.career_level,
+                COUNT(DISTINCT u.uuid) AS consultant_count
+            FROM user u
+            INNER JOIN userstatus us ON us.useruuid = u.uuid
+            INNER JOIN current_career_level ccl ON ccl.useruuid = u.uuid
+            WHERE u.type = 'USER'
+              AND us.type = 'CONSULTANT'
+              AND us.status = 'ACTIVE'
+              AND us.statusdate = (
+                  SELECT MAX(us2.statusdate)
+                  FROM userstatus us2
+                  WHERE us2.useruuid = u.uuid
+                    AND us2.statusdate <= CURDATE()
+              )
+            GROUP BY us.companyuuid, ccl.career_level
+        ),
+
+        avg_salary AS (
+            SELECT
+                us.companyuuid AS company_id,
+                ccl.career_level,
+                AVG(s.salary) AS avg_monthly_salary,
+                MIN(s.salary) AS min_monthly_salary,
+                MAX(s.salary) AS max_monthly_salary
+            FROM user u
+            INNER JOIN userstatus us ON us.useruuid = u.uuid
+            INNER JOIN salary s ON s.useruuid = u.uuid
+            INNER JOIN current_career_level ccl ON ccl.useruuid = u.uuid
+            WHERE u.type = 'USER'
+              AND us.type = 'CONSULTANT'
+              AND us.status = 'ACTIVE'
+              AND us.statusdate = (
+                  SELECT MAX(us2.statusdate)
+                  FROM userstatus us2
+                  WHERE us2.useruuid = u.uuid
+                    AND us2.statusdate <= CURDATE()
+              )
+              AND s.activefrom = (
+                  SELECT MAX(s2.activefrom)
+                  FROM salary s2
+                  WHERE s2.useruuid = u.uuid
+                    AND s2.activefrom <= CURDATE()
+              )
+            GROUP BY us.companyuuid, ccl.career_level
+        ),
+
+        gl_statutory_costs AS (
+            SELECT
+                fd.companyuuid AS company_id,
+                SUM(CASE
+                    WHEN fd.companyuuid = 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 3502 THEN ABS(fd.amount)
+                    WHEN fd.companyuuid != 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 2210 THEN ABS(fd.amount)
+                    ELSE 0
+                END) AS total_salary,
+                SUM(CASE
+                    WHEN fd.companyuuid = 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 3510 THEN ABS(fd.amount)
+                    WHEN fd.companyuuid != 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 2215 THEN ABS(fd.amount)
+                    ELSE 0
+                END) AS total_pension,
+                SUM(CASE
+                    WHEN fd.companyuuid = 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 3580 THEN ABS(fd.amount)
+                    WHEN fd.companyuuid != 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 2222 THEN ABS(fd.amount)
+                    ELSE 0
+                END) AS total_atp,
+                SUM(CASE
+                    WHEN fd.companyuuid = 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 3578 THEN ABS(fd.amount)
+                    WHEN fd.companyuuid != 'd8894494-2fb4-4f72-9e05-e6032e6dd691' AND fd.accountnumber = 2223 THEN ABS(fd.amount)
+                    ELSE 0
+                END) AS total_am_bidrag
+            FROM finance_details fd
+            CROSS JOIN ttm_range tr
+            WHERE fd.expensedate >= tr.start_date
+              AND fd.expensedate <= tr.end_date
+              AND fd.expensedate IS NOT NULL
+              AND fd.amount != 0
+              AND (
+                  (fd.companyuuid = 'd8894494-2fb4-4f72-9e05-e6032e6dd691'
+                      AND fd.accountnumber IN (3502, 3510, 3580, 3578))
+                  OR
+                  (fd.companyuuid != 'd8894494-2fb4-4f72-9e05-e6032e6dd691'
+                      AND fd.accountnumber IN (2210, 2215, 2222, 2223))
+              )
+            GROUP BY fd.companyuuid
+        ),
+
+        gl_benefit_costs AS (
+            SELECT
+                fd.companyuuid AS company_id,
+                SUM(ABS(fd.amount)) AS total_benefit_costs
+            FROM finance_details fd
+            CROSS JOIN ttm_range tr
+            WHERE fd.expensedate >= tr.start_date
+              AND fd.expensedate <= tr.end_date
+              AND fd.expensedate IS NOT NULL
+              AND fd.amount != 0
+              AND (
+                  (fd.companyuuid = 'd8894494-2fb4-4f72-9e05-e6032e6dd691'
+                      AND fd.accountnumber IN (3570, 3585, 3593, 3565))
+                  OR
+                  (fd.companyuuid != 'd8894494-2fb4-4f72-9e05-e6032e6dd691'
+                      AND fd.accountnumber IN (2245, 2250, 2255, 2242))
+              )
+            GROUP BY fd.companyuuid
+        ),
+
+        company_headcount AS (
+            SELECT
+                us.companyuuid AS company_id,
+                COUNT(DISTINCT us.useruuid) AS total_active_users,
+                SUM(CASE WHEN us.type = 'CONSULTANT' AND u.type = 'USER' THEN 1 ELSE 0 END) AS billable_consultant_count
+            FROM userstatus us
+            INNER JOIN user u ON u.uuid = us.useruuid
+            WHERE us.status = 'ACTIVE'
+              AND us.statusdate = (
+                  SELECT MAX(us2.statusdate)
+                  FROM userstatus us2
+                  WHERE us2.useruuid = us.useruuid
+                    AND us2.statusdate <= CURDATE()
+              )
+            GROUP BY us.companyuuid
+        ),
+
+        statutory_ratios AS (
+            SELECT
+                sc.company_id,
+                CASE WHEN sc.total_salary > 0
+                    THEN sc.total_pension / sc.total_salary
+                    ELSE 0
+                END AS pension_pct,
+                CASE WHEN ch.total_active_users > 0
+                    THEN sc.total_atp / 12.0 / ch.total_active_users
+                    ELSE 0
+                END AS atp_per_person_monthly,
+                CASE WHEN ch.total_active_users > 0
+                    THEN sc.total_am_bidrag / 12.0 / ch.total_active_users
+                    ELSE 0
+                END AS am_per_person_monthly
+            FROM gl_statutory_costs sc
+            INNER JOIN company_headcount ch ON ch.company_id = sc.company_id
+        ),
+
+        benefit_per_person AS (
+            SELECT
+                bc.company_id,
+                CASE WHEN ch.total_active_users > 0
+                    THEN bc.total_benefit_costs / 12.0 / ch.total_active_users
+                    ELSE 0
+                END AS benefit_per_person_monthly
+            FROM gl_benefit_costs bc
+            INNER JOIN company_headcount ch ON ch.company_id = bc.company_id
+        ),
+
+        staff_costs AS (
+            SELECT
+                us.companyuuid AS company_id,
+                SUM(s.salary) AS total_staff_monthly_salary
+            FROM userstatus us
+            INNER JOIN user u ON u.uuid = us.useruuid
+            INNER JOIN salary s ON s.useruuid = u.uuid
+            WHERE us.status = 'ACTIVE'
+              AND us.type = 'STAFF'
+              AND u.type = 'USER'
+              AND us.statusdate = (
+                  SELECT MAX(us2.statusdate)
+                  FROM userstatus us2
+                  WHERE us2.useruuid = us.useruuid
+                    AND us2.statusdate <= CURDATE()
+              )
+              AND s.activefrom = (
+                  SELECT MAX(s2.activefrom)
+                  FROM salary s2
+                  WHERE s2.useruuid = u.uuid
+                    AND s2.activefrom <= CURDATE()
+              )
+            GROUP BY us.companyuuid
+        ),
+
+        staff_allocation AS (
+            SELECT
+                ch.company_id,
+                CASE WHEN ch.billable_consultant_count > 0
+                    THEN COALESCE(sc.total_staff_monthly_salary, 0) / ch.billable_consultant_count
+                    ELSE 0
+                END AS staff_per_consultant_monthly
+            FROM company_headcount ch
+            LEFT JOIN staff_costs sc ON sc.company_id = ch.company_id
+        ),
+
+        -- OPTIMIZED: reads from fact_opex_mat instead of fact_opex view
+        group_opex AS (
+            SELECT
+                SUM(CASE WHEN fo.is_payroll_flag = 0 THEN fo.opex_amount_dkk ELSE 0 END) AS total_non_payroll_opex
+            FROM fact_opex_mat fo
+            CROSS JOIN ttm_range tr
+            WHERE CAST(fo.month_key AS CHAR CHARACTER SET utf8mb4) >= tr.start_month_key
+              AND CAST(fo.month_key AS CHAR CHARACTER SET utf8mb4) <= tr.end_month_key
+        ),
+
+        -- OPTIMIZED: reads from fact_employee_monthly_mat instead of fact_employee_monthly view
+        fte_weights AS (
+            SELECT
+                fem.company_id,
+                AVG(fem.fte_billable) AS avg_billable_fte,
+                AVG(fem.fte_total) AS avg_total_fte
+            FROM fact_employee_monthly_mat fem
+            CROSS JOIN ttm_range tr
+            WHERE CAST(fem.month_key AS CHAR CHARACTER SET utf8mb4) >= tr.start_month_key
+              AND CAST(fem.month_key AS CHAR CHARACTER SET utf8mb4) <= tr.end_month_key
+            GROUP BY fem.company_id
+        ),
+
+        total_fte AS (
+            SELECT SUM(avg_billable_fte) AS group_billable_fte
+            FROM fte_weights
+        ),
+
+        overhead_allocation AS (
+            SELECT
+                fw.company_id,
+                CASE WHEN tf.group_billable_fte > 0 AND ch.billable_consultant_count > 0
+                    THEN (go.total_non_payroll_opex * (fw.avg_billable_fte / tf.group_billable_fte))
+                         / 12.0
+                         / ch.billable_consultant_count
+                    ELSE 0
+                END AS overhead_per_consultant_monthly
+            FROM fte_weights fw
+            CROSS JOIN group_opex go
+            CROSS JOIN total_fte tf
+            INNER JOIN company_headcount ch ON ch.company_id = fw.company_id
+        ),
+
+        -- V275: Simplified utilization from fact_user_day (aligns with V272 convention).
+        -- fact_user_day already has pre-computed registered_billable_hours and
+        -- net_available_hours per user per day, refreshed every 5 minutes.
+        -- Replaces the previous 3-CTE approach (work_full + join).
+
+        first_billing_date AS (
+            SELECT useruuid, MIN(document_date) AS first_date
+            FROM fact_user_day
+            WHERE registered_billable_hours > 0
+              AND consultant_type = 'CONSULTANT'
+            GROUP BY useruuid
+        ),
+
+        utilization_stats AS (
+            SELECT
+                fud.companyuuid AS company_id,
+                ccl.career_level,
+                AVG(monthly_available) AS avg_net_available_hours,
+                AVG(monthly_billable) AS avg_billable_hours,
+                CASE WHEN SUM(monthly_available) > 0
+                     THEN SUM(monthly_billable) / SUM(monthly_available)
+                     ELSE 0
+                END AS avg_utilization_ratio,
+                CASE WHEN SUM(monthly_available_post_billing) > 0
+                     THEN SUM(monthly_billable_post_billing) / SUM(monthly_available_post_billing)
+                     ELSE 0
+                END AS utilization_post_first_billing
+            FROM (
+                SELECT
+                    fud.companyuuid, fud.useruuid, fud.year, fud.month,
+                    SUM(fud.net_available_hours) AS monthly_available,
+                    SUM(fud.registered_billable_hours) AS monthly_billable,
+                    SUM(CASE WHEN fb.first_date IS NOT NULL AND fud.document_date >= fb.first_date
+                             THEN fud.net_available_hours ELSE 0 END) AS monthly_available_post_billing,
+                    SUM(CASE WHEN fb.first_date IS NOT NULL AND fud.document_date >= fb.first_date
+                             THEN fud.registered_billable_hours ELSE 0 END) AS monthly_billable_post_billing
+                FROM fact_user_day fud
+                LEFT JOIN first_billing_date fb ON fb.useruuid = fud.useruuid
+                CROSS JOIN ttm_range tr
+                WHERE fud.consultant_type = 'CONSULTANT'
+                  AND fud.status_type = 'ACTIVE'
+                  AND fud.document_date >= tr.start_date
+                  AND fud.document_date <= tr.end_date
+                GROUP BY fud.companyuuid, fud.useruuid, fud.year, fud.month
+            ) fud
+            INNER JOIN current_career_level ccl ON ccl.useruuid = fud.useruuid
+            GROUP BY fud.companyuuid, ccl.career_level
+        ),
+
+        actual_rates AS (
+            SELECT
+                wf.consultant_company_uuid AS company_id,
+                ccl.career_level,
+                AVG(wf.rate) AS avg_billing_rate
+            FROM work_full wf
+            INNER JOIN user u ON u.uuid = wf.useruuid
+            INNER JOIN current_career_level ccl ON ccl.useruuid = u.uuid
+            CROSS JOIN ttm_range tr
+            WHERE wf.registered >= tr.start_date
+              AND wf.registered <= tr.end_date
+              AND wf.rate > 0
+            GROUP BY wf.consultant_company_uuid, ccl.career_level
+        )
+
+    SELECT
+        CONCAT(ac.company_id, '-', ac.career_level) AS rate_id,
+        ac.company_id,
+        CASE ac.company_id
+            WHEN 'd8894494-2fb4-4f72-9e05-e6032e6dd691' THEN 'Trustworks A/S'
+            WHEN '44592d3b-2be5-4b29-bfaf-4fafc60b0fa3' THEN 'Trustworks Technology ApS'
+            WHEN 'e4b0a2a4-0963-4153-b0a2-a409637153a2' THEN 'Trustworks Cyber Security ApS'
+            ELSE 'Unknown'
+        END AS company_name,
+        ac.career_level,
+        ac.consultant_count,
+        ROUND(asl.avg_monthly_salary, 2) AS avg_monthly_salary_dkk,
+        ROUND(asl.min_monthly_salary, 0) AS min_monthly_salary_dkk,
+        ROUND(asl.max_monthly_salary, 0) AS max_monthly_salary_dkk,
+        ROUND(COALESCE(sr.pension_pct, 0), 4) AS employer_pension_pct,
+        ROUND(COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary, 2) AS employer_pension_dkk,
+        ROUND(COALESCE(sr.atp_per_person_monthly, 0), 2) AS atp_per_person_dkk,
+        ROUND(COALESCE(sr.am_per_person_monthly, 0), 2) AS am_bidrag_per_person_dkk,
+        ROUND(COALESCE(bp.benefit_per_person_monthly, 0), 2) AS benefit_per_person_dkk,
+        ROUND(COALESCE(sa.staff_per_consultant_monthly, 0), 2) AS staff_allocation_dkk,
+        ROUND(COALESCE(oa.overhead_per_consultant_monthly, 0), 2) AS overhead_allocation_dkk,
+        ROUND(
+            asl.avg_monthly_salary
+            + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+            + COALESCE(sr.atp_per_person_monthly, 0)
+            + COALESCE(sr.am_per_person_monthly, 0)
+            + COALESCE(bp.benefit_per_person_monthly, 0)
+            + COALESCE(sa.staff_per_consultant_monthly, 0)
+            + COALESCE(oa.overhead_per_consultant_monthly, 0)
+        , 2) AS total_monthly_cost_dkk,
+        ROUND(COALESCE(us2.avg_net_available_hours, 0), 2) AS avg_net_available_hours,
+        ROUND(COALESCE(us2.avg_utilization_ratio, 0), 4) AS actual_utilization_ratio,
+        ROUND(COALESCE(us2.avg_billable_hours, 0), 2) AS actual_billable_hours,
+        ROUND(COALESCE(us2.utilization_post_first_billing, 0), 4) AS utilization_post_first_billing,
+        0.75 AS target_utilization_ratio,
+        ROUND(COALESCE(us2.avg_net_available_hours, 0) * 0.75, 2) AS target_billable_hours,
+        CASE WHEN COALESCE(us2.avg_billable_hours, 0) > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / us2.avg_billable_hours
+            , 2)
+            ELSE NULL
+        END AS break_even_rate_actual,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) * 0.75 > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / (us2.avg_net_available_hours * 0.75)
+            , 2)
+            ELSE NULL
+        END AS break_even_rate_target,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) * 0.75 > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / (us2.avg_net_available_hours * 0.75)
+                / 0.85
+            , 2)
+            ELSE NULL
+        END AS min_rate_15pct_margin,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) * 0.75 > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / (us2.avg_net_available_hours * 0.75)
+                / 0.80
+            , 2)
+            ELSE NULL
+        END AS min_rate_20pct_margin,
+        ROUND(COALESCE(ar.avg_billing_rate, 0), 2) AS avg_actual_billing_rate,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) * 0.75 > 0 AND COALESCE(ar.avg_billing_rate, 0) > 0
+            THEN ROUND(
+                ar.avg_billing_rate
+                - (asl.avg_monthly_salary
+                   + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                   + COALESCE(sr.atp_per_person_monthly, 0)
+                   + COALESCE(sr.am_per_person_monthly, 0)
+                   + COALESCE(bp.benefit_per_person_monthly, 0)
+                   + COALESCE(sa.staff_per_consultant_monthly, 0)
+                   + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                  / (us2.avg_net_available_hours * 0.75)
+            , 2)
+            ELSE NULL
+        END AS rate_buffer_dkk,
+        'OPERATIONAL' AS data_source,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) > 0 AND COALESCE(ar.avg_billing_rate, 0) > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / (us2.avg_net_available_hours * ar.avg_billing_rate)
+            , 4)
+            ELSE NULL
+        END AS break_even_utilization_pct,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) > 0 AND COALESCE(ar.avg_billing_rate, 0) > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / (0.85 * us2.avg_net_available_hours * ar.avg_billing_rate)
+            , 4)
+            ELSE NULL
+        END AS break_even_utilization_15pct,
+        CASE WHEN COALESCE(us2.avg_net_available_hours, 0) > 0 AND COALESCE(ar.avg_billing_rate, 0) > 0
+            THEN ROUND(
+                (asl.avg_monthly_salary
+                 + COALESCE(sr.pension_pct, 0) * asl.avg_monthly_salary
+                 + COALESCE(sr.atp_per_person_monthly, 0)
+                 + COALESCE(sr.am_per_person_monthly, 0)
+                 + COALESCE(bp.benefit_per_person_monthly, 0)
+                 + COALESCE(sa.staff_per_consultant_monthly, 0)
+                 + COALESCE(oa.overhead_per_consultant_monthly, 0))
+                / (0.80 * us2.avg_net_available_hours * ar.avg_billing_rate)
+            , 4)
+            ELSE NULL
+        END AS break_even_utilization_20pct
+
+    FROM active_consultants ac
+    INNER JOIN avg_salary asl ON asl.company_id = ac.company_id AND asl.career_level = ac.career_level
+    LEFT JOIN statutory_ratios sr ON sr.company_id = ac.company_id
+    LEFT JOIN benefit_per_person bp ON bp.company_id = ac.company_id
+    LEFT JOIN staff_allocation sa ON sa.company_id = ac.company_id
+    LEFT JOIN overhead_allocation oa ON oa.company_id = ac.company_id
+    LEFT JOIN utilization_stats us2 ON us2.company_id = ac.company_id AND us2.career_level = ac.career_level
+    LEFT JOIN actual_rates ar ON ar.company_id = ac.company_id AND ar.career_level = ac.career_level
+    ORDER BY ac.company_id, ac.career_level;
+
+    -- =========================================================================
+    -- 11. fact_company_revenue_mat  (was Block 12, RESTORED in V263)
+    -- =========================================================================
+    TRUNCATE TABLE fact_company_revenue_mat;
+    INSERT IGNORE INTO fact_company_revenue_mat
+        (revenue_id, company_id, month_key, year, month_number,
+         fiscal_year, fiscal_month_number,
+         invoice_phantom_dkk, internal_dkk, credit_note_dkk,
+         net_revenue_dkk)
+    SELECT
+        revenue_id, company_id, month_key, year, month_number,
+        fiscal_year, fiscal_month_number,
+        invoice_phantom_dkk, internal_dkk, credit_note_dkk,
+        net_revenue_dkk
+    FROM fact_company_revenue;
+
+    -- =========================================================================
+    -- 12. fact_internal_invoice_cost_mat  (was Block 13, RESTORED in V263)
+    -- =========================================================================
+    TRUNCATE TABLE fact_internal_invoice_cost_mat;
+    INSERT IGNORE INTO fact_internal_invoice_cost_mat
+        (internal_invoice_cost_id, company_id, month_key, year, month_number,
+         fiscal_year, fiscal_month_number,
+         internal_invoice_cost_dkk, queued_cost_dkk, created_cost_dkk,
+         entry_count, data_sources)
+    SELECT
+        internal_invoice_cost_id, company_id, month_key, year, month_number,
+        fiscal_year, fiscal_month_number,
+        internal_invoice_cost_dkk, queued_cost_dkk, created_cost_dkk,
+        entry_count, data_sources
+    FROM fact_internal_invoice_cost;
+
+    -- =========================================================================
+    -- 13. fact_sick_day_rolling_mat  (was Block 14, NEW in V264)
+    --
+    -- Unlike blocks 1-12 which truncate+insert from views, this block
+    -- delegates to sp_refresh_sick_day_rolling() which handles the full
+    -- computation pipeline (base values -> bridging -> rolling window).
+    -- The procedure internally truncates the table.
+    -- =========================================================================
+    CALL sp_refresh_sick_day_rolling();
+
+END //
+
+DELIMITER ;

--- a/src/main/resources/db/migration/V334__Fix_recalculate_budgets_discount_percent.sql
+++ b/src/main/resources/db/migration/V334__Fix_recalculate_budgets_discount_percent.sql
@@ -1,0 +1,186 @@
+-- ============================================================================
+-- V334: Fix sp_recalculate_budgets discount unit (percent 0-100)
+-- ============================================================================
+-- Purpose
+--   The contract_type_items.value column stores DISCOUNT as a percent in the
+--   range 0-100 (e.g. value='10' = 10% off). This is the convention used by
+--   the live `work_full` view, which casts the value as an unsigned integer
+--   and divides by 100 before applying it to the rate.
+--
+--   `sp_recalculate_budgets` was written with a different (incorrect)
+--   assumption: that the value is already a fraction in the range 0-1
+--   (e.g. value='0.10' = 10%). It applies the value directly without the
+--   /100 divisor:
+--       cc.rate * (1 - COALESCE(CAST(NULLIF(cti.value, '') AS DECIMAL(10,4)), 0))
+--   For a stored value of '10' this would compute rate * (1 - 10) = -9*rate,
+--   producing a negative budget rate. For a stored value of '0.10' it would
+--   compute rate * 0.90, which "looks correct" only by accident of how the
+--   data is stored today.
+--
+-- Background
+--   - V279 (2026) recreated `sp_recalculate_budgets` to fix a silent failure
+--     bug in the post-transaction UPDATE pipeline. The body has not been
+--     modified since.
+--   - The current `work_full` view applies the discount as:
+--         cast(nullif(cti.value, '') as unsigned) / 100
+--     so the budget procedure must use the same divisor to stay consistent.
+--
+-- Production impact today
+--   ZERO. As of 2026-05-10 there are 0 rows in contract_type_items with
+--   `name = 'DISCOUNT' AND value <> ''`. This is a preventive fix: the
+--   first contract that adds a DISCOUNT after this migration deploys will
+--   compute the correct budget rate; without this fix it would silently
+--   produce wrong budget revenue numbers.
+--
+-- Scope of body changes
+--   ONE-LINE change in the INSERT IGNORE INTO fact_budget_day SELECT:
+--     BEFORE:
+--       cc.rate * (1 - COALESCE(CAST(NULLIF(cti.value, '') AS DECIMAL(10,4)), 0)) AS rate
+--     AFTER:
+--       cc.rate * (1 - COALESCE(CAST(NULLIF(cti.value, '') AS DECIMAL(10,4)), 0) / 100) AS rate
+--   All other lines (signature, error handler, transaction wrapping,
+--   normalization UPDATE, zero-out UPDATE) are byte-identical to V279.
+--
+-- Idempotency
+--   DROP PROCEDURE IF EXISTS guards re-runs in dev. In production it runs
+--   once.
+--
+-- Rollback
+--   Re-apply V279 verbatim. The procedure body is fully self-contained in
+--   that file. Both V279 and this V334 use the same DROP+CREATE pattern,
+--   so the rollback is a single-shot replay.
+--
+-- Verification (run after deploy)
+--   -- 1. Force a refresh so any future-discount contracts pick up the new
+--   --    formula.
+--   CALL sp_recalculate_budgets(
+--       DATE_SUB(CURDATE(), INTERVAL 3 MONTH),
+--       DATE_ADD(CURDATE(), INTERVAL 24 MONTH),
+--       NULL);
+--
+--   -- 2. Sanity: budget rows are unchanged for current month (since 0
+--   --    contracts have a non-empty DISCOUNT today).
+--   SELECT YEAR(document_date) AS y, MONTH(document_date) AS m,
+--          COUNT(*) AS c,
+--          ROUND(SUM(budgetHours * rate), 0) AS revenue
+--   FROM fact_budget_day
+--   WHERE document_date BETWEEN '2026-05-01' AND '2026-05-31'
+--   GROUP BY y, m;
+--   -- compare against the same rollup before the migration; values must match.
+--
+--   -- 3. Confirm the new procedure body contains the /100 divisor.
+--   SELECT routine_definition
+--   FROM information_schema.routines
+--   WHERE routine_schema = DATABASE()
+--     AND routine_name = 'sp_recalculate_budgets'
+--     AND routine_definition LIKE '%/ 100)%';
+--   -- expected: 1 row
+-- ============================================================================
+
+DROP PROCEDURE IF EXISTS sp_recalculate_budgets;
+
+DELIMITER $$
+
+CREATE PROCEDURE sp_recalculate_budgets(
+    IN p_start_date DATE,
+    IN p_end_date   DATE,
+    IN p_user_uuid  VARCHAR(36)
+)
+BEGIN
+    -- Any SQL error rolls back the entire procedure and re-raises the error.
+    -- This ensures we never commit a partial state (NULL companyuuid,
+    -- un-normalized budgets, etc.) that silently breaks downstream views.
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    -- Delete existing rows in the target range
+    DELETE FROM fact_budget_day
+    WHERE document_date >= p_start_date
+      AND document_date < p_end_date
+      AND (p_user_uuid IS NULL OR useruuid = p_user_uuid);
+
+    -- Insert new rows with companyuuid resolved via fact_user_day.
+    -- sp_recalculate_availability runs before this procedure in both the
+    -- nightly and incremental paths, so fact_user_day is guaranteed to have
+    -- rows for this date range with valid companyuuid.
+    --
+    -- V334: discount value is a percent in 0-100 (matches `work_full`).
+    -- The /100 divisor below was missing in V279 and earlier.
+    INSERT IGNORE INTO fact_budget_day (
+        document_date, year, month, day,
+        clientuuid, useruuid, companyuuid, contractuuid,
+        budgetHours, budgetHoursWithNoAvailabilityAdjustment, rate
+    )
+    SELECT
+        dd.date_key, dd.year, dd.month, dd.day,
+        c.clientuuid, cc.useruuid, fud.companyuuid, c.uuid AS contractuuid,
+        cc.hours / 5.0 AS budgetHours,
+        cc.hours / 5.0 AS budgetHoursRaw,
+        cc.rate * (1 - COALESCE(CAST(NULLIF(cti.value, '') AS DECIMAL(10,4)), 0) / 100) AS rate
+    FROM contracts c
+    JOIN contract_consultants cc ON cc.contractuuid = c.uuid
+    JOIN (
+        SELECT contractuuid,
+               MIN(activefrom) AS min_activefrom,
+               MAX(activeto)   AS max_activeto
+        FROM contract_consultants
+        GROUP BY contractuuid
+    ) cp ON cp.contractuuid = c.uuid
+    JOIN dim_date dd ON dd.date_key >= cc.activefrom
+        AND dd.date_key < COALESCE(cc.activeto, '2035-01-01')
+        AND dd.date_key >= COALESCE(cp.min_activefrom, '2014-01-01')
+        AND dd.date_key < COALESCE(cp.max_activeto, '2035-01-01')
+        AND dd.is_weekend = 0
+    LEFT JOIN contract_type_items cti
+        ON cti.contractuuid = c.uuid
+        AND cti.name = 'DISCOUNT'
+    LEFT JOIN fact_user_day fud
+        ON fud.useruuid = cc.useruuid
+        AND fud.document_date = dd.date_key
+    WHERE dd.date_key >= p_start_date
+      AND dd.date_key < p_end_date
+      AND cc.hours > 0
+      AND c.status IN ('SIGNED', 'TIME', 'CLOSED')
+      AND (p_user_uuid IS NULL OR cc.useruuid = p_user_uuid);
+
+    -- Normalize over-allocated budgets (inside transaction).
+    -- If a consultant has multiple contracts whose combined daily hours
+    -- exceed their net available hours, proportionally reduce each contract
+    -- so the total fits within availability.
+    UPDATE fact_budget_day fbd
+    JOIN (
+        SELECT fbd2.useruuid, fbd2.document_date,
+            SUM(fbd2.budgetHours) AS total_budget,
+            COALESCE(fud.net_available_hours, 0) AS net_available
+        FROM fact_budget_day fbd2
+        LEFT JOIN fact_user_day fud
+            ON fud.useruuid = fbd2.useruuid AND fud.document_date = fbd2.document_date
+        WHERE fbd2.document_date >= p_start_date AND fbd2.document_date < p_end_date
+          AND (p_user_uuid IS NULL OR fbd2.useruuid = p_user_uuid)
+        GROUP BY fbd2.useruuid, fbd2.document_date
+        HAVING total_budget > net_available AND net_available > 0
+    ) overalloc ON fbd.useruuid = overalloc.useruuid AND fbd.document_date = overalloc.document_date
+    SET fbd.budgetHours = fbd.budgetHours * (overalloc.net_available / overalloc.total_budget)
+    WHERE fbd.document_date >= p_start_date AND fbd.document_date < p_end_date;
+
+    -- Zero out budget when no availability (inside transaction).
+    -- Vacation, sick days, weekends, maternity leave etc. -> net available = 0
+    -- -> budget must also be 0 even though the contract allocates hours.
+    UPDATE fact_budget_day fbd
+    JOIN fact_user_day fud
+        ON fud.useruuid = fbd.useruuid AND fud.document_date = fbd.document_date
+    SET fbd.budgetHours = 0
+    WHERE fud.net_available_hours = 0
+      AND fbd.document_date >= p_start_date
+      AND fbd.document_date < p_end_date
+      AND (p_user_uuid IS NULL OR fbd.useruuid = p_user_uuid);
+
+    COMMIT;
+END$$
+
+DELIMITER ;

--- a/src/main/resources/db/migration/V335__Drop_aggregate_monthly_noop.sql
+++ b/src/main/resources/db/migration/V335__Drop_aggregate_monthly_noop.sql
@@ -1,0 +1,225 @@
+-- ============================================================================
+-- V335: Drop sp_aggregate_monthly (no-op) and remove its callers
+-- ============================================================================
+-- Purpose
+--   `sp_aggregate_monthly` has been a no-op (`DO 0;`) ever since
+--   `company_work_per_month` became a live VIEW. Both BI orchestrators
+--   (`sp_nightly_bi_refresh` and `sp_incremental_bi_refresh`) still call
+--   it, wasting an open/close round-trip and adding noise to the refresh
+--   pipeline. This migration removes the dead orchestration step.
+--
+-- Scope of changes
+--   1. Recreate `sp_nightly_bi_refresh` WITHOUT the `CALL sp_aggregate_monthly`
+--      line. The "Step 4" block is removed and "Step 5" (refresh fact tables)
+--      is renumbered to "Step 4" with a comment noting the removal.
+--   2. Recreate `sp_incremental_bi_refresh` WITHOUT the inner BEGIN..END
+--      block that called `sp_aggregate_monthly(v_global_start, v_global_end)`.
+--      Everything else (lock acquisition, change-log scan, per-user cursor
+--      loop, fact-tables refresh, change-log marking, temp-table cleanup,
+--      lock release) is byte-identical to the captured production body.
+--   3. `DROP PROCEDURE IF EXISTS sp_aggregate_monthly` as the FINAL step.
+--
+-- Order matters
+--   The two orchestrators MUST stop calling `sp_aggregate_monthly` BEFORE
+--   the procedure is dropped. Otherwise the next refresh tick (nightly at
+--   ~02:00 UTC, incremental every 5 minutes) would error out trying to
+--   call a non-existent procedure. This file enforces the order: orchestrators
+--   first, then DROP.
+--
+-- Background
+--   - `sp_aggregate_monthly` was originally responsible for refreshing
+--     `company_work_per_month` as a materialized table. When that object
+--     became a regular VIEW the procedure body was replaced with `DO 0;`
+--     but the call sites were never removed.
+--   - Production already runs both orchestrators every cycle, so the cost
+--     of the no-op is real (one cross-procedure call per cycle for the
+--     incremental case, one per nightly run).
+--
+-- Idempotency
+--   - CREATE OR REPLACE on both orchestrators makes the call-site removal
+--     idempotent.
+--   - DROP PROCEDURE IF EXISTS guards the final step.
+--
+-- Rollback
+--   1. Recreate `sp_aggregate_monthly` with `BEGIN DO 0; END`.
+--   2. Restore the prior orchestrator bodies (captured production bodies
+--      kept in the deployment runbook): re-add the `CALL sp_aggregate_monthly`
+--      line in `sp_nightly_bi_refresh` Step 4, and re-add the inner
+--      BEGIN..END in `sp_incremental_bi_refresh` after the cursor loop.
+--   Both procedures are pure DDL on stored objects -- no data is touched.
+--
+-- Verification (run after deploy)
+--   -- 1. Confirm sp_aggregate_monthly is gone.
+--   SELECT routine_name FROM information_schema.routines
+--   WHERE routine_schema = DATABASE()
+--     AND routine_name = 'sp_aggregate_monthly';
+--   -- expected: 0 rows
+--
+--   -- 2. Confirm orchestrators don't reference it.
+--   SELECT routine_name FROM information_schema.routines
+--   WHERE routine_schema = DATABASE()
+--     AND routine_definition LIKE '%sp_aggregate_monthly%';
+--   -- expected: 0 rows
+--
+--   -- 3. Confirm the next nightly run completes.
+--   SELECT event_name, status, last_executed
+--   FROM information_schema.events
+--   WHERE event_schema = DATABASE()
+--     AND event_name = 'ev_bi_nightly_refresh';
+--   -- last_executed should be today/tomorrow.
+--
+--   -- 4. Manually call the nightly orchestrator (staging only) to make
+--   --    sure the body parses and executes end-to-end.
+--   --    CALL sp_nightly_bi_refresh(3, 24);
+-- ============================================================================
+
+
+-- ----------------------------------------------------------------------------
+-- 1. sp_nightly_bi_refresh -- remove CALL sp_aggregate_monthly
+-- ----------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS sp_nightly_bi_refresh;
+
+DELIMITER $$
+
+CREATE PROCEDURE sp_nightly_bi_refresh(
+    IN p_lookback_months INT,
+    IN p_forward_months  INT
+)
+nightly_body: BEGIN
+    DECLARE v_start DATE;
+    DECLARE v_end   DATE;
+    DECLARE v_lock_acquired INT DEFAULT 0;
+
+    -- Acquire shared lock with incremental refresh (wait up to 5 min)
+    SELECT GET_LOCK('bi_refresh', 300) INTO v_lock_acquired;
+    IF v_lock_acquired = 0 THEN
+        LEAVE nightly_body;
+    END IF;
+
+    SET v_start = DATE_FORMAT(DATE_SUB(CURDATE(), INTERVAL p_lookback_months MONTH), '%Y-%m-01');
+    SET v_end   = DATE_FORMAT(DATE_ADD(CURDATE(), INTERVAL p_forward_months MONTH), '%Y-%m-01');
+
+    -- Step 1: Availability (creates/updates rows in bi_data_per_day)
+    CALL sp_recalculate_availability(v_start, v_end, NULL);
+
+    -- Step 2: Work aggregation (updates registered_billable_hours, registered_amount)
+    CALL sp_aggregate_work(v_start, v_end);
+
+    -- Step 3: Budget calculation (populates bi_budget_per_day)
+    CALL sp_recalculate_budgets(v_start, v_end, NULL);
+
+    -- Step 4: Refresh materialized fact tables (truncate + repopulate from views)
+    -- This includes block 14 which calls sp_refresh_sick_day_rolling()
+    --
+    -- V335: removed the previous "Step 4: Monthly aggregation" call to
+    -- sp_aggregate_monthly. That procedure was a no-op (`DO 0;`) since
+    -- company_work_per_month became a live VIEW; sp_aggregate_monthly
+    -- itself is dropped at the end of this migration.
+    CALL sp_refresh_fact_tables();
+
+    DO RELEASE_LOCK('bi_refresh');
+END$$
+
+DELIMITER ;
+
+
+-- ----------------------------------------------------------------------------
+-- 2. sp_incremental_bi_refresh -- remove inner CALL sp_aggregate_monthly block
+-- ----------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS sp_incremental_bi_refresh;
+
+DELIMITER $$
+
+CREATE PROCEDURE sp_incremental_bi_refresh()
+proc_body: BEGIN
+    DECLARE v_count INT DEFAULT 0;
+    DECLARE v_lock_acquired INT DEFAULT 0;
+
+    -- Use same lock as nightly to prevent concurrent execution
+    SELECT GET_LOCK('bi_refresh', 0) INTO v_lock_acquired;
+    IF v_lock_acquired = 0 THEN
+        LEAVE proc_body;
+    END IF;
+
+    SELECT COUNT(*) INTO v_count
+    FROM fact_change_log
+    WHERE processed_at IS NULL;
+
+    IF v_count = 0 THEN
+        DO RELEASE_LOCK('bi_refresh');
+        LEAVE proc_body;
+    END IF;
+
+    DROP TEMPORARY TABLE IF EXISTS tmp_affected_ranges;
+
+    CREATE TEMPORARY TABLE tmp_affected_ranges (
+        useruuid   VARCHAR(36) NOT NULL,
+        month_start DATE       NOT NULL,
+        month_end   DATE       NOT NULL,
+        PRIMARY KEY (useruuid, month_start)
+    ) ENGINE=MEMORY;
+
+    -- For CONTRACT changes, expand to cover the full contract date range
+    -- For other changes, use the single affected month
+    INSERT IGNORE INTO tmp_affected_ranges (useruuid, month_start, month_end)
+    SELECT DISTINCT
+        fcl.useruuid,
+        DATE_FORMAT(fcl.affected_date, '%Y-%m-01') AS month_start,
+        DATE_FORMAT(fcl.affected_date + INTERVAL 1 MONTH, '%Y-%m-01') AS month_end
+    FROM fact_change_log fcl
+    WHERE fcl.processed_at IS NULL;
+
+    BEGIN
+        DECLARE done INT DEFAULT FALSE;
+        DECLARE v_useruuid VARCHAR(36);
+        DECLARE v_month_start DATE;
+        DECLARE v_month_end DATE;
+
+        DECLARE cur CURSOR FOR
+            SELECT useruuid, month_start, month_end
+            FROM tmp_affected_ranges;
+
+        DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+        OPEN cur;
+
+        read_loop: LOOP
+            FETCH cur INTO v_useruuid, v_month_start, v_month_end;
+            IF done THEN
+                LEAVE read_loop;
+            END IF;
+
+            CALL sp_recalculate_availability(v_month_start, v_month_end, v_useruuid);
+            CALL sp_aggregate_work(v_month_start, v_month_end);
+            CALL sp_recalculate_budgets(v_month_start, v_month_end, v_useruuid);
+        END LOOP;
+
+        CLOSE cur;
+    END;
+
+    -- V335: removed the global sp_aggregate_monthly inner BEGIN..END block.
+    -- That procedure was a no-op (`DO 0;`) since company_work_per_month
+    -- became a live VIEW; sp_aggregate_monthly itself is dropped at the
+    -- end of this migration.
+
+    CALL sp_refresh_fact_tables();
+
+    UPDATE fact_change_log
+    SET processed_at = NOW()
+    WHERE processed_at IS NULL;
+
+    DROP TEMPORARY TABLE IF EXISTS tmp_affected_ranges;
+
+    DO RELEASE_LOCK('bi_refresh');
+END$$
+
+DELIMITER ;
+
+
+-- ----------------------------------------------------------------------------
+-- 3. Drop sp_aggregate_monthly
+--
+-- Both orchestrators above no longer reference it; the next refresh tick
+-- will not attempt to call the dropped procedure.
+-- ----------------------------------------------------------------------------
+DROP PROCEDURE IF EXISTS sp_aggregate_monthly;

--- a/src/test/java/dk/trustworks/intranet/aggregates/bidata/jobs/ChangeLogRetentionBatchletTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/bidata/jobs/ChangeLogRetentionBatchletTest.java
@@ -1,0 +1,122 @@
+package dk.trustworks.intranet.aggregates.bidata.jobs;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Mockito-only unit tests — same pattern as {@code S3RetentionCleanupBatchletTest}.
+ * The transactional wrapper is overridden via {@link Mockito#spy} so tests do
+ * not need a Quarkus context.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ChangeLogRetentionBatchletTest {
+
+    @Mock
+    EntityManager em;
+
+    @Mock
+    Query deleteQuery;
+
+    private ChangeLogRetentionBatchlet batchlet;
+
+    @BeforeEach
+    void setUp() {
+        ChangeLogRetentionBatchlet real = new ChangeLogRetentionBatchlet();
+        real.em = em;
+        real.retentionDays = 30;
+        batchlet = Mockito.spy(real);
+        // Bypass QuarkusTransaction.requiringNew() — not available in unit context.
+        Mockito.doAnswer(inv -> batchlet.deleteOneChunk())
+                .when(batchlet).deleteOneChunkInOwnTransaction();
+    }
+
+    @Test
+    void run_singleShortChunk_returnsRowsDeletedAndStops() {
+        when(em.createNativeQuery(anyString())).thenReturn(deleteQuery);
+        when(deleteQuery.setParameter(eq("days"), eq(30))).thenReturn(deleteQuery);
+        when(deleteQuery.executeUpdate()).thenReturn(7);
+
+        long deleted = batchlet.run();
+
+        assertEquals(7L, deleted);
+        verify(deleteQuery, times(1)).executeUpdate();
+    }
+
+    @Test
+    void run_multipleFullChunks_loopsUntilShortChunk() {
+        when(em.createNativeQuery(anyString())).thenReturn(deleteQuery);
+        when(deleteQuery.setParameter(eq("days"), eq(30))).thenReturn(deleteQuery);
+        when(deleteQuery.executeUpdate())
+                .thenReturn(ChangeLogRetentionBatchlet.DELETE_CHUNK_SIZE,
+                            ChangeLogRetentionBatchlet.DELETE_CHUNK_SIZE,
+                            42);
+
+        long deleted = batchlet.run();
+
+        assertEquals(2L * ChangeLogRetentionBatchlet.DELETE_CHUNK_SIZE + 42L, deleted);
+        verify(deleteQuery, times(3)).executeUpdate();
+    }
+
+    @Test
+    void run_zeroRows_returnsZeroAndExitsImmediately() {
+        when(em.createNativeQuery(anyString())).thenReturn(deleteQuery);
+        when(deleteQuery.setParameter(eq("days"), eq(30))).thenReturn(deleteQuery);
+        when(deleteQuery.executeUpdate()).thenReturn(0);
+
+        long deleted = batchlet.run();
+
+        assertEquals(0L, deleted);
+        verify(deleteQuery, times(1)).executeUpdate();
+    }
+
+    @Test
+    void run_customRetentionDays_isBoundToQueryParameter() {
+        batchlet.retentionDays = 7;
+        when(em.createNativeQuery(anyString())).thenReturn(deleteQuery);
+        when(deleteQuery.setParameter(eq("days"), eq(7))).thenReturn(deleteQuery);
+        when(deleteQuery.executeUpdate()).thenReturn(0);
+
+        batchlet.run();
+
+        verify(deleteQuery).setParameter("days", 7);
+        verify(deleteQuery, never()).setParameter("days", 30);
+    }
+
+    @Test
+    void scheduledRun_swallowsExceptions_soSchedulerKeepsRunning() {
+        when(em.createNativeQuery(anyString()))
+                .thenThrow(new RuntimeException("simulated DB outage"));
+
+        batchlet.scheduledRun();
+    }
+
+    @Test
+    void scheduledRun_isAnnotatedWithDailyCron() throws NoSuchMethodException {
+        Method m = ChangeLogRetentionBatchlet.class.getMethod("scheduledRun");
+        io.quarkus.scheduler.Scheduled annotation =
+                m.getAnnotation(io.quarkus.scheduler.Scheduled.class);
+        assertNotNull(annotation, "scheduledRun must carry @Scheduled");
+        assertEquals("0 15 2 * * ?", annotation.cron(),
+                "Retention reaper should run daily at 02:15 UTC.");
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/bidata/jobs/FactChangeLogBacklogAlertBatchletTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/bidata/jobs/FactChangeLogBacklogAlertBatchletTest.java
@@ -1,0 +1,152 @@
+package dk.trustworks.intranet.aggregates.bidata.jobs;
+
+import dk.trustworks.intranet.communicationsservice.services.SlackService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Mockito-only unit tests. The single backlog query returns {@code Object[]}
+ * with {pending, oldestMinutes}; we stub it via {@link #stubBacklog}.
+ */
+@ExtendWith(MockitoExtension.class)
+class FactChangeLogBacklogAlertBatchletTest {
+
+    private static final String CHANNEL = "C0B2VQ2CFU1";
+
+    @InjectMocks
+    FactChangeLogBacklogAlertBatchlet batchlet;
+
+    @Mock
+    EntityManager em;
+
+    @Mock
+    SlackService slackService;
+
+    @Mock
+    Query backlogQuery;
+
+    @BeforeEach
+    void setUp() {
+        batchlet.opsAlertChannel = CHANNEL;
+        batchlet.maxPending = 500L;
+        batchlet.maxOldestPendingMinutes = 30L;
+    }
+
+    @Test
+    void pendingExceedsThreshold_sendsSlackAlert() {
+        stubBacklog(600L, 5L);
+
+        batchlet.checkBacklog();
+
+        verify(slackService).sendMessage(
+                eq(CHANNEL),
+                contains("pending events: 600"),
+                eq("mother"));
+    }
+
+    @Test
+    void healthyBacklog_doesNotSendAlert() {
+        stubBacklog(10L, null);
+
+        batchlet.checkBacklog();
+
+        verify(slackService, never()).sendMessage(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void oldestPendingExceedsThreshold_sendsSlackAlert() {
+        stubBacklog(5L, 45L);
+
+        batchlet.checkBacklog();
+
+        verify(slackService).sendMessage(
+                eq(CHANNEL),
+                contains("oldest pending: 45 minutes"),
+                eq("mother"));
+    }
+
+    @Test
+    void repeatBreachWithinWindow_doesNotResendAlert() {
+        stubBacklog(600L, 5L);
+
+        batchlet.checkBacklog();
+        batchlet.checkBacklog();
+
+        verify(slackService, times(1)).sendMessage(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void breachClearsThenRecurs_alertFiresAgainImmediately() {
+        stubBacklog(600L, 5L);
+        batchlet.checkBacklog();
+
+        stubBacklog(10L, null);
+        batchlet.checkBacklog();
+
+        stubBacklog(700L, 5L);
+        batchlet.checkBacklog();
+
+        // Two alerts: first breach + re-occurrence after recovery cleared the window.
+        verify(slackService, times(2)).sendMessage(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void alertMessage_includesAllRequiredFields() {
+        stubBacklog(750L, 42L);
+
+        batchlet.checkBacklog();
+
+        verify(slackService).sendMessage(eq(CHANNEL),
+                argThat((String msg) -> msg.contains(":rotating_light:")
+                        && msg.contains("fact_change_log backlog alert")
+                        && msg.contains("pending events: 750")
+                        && msg.contains("oldest pending: 42 minutes")
+                        && msg.contains("ev_bi_incremental_refresh")),
+                eq("mother"));
+    }
+
+    @Test
+    void scheduledRun_swallowsExceptions() {
+        when(em.createNativeQuery(anyString()))
+                .thenThrow(new RuntimeException("simulated DB outage"));
+
+        batchlet.scheduledRun();
+
+        verify(slackService, never()).sendMessage(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void scheduledRun_runsEveryFiveMinutes() throws NoSuchMethodException {
+        Method m = FactChangeLogBacklogAlertBatchlet.class.getMethod("scheduledRun");
+        io.quarkus.scheduler.Scheduled annotation =
+                m.getAnnotation(io.quarkus.scheduler.Scheduled.class);
+        assertNotNull(annotation, "scheduledRun must carry @Scheduled");
+        assertEquals("0 */5 * * * ?", annotation.cron(),
+                "Backlog alert should run every 5 minutes (aligned with ev_bi_incremental_refresh).");
+    }
+
+    private void stubBacklog(long pending, Long oldestMinutes) {
+        when(em.createNativeQuery(anyString())).thenReturn(backlogQuery);
+        when(backlogQuery.getSingleResult())
+                .thenReturn(new Object[]{Long.valueOf(pending), oldestMinutes});
+    }
+}


### PR DESCRIPTION
## Summary
Per audit of budget/availability tables (2026-05-10). Three Flyway migrations following the staging deploy verified at 2026-05-10 09:18 UTC.

- **V333**: `fact_employee_monthly` view + `sp_refresh_fact_tables` block 4 — divisor changes from `/ 8.0` to `/ 7.4` (full Trustworks consultant day), removes dead `PROBATION` classification.
- **V334**: `sp_recalculate_budgets` — discount divisor `/ 100` to align with `work_full`'s percent (0–100) interpretation. 0 contracts have discounts today (preventive).
- **V335**: drops `sp_aggregate_monthly` (no-op `DO 0;`) and removes its calls from both orchestrators.

## Production impact
- `fact_employee_monthly_mat` FTE values rise by ~8.1% on the next nightly refresh (03:00 UTC). Verified on staging:
  - Trustworks A/S BA-BILLABLE 17.13 → 18.52 (1.0811 ×)
  - Trustworks A/S PM-BILLABLE 22.20 → 24.00 (1.0811 ×)
  - Trustworks A/S SA-BILLABLE 18.94 → 20.48 (1.0813 ×)
- No data is touched, only DDL.
- No Java / TypeScript changes required.

## Test plan
- [x] Local: 3 migration files reviewed
- [x] Staging deploy: succeeded; Flyway recorded V333/V334/V335 with success=1
- [x] Staging verification: view divisor `/ 7.4` ✓, no `PROBATION` executable references ✓, `sp_recalculate_budgets` has `/ 100` ✓, `sp_aggregate_monthly` dropped ✓, FTE ratios in expected band (1.075–1.083)
- [ ] Production deploy + post-deploy probe (forthcoming)