### PR TITLE
fix(finance): correct salary + OPEX cost calculations broken by unpopulated fact_user_day.salary

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/accounting/services/IntercompanyCalcService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/accounting/services/IntercompanyCalcService.java
@@ -234,48 +234,32 @@ public class IntercompanyCalcService {
     }
 
     private Map<String, BigDecimal> staffBaseFromBI(int year, int month, double salaryBufferMultiplier) {
+        // Source: fact_salary_monthly (the canonical monthly salary fact table).
+        // Earlier versions read fact_user_day.salary, but that column is never populated
+        // by the running system — the writer (UserSalaryCalculatorService.recalculateSalary)
+        // is only invoked by the unscheduled `budget-aggregation` batch job, leaving the
+        // staff cap silently disabled. fact_salary_monthly already apportions salary
+        // per (user × company × month) via its own ETL, so no day-weighting is needed here.
+        String monthKey = String.format("%04d%02d", year, month);
         String sql = """
-        SELECT t.companyuuid, SUM(t.weighted_avg) AS staff_month_avg
-        FROM (
-            SELECT b.companyuuid,
-                   a.useruuid,
-                   a.avg_salary * (CAST(b.days_in_company AS DECIMAL(18,6)) / CAST(c.days_total AS DECIMAL(18,6))) AS weighted_avg
-            FROM (
-                SELECT useruuid, AVG(COALESCE(salary,0)) AS avg_salary
-                FROM fact_user_day
-                WHERE year = :year AND month = :month
-                  AND consultant_type = 'STAFF'
-                GROUP BY useruuid
-            ) a
-            JOIN (
-                SELECT useruuid, companyuuid, COUNT(DISTINCT day) AS days_in_company
-                FROM fact_user_day
-                WHERE year = :year AND month = :month
-                  AND consultant_type = 'STAFF'
-                  AND companyuuid IS NOT NULL
-                GROUP BY useruuid, companyuuid
-            ) b ON a.useruuid = b.useruuid
-            JOIN (
-                SELECT useruuid, COUNT(DISTINCT day) AS days_total
-                FROM fact_user_day
-                WHERE year = :year AND month = :month
-                  AND consultant_type = 'STAFF'
-                GROUP BY useruuid
-            ) c ON a.useruuid = c.useruuid AND c.days_total > 0
-        ) t
-        GROUP BY t.companyuuid
+        SELECT companyuuid, SUM(effective_salary) AS staff_month_total
+        FROM fact_salary_monthly
+        WHERE month_key = :monthKey
+          AND employee_type = 'STAFF'
+          AND employee_status = 'ACTIVE'
+          AND effective_salary > 0
+        GROUP BY companyuuid
         """;
         Query q = em.createNativeQuery(sql);
-        q.setParameter("year", year);
-        q.setParameter("month", month);
+        q.setParameter("monthKey", monthKey);
 
         Map<String, BigDecimal> map = new HashMap<>();
         @SuppressWarnings("unchecked")
         List<Object[]> rows = q.getResultList();
         for (Object[] r : rows) {
             String companyuuid = (String) r[0];
-            BigDecimal avgSum = new BigDecimal(String.valueOf(r[1]));
-            map.put(companyuuid, avgSum);
+            BigDecimal staffSum = new BigDecimal(String.valueOf(r[1]));
+            map.put(companyuuid, staffSum);
         }
 
         // Sikr nøgler for alle companies og påfør pensionsfaktor

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/DistributionAwareOpexProvider.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/DistributionAwareOpexProvider.java
@@ -390,8 +390,11 @@ public class DistributionAwareOpexProvider {
         // Salary pool cap state — must be mutable and reset per month (legacy semantics)
         Map<String, BigDecimal> staffRemainingByCompany = new HashMap<>(md.staffBaseBI102);
 
-        // Accumulator: payerUuid → costCenterId → expenseCategoryId → {amount, isPayroll}
-        Map<String, Map<String, Map<String, double[]>>> accumulator = new HashMap<>();
+        // Accumulator: payerUuid → costCenterId → expenseCategoryId → isPayroll → amount.
+        // isPayroll is a key dimension so SALARIES accounts cannot contaminate the OPEX
+        // total inside categories that mix both cost types (e.g. "Delte services" maps
+        // 84 OPEX accounts and 3 SALARIES accounts into PEOPLE_NON_BILLABLE).
+        Map<String, Map<String, Map<String, Map<Boolean, Double>>>> accumulator = new HashMap<>();
 
         for (AccountingCategory category : md.categories) {
             String groupname = category.getAccountname();  // maps to groupname column
@@ -440,23 +443,19 @@ public class DistributionAwareOpexProvider {
 
                     if (allocated.compareTo(BigDecimal.ZERO) <= 0) continue;
 
-                    // Accumulate: payerUuid → costCenterId → expenseCategoryId → [amount, payrollFlag]
+                    // Accumulate: payerUuid → costCenterId → expenseCategoryId → isPayroll → amount
                     accumulator
                             .computeIfAbsent(payerUuid, k -> new HashMap<>())
                             .computeIfAbsent(costCenterId, k -> new HashMap<>())
-                            .merge(
-                                    expenseCategoryId,
-                                    new double[]{allocated.doubleValue(), isPayroll ? 1.0 : 0.0},
-                                    (existing, incoming) -> new double[]{
-                                            existing[0] + incoming[0],
-                                            Math.max(existing[1], incoming[1])
-                                    }
-                            );
+                            .computeIfAbsent(expenseCategoryId, k -> new HashMap<>())
+                            .merge(isPayroll, allocated.doubleValue(), Double::sum);
                 }
             }
         }
 
-        // Flatten accumulator → OpexRow list
+        // Flatten accumulator → OpexRow list. Each (payer, costCenter, expenseCategory)
+        // can produce up to two rows — one with isPayroll=true and one with isPayroll=false —
+        // mirroring how fact_opex_mat keeps SALARIES and OPEX rows separate by cost_type.
         List<OpexRow> rows = new ArrayList<>();
         for (var payerEntry : accumulator.entrySet()) {
             String payerUuid = payerEntry.getKey();
@@ -464,22 +463,23 @@ public class DistributionAwareOpexProvider {
                 String costCenterId = ccEntry.getKey();
                 for (var catEntry : ccEntry.getValue().entrySet()) {
                     String expenseCategoryId = catEntry.getKey();
-                    double[] vals = catEntry.getValue();
-                    double amount = vals[0];
-                    boolean isPayroll = vals[1] > 0.0;
+                    for (var prEntry : catEntry.getValue().entrySet()) {
+                        boolean isPayroll = prEntry.getKey();
+                        double amount = prEntry.getValue();
 
-                    if (amount <= 0.0) continue;
+                        if (amount <= 0.0) continue;
 
-                    rows.add(new OpexRow(
-                            payerUuid,
-                            costCenterId,
-                            expenseCategoryId,
-                            monthKeyStr,
-                            amount,
-                            1,  // distribution rows don't have individual GL entry counts
-                            isPayroll,
-                            OpexRow.SOURCE_DISTRIBUTION
-                    ));
+                        rows.add(new OpexRow(
+                                payerUuid,
+                                costCenterId,
+                                expenseCategoryId,
+                                monthKeyStr,
+                                amount,
+                                1,  // distribution rows don't have individual GL entry counts
+                                isPayroll,
+                                OpexRow.SOURCE_DISTRIBUTION
+                        ));
+                    }
                 }
             }
         }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/analytics/ProfitabilityProvider.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/analytics/ProfitabilityProvider.java
@@ -77,25 +77,24 @@ public class ProfitabilityProvider {
         @SuppressWarnings("unchecked")
         List<Tuple> fteRows = fteQuery.getResultList();
 
-        // 2. Query salary per month from fact_user_day (same pattern as SalaryAnalyticsProvider)
+        // 2. Query salary per month from fact_salary_monthly.
+        // fact_user_day.salary is unpopulated in production (always 0); the canonical
+        // monthly consultant salary lives in fact_salary_monthly.effective_salary.
         StringBuilder salSql = new StringBuilder();
-        salSql.append("SELECT CONCAT(LPAD(yr, 4, '0'), LPAD(mn, 2, '0')) AS month_key, ");
-        salSql.append("  SUM(monthly_sal) AS total_salary ");
-        salSql.append("FROM ( ");
-        salSql.append("  SELECT fud.year AS yr, fud.month AS mn, MAX(fud.salary) AS monthly_sal ");
-        salSql.append("  FROM fact_user_day fud ");
-        salSql.append("  WHERE fud.consultant_type = 'CONSULTANT' ");
-        salSql.append("    AND fud.status_type = 'ACTIVE' AND fud.salary > 0 ");
-        salSql.append("    AND fud.document_date >= :fromDate AND fud.document_date <= :toDate ");
+        salSql.append("SELECT month_key, SUM(effective_salary) AS total_salary ");
+        salSql.append("FROM fact_salary_monthly ");
+        salSql.append("WHERE month_key >= :fromKey AND month_key <= :toKey ");
+        salSql.append("  AND employee_type = 'CONSULTANT' ");
+        salSql.append("  AND employee_status = 'ACTIVE' ");
+        salSql.append("  AND effective_salary > 0 ");
         if (companyIds != null && !companyIds.isEmpty()) {
-            salSql.append("    AND fud.companyuuid IN (:companyIds) ");
+            salSql.append("  AND companyuuid IN (:companyIds) ");
         }
-        salSql.append("  GROUP BY fud.useruuid, fud.year, fud.month ");
-        salSql.append(") per_user GROUP BY yr, mn");
+        salSql.append("GROUP BY month_key");
 
         var salQuery = em.createNativeQuery(salSql.toString(), Tuple.class);
-        salQuery.setParameter("fromDate", fromDate);
-        salQuery.setParameter("toDate", toDate);
+        salQuery.setParameter("fromKey", fromKey);
+        salQuery.setParameter("toKey", toKey);
         if (companyIds != null && !companyIds.isEmpty()) {
             salQuery.setParameter("companyIds", companyIds);
         }


### PR DESCRIPTION
## Summary

Three independent code paths read from `fact_user_day.salary`, a column whose ETL job (`budget-aggregation`) is never scheduled or manually triggered, leaving the column at `DEFAULT 0` for all 301k+ rows in production. Each path failed differently:

1. **`ProfitabilityProvider.getCostPerFte`** salary numerator returned 0 → CXO/Executive cost-per-FTE chart showed a flat-zero salary line. Now reads `fact_salary_monthly` with `employee_type='CONSULTANT'`.

2. **`DistributionAwareOpexProvider`** accumulator merged OPEX and SALARIES rows into one bucket per `(payer × costCenter × expenseCategory)` and used `Math.max` on the `isPayroll` flag. Categories like "Delte services" map 84 OPEX accounts and 3 SALARIES accounts into the same bucket; the max flag flipped the entire bucket to payroll, excluding ~50% of legitimate current-FY OPEX from the chart. Adding `isPayroll` as a key dimension keeps them separate, mirroring how `fact_opex_mat` groups by `cost_type`.

3. **`IntercompanyCalcService.staffBaseFromBI`** computed the staff salary cap from `fact_user_day.salary` and returned 0 for every company → cap branch never executed → all salary stayed with origin → INTERNAL_SERVICE intercompany invoices and `/accounting/distribution` view silently lost the staff-cost split. Now reads `fact_salary_monthly` with `employee_type='STAFF'`.

## Behaviour change for finance

Activating the staff cap will restore `Lønninger` lines on monthly INTERNAL_SERVICE drafts (~60K/month TW Tech, ~37K/month TW Cyber at current staff base; ~10× those at FY close). This restores design intent — the cap has been silently disabled since the column population path stopped running.

## Test plan
- [ ] Verify `salaryPerFteDkk` returns ~65–70K (instead of 0) on `/finance/analytics/cost-per-fte` after deploy
- [ ] Verify `opexPerFteDkk` shows ~20–40K continuously across the July 2025 boundary (no step-change to ~10K)
- [ ] Generate a monthly INTERNAL_SERVICE draft and confirm `Lønninger` line appears with reasonable amount

🤖 Generated with [Claude Code](https://claude.com/claude-code)