### PR TITLE
Stamp supplier number and VAT code on INTERNAL invoice e-conomic upload

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSupplierResolver.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSupplierResolver.java
@@ -30,6 +30,8 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class EconomicsSupplierResolver {
 
+    private static final String CVR_FILTER_PREFIX = "corporateIdentificationNumber$eq:";
+
     @Inject
     EconomicsAgreementResolver agreementResolver;
 
@@ -67,7 +69,7 @@ public class EconomicsSupplierResolver {
             page = suppliersApi.findByFilter(
                     tokens.appSecret(),
                     tokens.agreementGrant(),
-                    "corporateIdentificationNumber$eq:" + issuerCvr);
+                    CVR_FILTER_PREFIX + issuerCvr);
         } catch (RuntimeException e) {
             log.errorf(e, "Supplier resolve failed for CVR %s in debtor %s: API error",
                     issuerCvr, debtorCompanyUuid);

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSupplierResolver.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSupplierResolver.java
@@ -1,0 +1,101 @@
+package dk.trustworks.intranet.aggregates.invoice.economics.supplier;
+
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto.SupplierDto;
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto.SuppliersPage;
+import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver;
+import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver.Tokens;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.jbosslog.JBossLog;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Resolves an issuer company's e-conomic supplier number in a debtor company's
+ * e-conomic agreement by looking up the issuer's CVR via the legacy /suppliers
+ * endpoint.
+ *
+ * <p>Used by {@code EconomicsInvoiceService} to enrich the debtor-side
+ * {@code SupplierInvoice} voucher for INTERNAL and INTERNAL_SERVICE invoices.
+ *
+ * <p>This resolver never throws. All non-happy paths return
+ * {@link Optional#empty()} so the caller can fall back to today's behavior of
+ * posting the voucher without a supplier reference. The caller logs the
+ * fallback so finance can act on the bookkeeping side.
+ */
+@JBossLog
+@ApplicationScoped
+public class EconomicsSupplierResolver {
+
+    @Inject
+    EconomicsAgreementResolver agreementResolver;
+
+    @Inject
+    @RestClient
+    EconomicsSuppliersApiClient suppliersApi;
+
+    /**
+     * Returns the supplier number in the debtor company's e-conomic whose
+     * {@code corporateIdentificationNumber} equals {@code issuerCvr}.
+     *
+     * @return the supplier number on exact-one match; {@link Optional#empty()}
+     *         when the CVR is null/blank, zero suppliers match, multiple
+     *         suppliers match (ambiguous), the debtor's integration keys are
+     *         missing, or the /suppliers call fails for any reason.
+     */
+    public Optional<Integer> resolveByCvr(String debtorCompanyUuid, String issuerCvr) {
+        if (issuerCvr == null || issuerCvr.isBlank()) {
+            log.warnf("Supplier resolve skipped: issuer CVR is null/blank for debtor %s",
+                    debtorCompanyUuid);
+            return Optional.empty();
+        }
+
+        Tokens tokens;
+        try {
+            tokens = agreementResolver.tokens(debtorCompanyUuid);
+        } catch (RuntimeException e) {
+            log.errorf(e, "Supplier resolve failed: cannot load debtor %s integration keys",
+                    debtorCompanyUuid);
+            return Optional.empty();
+        }
+
+        SuppliersPage page;
+        try {
+            page = suppliersApi.findByFilter(
+                    tokens.appSecret(),
+                    tokens.agreementGrant(),
+                    "corporateIdentificationNumber$eq:" + issuerCvr);
+        } catch (RuntimeException e) {
+            log.errorf(e, "Supplier resolve failed for CVR %s in debtor %s: API error",
+                    issuerCvr, debtorCompanyUuid);
+            return Optional.empty();
+        }
+
+        List<SupplierDto> matches = page == null || page.getCollection() == null
+                ? List.of()
+                : page.getCollection();
+
+        if (matches.isEmpty()) {
+            log.warnf("Supplier resolve: zero matches for CVR %s in debtor %s",
+                    issuerCvr, debtorCompanyUuid);
+            return Optional.empty();
+        }
+
+        if (matches.size() > 1) {
+            String numbers = matches.stream()
+                    .map(s -> String.valueOf(s.getSupplierNumber()))
+                    .collect(Collectors.joining(", "));
+            log.warnf("Supplier resolve: ambiguous match for CVR %s in debtor %s -- candidates [%s]",
+                    issuerCvr, debtorCompanyUuid, numbers);
+            return Optional.empty();
+        }
+
+        int supplierNumber = matches.get(0).getSupplierNumber();
+        log.infof("Resolved issuer CVR %s -> supplier number %d in debtor %s",
+                issuerCvr, supplierNumber, debtorCompanyUuid);
+        return Optional.of(supplierNumber);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSuppliersApiClient.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSuppliersApiClient.java
@@ -1,0 +1,35 @@
+package dk.trustworks.intranet.aggregates.invoice.economics.supplier;
+
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto.SuppliersPage;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+/**
+ * MicroProfile REST client for e-conomic's legacy /suppliers endpoint.
+ *
+ * Reuses the existing {@code economics-legacy-rest} configKey which is already
+ * mapped to {@code https://restapi.e-conomic.com} in application.yml.
+ *
+ * Used by {@link EconomicsSupplierResolver} to resolve an issuer company's
+ * supplier number in a debtor company's e-conomic agreement by CVR.
+ */
+@RegisterRestClient(configKey = "economics-legacy-rest")
+@Produces(MediaType.APPLICATION_JSON)
+public interface EconomicsSuppliersApiClient {
+
+    /**
+     * Returns the suppliers in the agreement that match the given filter.
+     * Filter syntax: {@code corporateIdentificationNumber$eq:{cvr}}.
+     */
+    @GET
+    @Path("/suppliers")
+    SuppliersPage findByFilter(
+            @HeaderParam("X-AppSecretToken") String appSecret,
+            @HeaderParam("X-AgreementGrantToken") String agreementGrant,
+            @QueryParam("filter") String filter);
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSuppliersApiClient.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSuppliersApiClient.java
@@ -23,7 +23,6 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 public interface EconomicsSuppliersApiClient {
 
     /**
-     * Returns the suppliers in the agreement that match the given filter.
      * Filter syntax: {@code corporateIdentificationNumber$eq:{cvr}}.
      */
     @GET

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/dto/SupplierDto.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/dto/SupplierDto.java
@@ -1,0 +1,36 @@
+package dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Minimal view of an e-conomic supplier returned by GET /suppliers.
+ * Only the fields the resolver needs are mapped; all others are ignored.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SupplierDto {
+
+    @JsonProperty("supplierNumber")
+    public int supplierNumber;
+
+    @JsonProperty("corporateIdentificationNumber")
+    public String corporateIdentificationNumber;
+
+    public SupplierDto() {}
+
+    public int getSupplierNumber() {
+        return supplierNumber;
+    }
+
+    public void setSupplierNumber(int supplierNumber) {
+        this.supplierNumber = supplierNumber;
+    }
+
+    public String getCorporateIdentificationNumber() {
+        return corporateIdentificationNumber;
+    }
+
+    public void setCorporateIdentificationNumber(String corporateIdentificationNumber) {
+        this.corporateIdentificationNumber = corporateIdentificationNumber;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/dto/SupplierDto.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/dto/SupplierDto.java
@@ -2,35 +2,20 @@ package dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Minimal view of an e-conomic supplier returned by GET /suppliers.
  * Only the fields the resolver needs are mapped; all others are ignored.
  */
+@Getter @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SupplierDto {
 
     @JsonProperty("supplierNumber")
-    public int supplierNumber;
+    private int supplierNumber;
 
     @JsonProperty("corporateIdentificationNumber")
-    public String corporateIdentificationNumber;
-
-    public SupplierDto() {}
-
-    public int getSupplierNumber() {
-        return supplierNumber;
-    }
-
-    public void setSupplierNumber(int supplierNumber) {
-        this.supplierNumber = supplierNumber;
-    }
-
-    public String getCorporateIdentificationNumber() {
-        return corporateIdentificationNumber;
-    }
-
-    public void setCorporateIdentificationNumber(String corporateIdentificationNumber) {
-        this.corporateIdentificationNumber = corporateIdentificationNumber;
-    }
+    private String corporateIdentificationNumber;
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/dto/SuppliersPage.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/dto/SuppliersPage.java
@@ -2,6 +2,8 @@ package dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,19 +12,10 @@ import java.util.List;
  * Paged response wrapper for e-conomic GET /suppliers.
  * Only the {@code collection} field is mapped; pagination/meta fields are ignored.
  */
+@Getter @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SuppliersPage {
 
     @JsonProperty("collection")
-    public List<SupplierDto> collection = new ArrayList<>();
-
-    public SuppliersPage() {}
-
-    public List<SupplierDto> getCollection() {
-        return collection;
-    }
-
-    public void setCollection(List<SupplierDto> collection) {
-        this.collection = collection;
-    }
+    private List<SupplierDto> collection = new ArrayList<>();
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/dto/SuppliersPage.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/dto/SuppliersPage.java
@@ -1,0 +1,28 @@
+package dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Paged response wrapper for e-conomic GET /suppliers.
+ * Only the {@code collection} field is mapped; pagination/meta fields are ignored.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SuppliersPage {
+
+    @JsonProperty("collection")
+    public List<SupplierDto> collection = new ArrayList<>();
+
+    public SuppliersPage() {}
+
+    public List<SupplierDto> getCollection() {
+        return collection;
+    }
+
+    public void setCollection(List<SupplierDto> collection) {
+        this.collection = collection;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/Supplier.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/Supplier.java
@@ -2,8 +2,10 @@ package dk.trustworks.intranet.expenseservice.remote.dto.economics;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"supplierNumber"})
 public class Supplier {
 
     @JsonProperty("supplierNumber")

--- a/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/Supplier.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/Supplier.java
@@ -1,0 +1,32 @@
+package dk.trustworks.intranet.expenseservice.remote.dto.economics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Supplier {
+
+    @JsonProperty("supplierNumber")
+    public int supplierNumber;
+
+    public Supplier() {}
+
+    public Supplier(int supplierNumber) {
+        this.supplierNumber = supplierNumber;
+    }
+
+    @JsonProperty("supplierNumber")
+    public int getSupplierNumber() {
+        return supplierNumber;
+    }
+
+    @JsonProperty("supplierNumber")
+    public void setSupplierNumber(int supplierNumber) {
+        this.supplierNumber = supplierNumber;
+    }
+
+    @Override
+    public String toString() {
+        return "Supplier{supplierNumber=" + supplierNumber + "}";
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/SupplierInvoice.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/SupplierInvoice.java
@@ -7,9 +7,11 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
         "account",
+        "supplier",
         "text",
         "amount",
         "contraAccount",
+        "contraVatAccount",
         "supplierInvoiceNumber",
         "date"
 })
@@ -27,6 +29,12 @@ public class SupplierInvoice {
     public String date;
     @JsonProperty("supplierInvoiceNumber")
     public String supplierInvoiceNumber;
+
+    @JsonProperty("supplier")
+    public Supplier supplier;
+
+    @JsonProperty("contraVatAccount")
+    public VatAccount contraVatAccount;
 
     public SupplierInvoice(){
 
@@ -101,13 +109,35 @@ public class SupplierInvoice {
         this.supplierInvoiceNumber = supplierInvoiceNumber;
     }
 
+    @JsonProperty("supplier")
+    public Supplier getSupplier() {
+        return supplier;
+    }
+
+    @JsonProperty("supplier")
+    public void setSupplier(Supplier supplier) {
+        this.supplier = supplier;
+    }
+
+    @JsonProperty("contraVatAccount")
+    public VatAccount getContraVatAccount() {
+        return contraVatAccount;
+    }
+
+    @JsonProperty("contraVatAccount")
+    public void setContraVatAccount(VatAccount contraVatAccount) {
+        this.contraVatAccount = contraVatAccount;
+    }
+
     @Override
     public String toString() {
         return "SupplierInvoice{" +
                 "account='" + account + '\'' +
+                ", supplier=" + supplier +
                 ", text='" + text + '\'' +
                 ", amount='" + amount + '\'' +
                 ", contraAccount='" + contraAccount + '\'' +
+                ", contraVatAccount=" + contraVatAccount +
                 ", supplierInvoiceNumber=" + supplierInvoiceNumber +
                 ", date='" + date +
                 '}';

--- a/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/VatAccount.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/VatAccount.java
@@ -1,0 +1,32 @@
+package dk.trustworks.intranet.expenseservice.remote.dto.economics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class VatAccount {
+
+    @JsonProperty("vatCode")
+    public String vatCode;
+
+    public VatAccount() {}
+
+    public VatAccount(String vatCode) {
+        this.vatCode = vatCode;
+    }
+
+    @JsonProperty("vatCode")
+    public String getVatCode() {
+        return vatCode;
+    }
+
+    @JsonProperty("vatCode")
+    public void setVatCode(String vatCode) {
+        this.vatCode = vatCode;
+    }
+
+    @Override
+    public String toString() {
+        return "VatAccount{vatCode='" + vatCode + "'}";
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/VatAccount.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/VatAccount.java
@@ -2,8 +2,10 @@ package dk.trustworks.intranet.expenseservice.remote.dto.economics;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"vatCode"})
 public class VatAccount {
 
     @JsonProperty("vatCode")

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -8,6 +8,7 @@ import dk.trustworks.intranet.expenseservice.exceptions.PdfNotYetRenderedExcepti
 import dk.trustworks.intranet.financeservice.model.IntegrationKey;
 import dk.trustworks.intranet.financeservice.remote.EconomicsDynamicHeaderFilter;
 import dk.trustworks.intranet.aggregates.invoice.economics.book.EconomicsBookingApiClient;
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.EconomicsSupplierResolver;
 import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
 import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver;
 import dk.trustworks.intranet.aggregates.invoice.utils.StringUtils;
@@ -30,13 +31,20 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @JBossLog
 @ApplicationScoped
 public class EconomicsInvoiceService {
 
+    /** Hardcoded Danish 25% purchase VAT code applied to account 2101 on INTERNAL invoices. */
+    private static final String INTERCOMPANY_VAT_CODE = "I25";
+
     @Inject
     InvoicePdfS3Service invoicePdfS3Service;
+
+    @Inject
+    EconomicsSupplierResolver supplierResolver;
 
     @Inject
     @RestClient
@@ -148,8 +156,34 @@ public class EconomicsInvoiceService {
         // Check if this is an internal journal (supplier invoice) or regular journal (customer invoice)
         if (journal.getJournalNumber() == integrationKeyValue.internalJournalNumber()) {
             log.info("Creating supplier invoice for number " + invoice.getInvoicenumber());
-            SupplierInvoice supplierInvoice = new SupplierInvoice(account, StringUtils.convertInvoiceNumberToString(invoice.getInvoicenumber()), text, invoice.getGrandTotal() != null ? invoice.getGrandTotal() : 0.0, contraAccount, date);
-            log.debug("SupplierInvoice text=" + supplierInvoice.text + ", contraAccount=" + contraAccount.getAccountNumber());
+            SupplierInvoice supplierInvoice = new SupplierInvoice(
+                    account,
+                    StringUtils.convertInvoiceNumberToString(invoice.getInvoicenumber()),
+                    text,
+                    invoice.getGrandTotal() != null ? invoice.getGrandTotal() : 0.0,
+                    contraAccount,
+                    date);
+
+            String issuerCvr = invoice.getCompany() != null ? invoice.getCompany().getCvr() : null;
+            Optional<Integer> resolvedSupplier = supplierResolver.resolveByCvr(
+                    targetCompany.getUuid(), issuerCvr);
+            if (resolvedSupplier.isPresent()) {
+                supplierInvoice.setSupplier(new Supplier(resolvedSupplier.get()));
+                supplierInvoice.setContraVatAccount(new VatAccount(INTERCOMPANY_VAT_CODE));
+                log.infof("Enriched SupplierInvoice for invoice %s with supplier %d and vatCode %s",
+                        invoice.getUuid(), resolvedSupplier.get(), INTERCOMPANY_VAT_CODE);
+            } else {
+                log.warnf(
+                        "INTERNAL invoice %s: no supplier in debtor %s e-conomic for CVR %s — posting without supplier/VAT",
+                        invoice.getUuid(),
+                        targetCompany.getName(),
+                        issuerCvr);
+            }
+
+            log.debug("SupplierInvoice text=" + supplierInvoice.text
+                    + ", contraAccount=" + contraAccount.getAccountNumber()
+                    + ", supplier=" + supplierInvoice.getSupplier()
+                    + ", contraVatAccount=" + supplierInvoice.getContraVatAccount());
             List<SupplierInvoice> supplierInvoices = new ArrayList<>();
             supplierInvoices.add(supplierInvoice);
             entries.setSupplierInvoices(supplierInvoices);

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -180,10 +180,11 @@ public class EconomicsInvoiceService {
                         issuerCvr);
             }
 
-            log.debug("SupplierInvoice text=" + supplierInvoice.text
-                    + ", contraAccount=" + contraAccount.getAccountNumber()
-                    + ", supplier=" + supplierInvoice.getSupplier()
-                    + ", contraVatAccount=" + supplierInvoice.getContraVatAccount());
+            log.debugf("SupplierInvoice text=%s, contraAccount=%s, supplier=%s, contraVatAccount=%s",
+                    supplierInvoice.text,
+                    contraAccount.getAccountNumber(),
+                    supplierInvoice.getSupplier(),
+                    supplierInvoice.getContraVatAccount());
             List<SupplierInvoice> supplierInvoices = new ArrayList<>();
             supplierInvoices.add(supplierInvoice);
             entries.setSupplierInvoices(supplierInvoices);

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSupplierResolverTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSupplierResolverTest.java
@@ -1,0 +1,125 @@
+package dk.trustworks.intranet.aggregates.invoice.economics.supplier;
+
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto.SupplierDto;
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto.SuppliersPage;
+import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver;
+import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver.Tokens;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EconomicsSupplierResolverTest {
+
+    @InjectMocks EconomicsSupplierResolver resolver;
+
+    @Mock EconomicsAgreementResolver agreementResolver;
+    @Mock EconomicsSuppliersApiClient suppliersApi;
+
+    private static final String DEBTOR_UUID = "debtor-1";
+    private static final String ISSUER_CVR = "44232855";
+
+    private void agreementTokens() {
+        when(agreementResolver.tokens(DEBTOR_UUID))
+                .thenReturn(new Tokens("app-secret", "agreement-grant"));
+    }
+
+    private SuppliersPage page(SupplierDto... items) {
+        SuppliersPage p = new SuppliersPage();
+        p.setCollection(List.of(items));
+        return p;
+    }
+
+    private SupplierDto supplier(int number, String cvr) {
+        SupplierDto s = new SupplierDto();
+        s.setSupplierNumber(number);
+        s.setCorporateIdentificationNumber(cvr);
+        return s;
+    }
+
+    @Test
+    void single_match_returns_supplier_number() {
+        agreementTokens();
+        when(suppliersApi.findByFilter("app-secret", "agreement-grant",
+                "corporateIdentificationNumber$eq:" + ISSUER_CVR))
+                .thenReturn(page(supplier(50007, ISSUER_CVR)));
+
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, ISSUER_CVR);
+
+        assertTrue(result.isPresent());
+        assertEquals(50007, result.get());
+    }
+
+    @Test
+    void zero_matches_returns_empty() {
+        agreementTokens();
+        when(suppliersApi.findByFilter(anyString(), anyString(), anyString()))
+                .thenReturn(page());
+
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, ISSUER_CVR);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void multiple_matches_returns_empty() {
+        agreementTokens();
+        when(suppliersApi.findByFilter(anyString(), anyString(), anyString()))
+                .thenReturn(page(supplier(50007, ISSUER_CVR), supplier(50008, ISSUER_CVR)));
+
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, ISSUER_CVR);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void null_cvr_returns_empty_without_api_call() {
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, null);
+
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(suppliersApi);
+        verifyNoInteractions(agreementResolver);
+    }
+
+    @Test
+    void blank_cvr_returns_empty_without_api_call() {
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, "   ");
+
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(suppliersApi);
+        verifyNoInteractions(agreementResolver);
+    }
+
+    @Test
+    void api_exception_returns_empty() {
+        agreementTokens();
+        when(suppliersApi.findByFilter(anyString(), anyString(), anyString()))
+                .thenThrow(new WebApplicationException(Response.serverError().build()));
+
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, ISSUER_CVR);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void agreement_resolver_failure_returns_empty() {
+        when(agreementResolver.tokens(DEBTOR_UUID))
+                .thenThrow(new IllegalStateException("no integration keys"));
+
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, ISSUER_CVR);
+
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(suppliersApi);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceTest.java
@@ -1,11 +1,16 @@
 package dk.trustworks.intranet.expenseservice.services;
 
 import dk.trustworks.intranet.aggregates.invoice.economics.book.EconomicsBookingApiClient;
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.EconomicsSupplierResolver;
 import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
 import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver;
 import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver.Tokens;
 import dk.trustworks.intranet.aggregates.invoice.services.InvoicePdfS3Service;
 import dk.trustworks.intranet.expenseservice.exceptions.PdfNotYetRenderedException;
+import dk.trustworks.intranet.expenseservice.remote.dto.economics.Journal;
+import dk.trustworks.intranet.expenseservice.remote.dto.economics.SupplierInvoice;
+import dk.trustworks.intranet.expenseservice.remote.dto.economics.Voucher;
+import dk.trustworks.intranet.financeservice.model.IntegrationKey;
 import dk.trustworks.intranet.model.Company;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
@@ -37,6 +42,7 @@ class EconomicsInvoiceServiceTest {
     @Mock InvoicePdfS3Service invoicePdfS3Service;
     @Mock EconomicsBookingApiClient bookingApi;
     @Mock EconomicsAgreementResolver agreementResolver;
+    @Mock EconomicsSupplierResolver supplierResolver;
 
     @Test
     void loadInvoicePdfBytes_reads_from_s3_when_storage_key_present() throws IOException {
@@ -130,5 +136,111 @@ class EconomicsInvoiceServiceTest {
         inv.setCompany(company);
         inv.setEconomicsBookedNumber(bookedNumber);
         return inv;
+    }
+
+    private Invoice internalInvoiceWithCvr(String invoiceUuid,
+                                           String issuerUuid,
+                                           String issuerCvr,
+                                           String debtorUuid) {
+        Invoice inv = new Invoice();
+        inv.setUuid(invoiceUuid);
+        inv.setInvoicenumber(20240315);
+        inv.setClientname("Trustworks A/S");
+        inv.setGrandTotal(12500.00);
+        inv.setInvoicedate(java.time.LocalDate.of(2025, 2, 14));
+
+        Company issuer = new Company();
+        issuer.setUuid(issuerUuid);
+        issuer.setName("Trustworks A/S");
+        issuer.setCvr(issuerCvr);
+        inv.setCompany(issuer);
+
+        inv.setDebtorCompanyuuid(debtorUuid);
+
+        return inv;
+    }
+
+    @Test
+    void buildJSONRequest_internalJournal_enrichesWhenSupplierResolved() {
+        Invoice inv = internalInvoiceWithCvr("inv-int-1", "issuer-1", "44232855", "debtor-1");
+
+        IntegrationKey.IntegrationKeyValue keys = new IntegrationKey.IntegrationKeyValue(
+                "https://restapi.e-conomic.com",
+                "app-secret",
+                "agreement-grant",
+                /*expenseJournalNumber*/ 1,
+                /*invoiceJournalNumber*/ 5,
+                /*invoiceAccountNumber*/ 2101,
+                /*internalJournalNumber*/ 7,
+                /*invoiceProductNumber*/ 1);
+
+        Company debtor = new Company();
+        debtor.setUuid("debtor-1");
+        debtor.setName("Trustworks NO AS");
+
+        Journal journal = new Journal(7);  // internal journal
+        when(supplierResolver.resolveByCvr("debtor-1", "44232855"))
+                .thenReturn(java.util.Optional.of(50007));
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "text", keys, debtor);
+
+        java.util.List<SupplierInvoice> supplierInvoices = voucher.getEntries().getSupplierInvoices();
+        assertNotNull(supplierInvoices);
+        assertEquals(1, supplierInvoices.size());
+        SupplierInvoice si = supplierInvoices.get(0);
+        assertNotNull(si.getSupplier(), "supplier should be set");
+        assertEquals(50007, si.getSupplier().getSupplierNumber());
+        assertNotNull(si.getContraVatAccount(), "contraVatAccount should be set");
+        assertEquals("I25", si.getContraVatAccount().getVatCode());
+        // Customer-invoice list must be null in the supplier-journal branch
+        assertNull(voucher.getEntries().getManualCustomerInvoices());
+    }
+
+    @Test
+    void buildJSONRequest_internalJournal_omitsEnrichmentWhenResolverEmpty() {
+        Invoice inv = internalInvoiceWithCvr("inv-int-2", "issuer-1", "44232855", "debtor-1");
+
+        IntegrationKey.IntegrationKeyValue keys = new IntegrationKey.IntegrationKeyValue(
+                "https://restapi.e-conomic.com",
+                "app-secret",
+                "agreement-grant",
+                1, 5, 2101, 7, 1);
+
+        Company debtor = new Company();
+        debtor.setUuid("debtor-1");
+        debtor.setName("Trustworks NO AS");
+
+        Journal journal = new Journal(7);
+        when(supplierResolver.resolveByCvr("debtor-1", "44232855"))
+                .thenReturn(java.util.Optional.empty());
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "text", keys, debtor);
+
+        SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
+        assertNull(si.getSupplier(), "supplier must remain unset when resolver returns empty");
+        assertNull(si.getContraVatAccount(), "contraVatAccount must remain unset when resolver returns empty");
+    }
+
+    @Test
+    void buildJSONRequest_customerJournal_doesNotInvokeResolver() {
+        Invoice inv = internalInvoiceWithCvr("inv-cust-1", "issuer-1", "44232855", "debtor-1");
+
+        IntegrationKey.IntegrationKeyValue keys = new IntegrationKey.IntegrationKeyValue(
+                "https://restapi.e-conomic.com",
+                "app-secret",
+                "agreement-grant",
+                1, 5, 2101, 7, 1);
+
+        Company issuerAsTarget = new Company();
+        issuerAsTarget.setUuid("issuer-1");
+        issuerAsTarget.setName("Trustworks A/S");
+
+        Journal journal = new Journal(5);  // customer journal (NOT internal)
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "text", keys, issuerAsTarget);
+
+        assertNull(voucher.getEntries().getSupplierInvoices());
+        assertNotNull(voucher.getEntries().getManualCustomerInvoices());
+        verifyNoInteractions(supplierResolver);
     }
 }


### PR DESCRIPTION
## Summary
- When finalizing an INTERNAL or INTERNAL_SERVICE invoice, the debtor-side `SupplierInvoice` voucher now includes the issuer's supplier number (resolved on the fly from the debtor's e-conomic via CVR) and `contraVatAccount.vatCode = "I25"` on account 2101 — removing the bookkeeper's manual fill-in step.
- Resolution is best-effort: zero matches, ambiguous matches, missing CVR, or API errors all fall back to today's behavior (voucher posted without supplier/VAT). Finalization is never blocked. WARN logs identify what to fix in e-conomic master data.
- No DB migration, no new integration_keys, no `application.yml` changes (reuses the existing `economics-legacy-rest` REST client).

## Implementation
- New `EconomicsSupplierResolver` + `EconomicsSuppliersApiClient` under `aggregates/invoice/economics/supplier/`.
- New DTOs: `Supplier`, `VatAccount` (request side), `SupplierDto`, `SuppliersPage` (response side).
- `SupplierInvoice` DTO extended with optional `supplier` + `contraVatAccount` fields (`@JsonInclude(NON_NULL)` — absent when null, so existing happy paths produce byte-identical payloads).
- `EconomicsInvoiceService.buildJSONRequest` enrichment gated to the internal-journal branch only; customer-journal branch untouched.

## Test plan
- [x] Unit: `EconomicsSupplierResolverTest` — 7/7 pass (single match, zero, ambiguous, null CVR, blank CVR, API exception, agreement-resolver failure)
- [x] Unit: `EconomicsInvoiceServiceTest` — 9/9 pass (6 existing PDF-loading tests + 3 new enrichment tests: resolved, empty, customer-journal isolation)
- [ ] Staging smoke: finalize one INTERNAL invoice between two sister companies; confirm the debtor's draft voucher has supplier line + VAT code I25 on 2101 + PDF attached
- [ ] Watch logs on first finalization for `Enriched SupplierInvoice ...` (happy) or `INTERNAL invoice ...: no supplier in debtor ... e-conomic for CVR ...` (means add the supplier in that debtor's e-conomic; voucher still posted)

## Operational prerequisite
The issuer company must exist as a `Supplier` in each debtor company's e-conomic with the issuer's CVR populated under `corporateIdentificationNumber`. If missing on first roll-out, the voucher posts without the new fields (same as today) — finance can add the supplier at any time and the next INTERNAL invoice picks it up.

## Spec & plan
- Spec: docs/superpowers/specs/2026-05-11-internal-invoice-supplier-vat-upload-design.md
- Plan: docs/superpowers/plans/2026-05-11-internal-invoice-supplier-vat-upload.md
- Docs updated: docs/finalized/operating-costs/e-conomics-integration.md §5.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)