### PR TITLE
perf(finance): unbreak EBITDA Forecast — halve provider calls + cache response

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
@@ -59,6 +59,9 @@ import lombok.extern.jbosslog.JBossLog;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
+import io.quarkus.cache.CacheKey;
+import io.quarkus.cache.CacheResult;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -1246,13 +1249,14 @@ public class CxoFinanceResource {
      */
     @GET
     @Path("/expected-accumulated-ebitda")
+    @CacheResult(cacheName = "expected-accumulated-ebitda")
     public List<MonthlyAccumulatedEbitdaDTO> getExpectedAccumulatedEBITDA(
-            @QueryParam("asOfDate") String asOfDateStr,
-            @QueryParam("sectors") String sectors,
-            @QueryParam("serviceLines") String serviceLines,
-            @QueryParam("contractTypes") String contractTypes,
-            @QueryParam("clientId") String clientId,
-            @QueryParam("companyIds") String companyIds) {
+            @CacheKey @QueryParam("asOfDate") String asOfDateStr,
+            @CacheKey @QueryParam("sectors") String sectors,
+            @CacheKey @QueryParam("serviceLines") String serviceLines,
+            @CacheKey @QueryParam("contractTypes") String contractTypes,
+            @CacheKey @QueryParam("clientId") String clientId,
+            @CacheKey @QueryParam("companyIds") String companyIds) {
 
         log.debugf("GET /finance/cxo/expected-accumulated-ebitda: asOfDate=%s, sectors=%s, serviceLines=%s, contractTypes=%s, clientId=%s, companyIds=%s",
                 asOfDateStr, sectors, serviceLines, contractTypes, clientId, companyIds);

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
@@ -4532,8 +4532,14 @@ public class CxoFinanceService {
 
         // 2. Average monthly OPEX (OPEX-only, excluding salaries) and average monthly salaries
         //    from fact_opex over TTM period. Both are used for projected future months.
-        double avgMonthlyOpex     = queryAvgMonthlyOpex(ttmFromKey, ttmToKey, companyIds);
-        double avgMonthlySalaries = queryAvgMonthlySalaries(ttmFromKey, ttmToKey, companyIds);
+        //    Fetch the TTM OpexRow list ONCE and filter twice — earlier this made 2 separate
+        //    DistributionAwareOpexProvider calls per range, each triggering its own
+        //    IntercompanyCalcService.loadFiscalYear (~27k finance_details rows). Halving
+        //    the call count cuts the cold-path latency that was timing out at the 60s ALB.
+        List<dk.trustworks.intranet.aggregates.finance.dto.OpexRow> ttmOpexRows =
+                opexProvider.getDistributionAwareOpex(ttmFromKey, ttmToKey, companyIds, null, null);
+        double avgMonthlyOpex     = averageMonthlyAmount(ttmOpexRows, row -> !row.isPayrollFlag());
+        double avgMonthlySalaries = averageMonthlyAmount(ttmOpexRows, dk.trustworks.intranet.aggregates.finance.dto.OpexRow::isPayrollFlag);
 
         log.debugf("TTM gross margin=%.2f%%, avg monthly OPEX=%.2f DKK, avg monthly salaries=%.2f DKK",
                 ttmGrossMarginPct, avgMonthlyOpex, avgMonthlySalaries);
@@ -4555,8 +4561,11 @@ public class CxoFinanceService {
         }
 
         // 4. Actual OPEX (OPEX-only) and salaries by month — separate fields per spec.
-        java.util.Map<String, Double> opexByMonth     = queryMonthlyOpex(fyFromKey, fyToKey, companyIds);
-        java.util.Map<String, Double> salariesByMonth = queryMonthlySalaries(fyFromKey, fyToKey, companyIds);
+        //    Same single-fetch + dual-filter optimization as in step 2 above, but for the FY window.
+        List<dk.trustworks.intranet.aggregates.finance.dto.OpexRow> fyOpexRows =
+                opexProvider.getDistributionAwareOpex(fyFromKey, fyToKey, companyIds, null, null);
+        java.util.Map<String, Double> opexByMonth     = sumByMonth(fyOpexRows, row -> !row.isPayrollFlag());
+        java.util.Map<String, Double> salariesByMonth = sumByMonth(fyOpexRows, dk.trustworks.intranet.aggregates.finance.dto.OpexRow::isPayrollFlag);
 
         // 4b. Actual internal invoice cost by month (intercompany INTERNAL invoices)
         java.util.Map<String, Double> internalCostByMonth = queryMonthlyInternalInvoiceCost(fyFromKey, fyToKey, companyIds);
@@ -5127,6 +5136,47 @@ public class CxoFinanceService {
 
         Object[] row = (Object[]) query.getSingleResult();
         return new double[]{((Number) row[0]).doubleValue(), ((Number) row[1]).doubleValue()};
+    }
+
+    /**
+     * Helper: Average monthly amount across a pre-fetched {@link OpexRow} list, filtered by predicate.
+     *
+     * <p>Used by {@link #getExpectedAccumulatedEBITDA} to compute both
+     * {@code avgMonthlyOpex} (non-payroll rows) and {@code avgMonthlySalaries} (payroll rows)
+     * from a single {@code DistributionAwareOpexProvider.getDistributionAwareOpex} fetch —
+     * each underlying fetch triggers {@code IntercompanyCalcService.loadFiscalYear} which
+     * scans every {@code finance_details} row for the FY range, so doing the fetch once and
+     * filtering twice is significantly cheaper on cold paths.
+     */
+    private double averageMonthlyAmount(
+            List<dk.trustworks.intranet.aggregates.finance.dto.OpexRow> rows,
+            java.util.function.Predicate<dk.trustworks.intranet.aggregates.finance.dto.OpexRow> filter) {
+        double total = 0.0;
+        java.util.Set<String> months = new java.util.HashSet<>();
+        for (dk.trustworks.intranet.aggregates.finance.dto.OpexRow row : rows) {
+            if (filter.test(row)) {
+                total += row.opexAmountDkk();
+                months.add(row.monthKey());
+            }
+        }
+        return months.isEmpty() ? 0.0 : total / months.size();
+    }
+
+    /**
+     * Helper: Sum amounts per month across a pre-fetched {@link OpexRow} list, filtered by predicate.
+     * Same single-fetch + dual-filter optimization rationale as
+     * {@link #averageMonthlyAmount(List, java.util.function.Predicate)}.
+     */
+    private java.util.Map<String, Double> sumByMonth(
+            List<dk.trustworks.intranet.aggregates.finance.dto.OpexRow> rows,
+            java.util.function.Predicate<dk.trustworks.intranet.aggregates.finance.dto.OpexRow> filter) {
+        java.util.Map<String, Double> byMonth = new java.util.TreeMap<>();
+        for (dk.trustworks.intranet.aggregates.finance.dto.OpexRow row : rows) {
+            if (filter.test(row)) {
+                byMonth.merge(row.monthKey(), row.opexAmountDkk(), Double::sum);
+            }
+        }
+        return byMonth;
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -170,6 +170,9 @@ quarkus:
       consultant-allocation:
         expire-after-write: 1H  # Consultant allocation cache (1 hour TTL)
         maximum-size: 1000  # Maximum number of allocation entries
+      expected-accumulated-ebitda:
+        expire-after-write: 5M  # EBITDA chart cold-path takes ~minutes; cache the full response
+        maximum-size: 200       # ~200 distinct (asOfDate, filter) combinations is generous
       page-registry:
         expire-after-write: 5M  # Page registry cache (5 min TTL for quick updates)
         maximum-size: 100  # Small table - only ~20-50 pages expected


### PR DESCRIPTION
## Summary

The "EBITDA Forecast" chart on \`/executive-dashboard\` was loading for ~60s then showing "No data available". Production probe with M2M token confirmed \`GET /finance/cxo/expected-accumulated-ebitda\` returns **HTTP 504 at exactly 60.2s** (ALB timeout). BFF then returns 500 to the frontend; SWR retries disabled per project convention → \`data = []\` → chart's \`if (!data.length)\` branch renders "No data available".

## Why slow

\`CxoFinanceService.getExpectedAccumulatedEBITDA\` made **4 separate calls** into \`DistributionAwareOpexProvider.getDistributionAwareOpex\`:
- \`queryAvgMonthlyOpex(ttmFromKey, ttmToKey, …)\`
- \`queryAvgMonthlySalaries(ttmFromKey, ttmToKey, …)\`  ← same range as above
- \`queryMonthlyOpex(fyFromKey, fyToKey, …)\`
- \`queryMonthlySalaries(fyFromKey, fyToKey, …)\`  ← same range as above

Each call independently triggered \`IntercompanyCalcService.loadFiscalYear\`, which scans every \`finance_details\` row for the FY range (~27k rows for FY 2025/26) and loads the full employee-availability matrix. With 11/11 elapsed FY months currently unsettled (no INTERNAL_SERVICE invoices issued yet for FY 2025/26), the distribution algorithm runs over all of them — and the \`@CacheResult\` on \`computeDistributionForMonth\` only caches per-month, not the outer per-range load.

## Fix

1. **Consolidate 4 OPEX provider calls into 2** (one per range — TTM, FY). Fetch the \`OpexRow\` list once per range and filter twice in-memory via two new helpers (\`averageMonthlyAmount\`, \`sumByMonth\`). Cuts cold-path latency roughly in half.

2. **Cache the resource-method response** with \`@CacheResult(cacheName="expected-accumulated-ebitda")\` + new Caffeine TTL entry (5 min, max 200 entries) in \`application.yml\`. Warm hits return instantly — repeated dashboard reloads within the TTL window no longer trigger the expensive math.

## What's NOT changed

- Fix 2 from the plan (raising BFF timeout) was skipped: raising past 60s doesn't help because the ALB itself caps at 60s. The fix must make the backend faster.
- The 4 now-unused private query helpers (\`queryAvgMonthlyOpex\`, etc.) are kept to keep this PR focused on the perf fix. Follow-up can remove them.

## Test plan
- [ ] Production deploy completes
- [ ] \`curl\` against \`/finance/cxo/expected-accumulated-ebitda\` with M2M token returns 200 in <30s (cold)
- [ ] Second \`curl\` (warm cache) returns 200 in <1s
- [ ] \`EbitdaForecastChart\` renders monthly bars + accumulated line on the Executive Summary tab
- [ ] No regression: Cost-tab charts still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)