### PR TITLE
Production deploy: supplier+VAT enrichment on INTERNAL invoices + voucher-date auto-shift

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSupplierResolver.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSupplierResolver.java
@@ -1,0 +1,103 @@
+package dk.trustworks.intranet.aggregates.invoice.economics.supplier;
+
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto.SupplierDto;
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto.SuppliersPage;
+import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver;
+import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver.Tokens;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.jbosslog.JBossLog;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Resolves an issuer company's e-conomic supplier number in a debtor company's
+ * e-conomic agreement by looking up the issuer's CVR via the legacy /suppliers
+ * endpoint.
+ *
+ * <p>Used by {@code EconomicsInvoiceService} to enrich the debtor-side
+ * {@code SupplierInvoice} voucher for INTERNAL and INTERNAL_SERVICE invoices.
+ *
+ * <p>This resolver never throws. All non-happy paths return
+ * {@link Optional#empty()} so the caller can fall back to today's behavior of
+ * posting the voucher without a supplier reference. The caller logs the
+ * fallback so finance can act on the bookkeeping side.
+ */
+@JBossLog
+@ApplicationScoped
+public class EconomicsSupplierResolver {
+
+    private static final String CVR_FILTER_PREFIX = "corporateIdentificationNumber$eq:";
+
+    @Inject
+    EconomicsAgreementResolver agreementResolver;
+
+    @Inject
+    @RestClient
+    EconomicsSuppliersApiClient suppliersApi;
+
+    /**
+     * Returns the supplier number in the debtor company's e-conomic whose
+     * {@code corporateIdentificationNumber} equals {@code issuerCvr}.
+     *
+     * @return the supplier number on exact-one match; {@link Optional#empty()}
+     *         when the CVR is null/blank, zero suppliers match, multiple
+     *         suppliers match (ambiguous), the debtor's integration keys are
+     *         missing, or the /suppliers call fails for any reason.
+     */
+    public Optional<Integer> resolveByCvr(String debtorCompanyUuid, String issuerCvr) {
+        if (issuerCvr == null || issuerCvr.isBlank()) {
+            log.warnf("Supplier resolve skipped: issuer CVR is null/blank for debtor %s",
+                    debtorCompanyUuid);
+            return Optional.empty();
+        }
+
+        Tokens tokens;
+        try {
+            tokens = agreementResolver.tokens(debtorCompanyUuid);
+        } catch (RuntimeException e) {
+            log.errorf(e, "Supplier resolve failed: cannot load debtor %s integration keys",
+                    debtorCompanyUuid);
+            return Optional.empty();
+        }
+
+        SuppliersPage page;
+        try {
+            page = suppliersApi.findByFilter(
+                    tokens.appSecret(),
+                    tokens.agreementGrant(),
+                    CVR_FILTER_PREFIX + issuerCvr);
+        } catch (RuntimeException e) {
+            log.errorf(e, "Supplier resolve failed for CVR %s in debtor %s: API error",
+                    issuerCvr, debtorCompanyUuid);
+            return Optional.empty();
+        }
+
+        List<SupplierDto> matches = page == null || page.getCollection() == null
+                ? List.of()
+                : page.getCollection();
+
+        if (matches.isEmpty()) {
+            log.warnf("Supplier resolve: zero matches for CVR %s in debtor %s",
+                    issuerCvr, debtorCompanyUuid);
+            return Optional.empty();
+        }
+
+        if (matches.size() > 1) {
+            String numbers = matches.stream()
+                    .map(s -> String.valueOf(s.getSupplierNumber()))
+                    .collect(Collectors.joining(", "));
+            log.warnf("Supplier resolve: ambiguous match for CVR %s in debtor %s -- candidates [%s]",
+                    issuerCvr, debtorCompanyUuid, numbers);
+            return Optional.empty();
+        }
+
+        int supplierNumber = matches.get(0).getSupplierNumber();
+        log.infof("Resolved issuer CVR %s -> supplier number %d in debtor %s",
+                issuerCvr, supplierNumber, debtorCompanyUuid);
+        return Optional.of(supplierNumber);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSuppliersApiClient.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSuppliersApiClient.java
@@ -1,0 +1,34 @@
+package dk.trustworks.intranet.aggregates.invoice.economics.supplier;
+
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto.SuppliersPage;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+/**
+ * MicroProfile REST client for e-conomic's legacy /suppliers endpoint.
+ *
+ * Reuses the existing {@code economics-legacy-rest} configKey which is already
+ * mapped to {@code https://restapi.e-conomic.com} in application.yml.
+ *
+ * Used by {@link EconomicsSupplierResolver} to resolve an issuer company's
+ * supplier number in a debtor company's e-conomic agreement by CVR.
+ */
+@RegisterRestClient(configKey = "economics-legacy-rest")
+@Produces(MediaType.APPLICATION_JSON)
+public interface EconomicsSuppliersApiClient {
+
+    /**
+     * Filter syntax: {@code corporateIdentificationNumber$eq:{cvr}}.
+     */
+    @GET
+    @Path("/suppliers")
+    SuppliersPage findByFilter(
+            @HeaderParam("X-AppSecretToken") String appSecret,
+            @HeaderParam("X-AgreementGrantToken") String agreementGrant,
+            @QueryParam("filter") String filter);
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/dto/SupplierDto.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/dto/SupplierDto.java
@@ -1,0 +1,21 @@
+package dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Minimal view of an e-conomic supplier returned by GET /suppliers.
+ * Only the fields the resolver needs are mapped; all others are ignored.
+ */
+@Getter @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SupplierDto {
+
+    @JsonProperty("supplierNumber")
+    private int supplierNumber;
+
+    @JsonProperty("corporateIdentificationNumber")
+    private String corporateIdentificationNumber;
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/dto/SuppliersPage.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/dto/SuppliersPage.java
@@ -1,0 +1,21 @@
+package dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Paged response wrapper for e-conomic GET /suppliers.
+ * Only the {@code collection} field is mapped; pagination/meta fields are ignored.
+ */
+@Getter @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SuppliersPage {
+
+    @JsonProperty("collection")
+    private List<SupplierDto> collection = new ArrayList<>();
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/Supplier.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/Supplier.java
@@ -1,0 +1,34 @@
+package dk.trustworks.intranet.expenseservice.remote.dto.economics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"supplierNumber"})
+public class Supplier {
+
+    @JsonProperty("supplierNumber")
+    public int supplierNumber;
+
+    public Supplier() {}
+
+    public Supplier(int supplierNumber) {
+        this.supplierNumber = supplierNumber;
+    }
+
+    @JsonProperty("supplierNumber")
+    public int getSupplierNumber() {
+        return supplierNumber;
+    }
+
+    @JsonProperty("supplierNumber")
+    public void setSupplierNumber(int supplierNumber) {
+        this.supplierNumber = supplierNumber;
+    }
+
+    @Override
+    public String toString() {
+        return "Supplier{supplierNumber=" + supplierNumber + "}";
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/SupplierInvoice.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/SupplierInvoice.java
@@ -7,9 +7,11 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
         "account",
+        "supplier",
         "text",
         "amount",
         "contraAccount",
+        "contraVatAccount",
         "supplierInvoiceNumber",
         "date"
 })
@@ -27,6 +29,12 @@ public class SupplierInvoice {
     public String date;
     @JsonProperty("supplierInvoiceNumber")
     public String supplierInvoiceNumber;
+
+    @JsonProperty("supplier")
+    public Supplier supplier;
+
+    @JsonProperty("contraVatAccount")
+    public VatAccount contraVatAccount;
 
     public SupplierInvoice(){
 
@@ -101,13 +109,35 @@ public class SupplierInvoice {
         this.supplierInvoiceNumber = supplierInvoiceNumber;
     }
 
+    @JsonProperty("supplier")
+    public Supplier getSupplier() {
+        return supplier;
+    }
+
+    @JsonProperty("supplier")
+    public void setSupplier(Supplier supplier) {
+        this.supplier = supplier;
+    }
+
+    @JsonProperty("contraVatAccount")
+    public VatAccount getContraVatAccount() {
+        return contraVatAccount;
+    }
+
+    @JsonProperty("contraVatAccount")
+    public void setContraVatAccount(VatAccount contraVatAccount) {
+        this.contraVatAccount = contraVatAccount;
+    }
+
     @Override
     public String toString() {
         return "SupplierInvoice{" +
                 "account='" + account + '\'' +
+                ", supplier=" + supplier +
                 ", text='" + text + '\'' +
                 ", amount='" + amount + '\'' +
                 ", contraAccount='" + contraAccount + '\'' +
+                ", contraVatAccount=" + contraVatAccount +
                 ", supplierInvoiceNumber=" + supplierInvoiceNumber +
                 ", date='" + date +
                 '}';

--- a/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/VatAccount.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/remote/dto/economics/VatAccount.java
@@ -1,0 +1,34 @@
+package dk.trustworks.intranet.expenseservice.remote.dto.economics;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"vatCode"})
+public class VatAccount {
+
+    @JsonProperty("vatCode")
+    public String vatCode;
+
+    public VatAccount() {}
+
+    public VatAccount(String vatCode) {
+        this.vatCode = vatCode;
+    }
+
+    @JsonProperty("vatCode")
+    public String getVatCode() {
+        return vatCode;
+    }
+
+    @JsonProperty("vatCode")
+    public void setVatCode(String vatCode) {
+        this.vatCode = vatCode;
+    }
+
+    @Override
+    public String toString() {
+        return "VatAccount{vatCode='" + vatCode + "'}";
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -8,6 +8,7 @@ import dk.trustworks.intranet.expenseservice.exceptions.PdfNotYetRenderedExcepti
 import dk.trustworks.intranet.financeservice.model.IntegrationKey;
 import dk.trustworks.intranet.financeservice.remote.EconomicsDynamicHeaderFilter;
 import dk.trustworks.intranet.aggregates.invoice.economics.book.EconomicsBookingApiClient;
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.EconomicsSupplierResolver;
 import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
 import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver;
 import dk.trustworks.intranet.aggregates.invoice.utils.StringUtils;
@@ -30,13 +31,20 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @JBossLog
 @ApplicationScoped
 public class EconomicsInvoiceService {
 
+    /** Hardcoded Danish 25% purchase VAT code applied to account 2101 on INTERNAL invoices. */
+    private static final String INTERCOMPANY_VAT_CODE = "I25";
+
     @Inject
     InvoicePdfS3Service invoicePdfS3Service;
+
+    @Inject
+    EconomicsSupplierResolver supplierResolver;
 
     @Inject
     @RestClient
@@ -148,8 +156,35 @@ public class EconomicsInvoiceService {
         // Check if this is an internal journal (supplier invoice) or regular journal (customer invoice)
         if (journal.getJournalNumber() == integrationKeyValue.internalJournalNumber()) {
             log.info("Creating supplier invoice for number " + invoice.getInvoicenumber());
-            SupplierInvoice supplierInvoice = new SupplierInvoice(account, StringUtils.convertInvoiceNumberToString(invoice.getInvoicenumber()), text, invoice.getGrandTotal() != null ? invoice.getGrandTotal() : 0.0, contraAccount, date);
-            log.debug("SupplierInvoice text=" + supplierInvoice.text + ", contraAccount=" + contraAccount.getAccountNumber());
+            SupplierInvoice supplierInvoice = new SupplierInvoice(
+                    account,
+                    StringUtils.convertInvoiceNumberToString(invoice.getInvoicenumber()),
+                    text,
+                    invoice.getGrandTotal() != null ? invoice.getGrandTotal() : 0.0,
+                    contraAccount,
+                    date);
+
+            String issuerCvr = invoice.getCompany() != null ? invoice.getCompany().getCvr() : null;
+            Optional<Integer> resolvedSupplier = supplierResolver.resolveByCvr(
+                    targetCompany.getUuid(), issuerCvr);
+            if (resolvedSupplier.isPresent()) {
+                supplierInvoice.setSupplier(new Supplier(resolvedSupplier.get()));
+                supplierInvoice.setContraVatAccount(new VatAccount(INTERCOMPANY_VAT_CODE));
+                log.infof("Enriched SupplierInvoice for invoice %s with supplier %d and vatCode %s",
+                        invoice.getUuid(), resolvedSupplier.get(), INTERCOMPANY_VAT_CODE);
+            } else {
+                log.warnf(
+                        "INTERNAL invoice %s: no supplier in debtor %s e-conomic for CVR %s — posting without supplier/VAT",
+                        invoice.getUuid(),
+                        targetCompany.getName(),
+                        issuerCvr);
+            }
+
+            log.debugf("SupplierInvoice text=%s, contraAccount=%s, supplier=%s, contraVatAccount=%s",
+                    supplierInvoice.text,
+                    contraAccount.getAccountNumber(),
+                    supplierInvoice.getSupplier(),
+                    supplierInvoice.getContraVatAccount());
             List<SupplierInvoice> supplierInvoices = new ArrayList<>();
             supplierInvoices.add(supplierInvoice);
             entries.setSupplierInvoices(supplierInvoices);

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
@@ -33,7 +33,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 import static dk.trustworks.intranet.financeservice.model.IntegrationKey.getIntegrationKeyValue;
@@ -53,6 +54,12 @@ public class  EconomicsService {
     @ConfigProperty(name = "dk.trustworks.environment.id", defaultValue = "production")
     String environmentId;
 
+    /**
+     * Cap on closed-period auto-shift retries. Covers the realistic edge cases (period
+     * boundary race, year-end roll-over) without risking runaway loops.
+     */
+    private static final int MAX_PERIOD_SHIFT_DAYS = 7;
+
     /** Builds the e-conomics Idempotency-Key header value for a voucher POST. */
     String buildIdempotencyKey(Expense expense) {
         if (expense.hasKnownCacheIssue() || Boolean.TRUE.equals(expense.getIsOrphaned())) {
@@ -60,6 +67,30 @@ public class  EconomicsService {
                     environmentId, expense.getUuid(), expense.getSafeRetryCount());
         }
         return environmentId + "-expense-" + expense.getUuid();
+    }
+
+    /**
+     * Idempotency key used when retrying after a closed-period rejection. Distinct from
+     * the standard and orphan keys so e-conomics' cache treats the shifted-date POST as a
+     * fresh request.
+     */
+    String buildPeriodShiftIdempotencyKey(Expense expense, int shiftDays) {
+        return String.format("%s-expense-%s-period-shift-%d",
+                environmentId, expense.getUuid(), shiftDays);
+    }
+
+    /**
+     * Detects e-conomic error responses indicating the voucher's entry date falls in a
+     * closed accounting period. e-conomic uses errorCode names in its problem-detail
+     * body; we match the known variants seen in production / documented in the API.
+     */
+    boolean isPeriodClosedError(String body) {
+        if (body == null) return false;
+        return body.contains("AccountingYearClosed")
+                || body.contains("EntryDateInClosedPeriod")
+                || body.contains("DateInClosedPeriod")
+                || body.contains("PeriodClosed")
+                || body.contains("ClosedAccountingYear");
     }
 
     public Response sendVoucher(Expense expense, ExpenseFile expensefile, UserAccount userAccount) throws Exception {
@@ -75,59 +106,80 @@ public class  EconomicsService {
             expense.setAccount(String.valueOf(convertKontokode(Integer.parseInt(expense.getAccount()))));
         }
 
-        Voucher voucher = buildJSONRequest(expense, userAccount, journal, text);
-
-        ObjectMapper o = new ObjectMapper();
-        String json = o.writeValueAsString(voucher);
-        // call e-conomics endpoint with proper resource management
-        log.info("Voucher payload = " + json);
-
         try (EconomicsAPI remoteApi = getEconomicsAPI(result)) {
+            Voucher voucher = null;
             Response response = null;
-            try {
-                String idempotencyKey = buildIdempotencyKey(expense);
-                log.debugf("Posting voucher for expense %s with idempotency key %s",
-                        expense.getUuid(), idempotencyKey);
+            String lastBody = null;
+            int lastStatus = 0;
 
-                response = remoteApi.postVoucher(journal.getJournalNumber(), idempotencyKey, json);
-            } catch (WebApplicationException e) {
-                String errorDetails = safeRead(e.getResponse());
-                log.error("Failed to post voucher to e-conomics. Expenseuuid: " + expense.getUseruuid() + ", status: " + e.getResponse().getStatus() + ", details: " + errorDetails);
-                throw new ExpenseUploadException("Failed to post voucher to e-conomics", e, e.getResponse().getStatus(), errorDetails);
-            } catch (Exception e) {
-                log.error("Failed to post voucher to e-conomics. Expenseuuid: " + expense.getUseruuid() + ", voucher: " + voucher);
-                throw new ExpenseUploadException("Failed to post voucher to e-conomics", e, null, e.getMessage());
+            // Period-closed auto-shift: each retry advances the voucher entry date by 1 day
+            // and uses a fresh idempotency key so e-conomic's cache treats it as new.
+            for (int shift = 0; shift <= MAX_PERIOD_SHIFT_DAYS; shift++) {
+                LocalDate voucherDate = LocalDate.now().plusDays(shift);
+                voucher = buildJSONRequestWithDate(expense, userAccount, journal, text, voucherDate);
+                String json = new ObjectMapper().writeValueAsString(voucher);
+                String idempotencyKey = (shift == 0)
+                        ? buildIdempotencyKey(expense)
+                        : buildPeriodShiftIdempotencyKey(expense, shift);
+
+                if (shift == 0) {
+                    log.debugf("Posting voucher for expense %s with idempotency key %s", expense.getUuid(), idempotencyKey);
+                    log.info("Voucher payload = " + json);
+                } else {
+                    log.warnf("Closed period on previous attempt — retrying expense %s with voucher date %s (shift +%d days, key %s)",
+                            expense.getUuid(), voucherDate, shift, idempotencyKey);
+                }
+
+                try {
+                    response = remoteApi.postVoucher(journal.getJournalNumber(), idempotencyKey, json);
+                } catch (WebApplicationException e) {
+                    String errorDetails = safeRead(e.getResponse());
+                    log.error("Failed to post voucher to e-conomics. Expenseuuid: " + expense.getUseruuid() + ", status: " + e.getResponse().getStatus() + ", details: " + errorDetails);
+                    throw new ExpenseUploadException("Failed to post voucher to e-conomics", e, e.getResponse().getStatus(), errorDetails);
+                } catch (Exception e) {
+                    log.error("Failed to post voucher to e-conomics. Expenseuuid: " + expense.getUseruuid() + ", voucher: " + voucher);
+                    throw new ExpenseUploadException("Failed to post voucher to e-conomics", e, null, e.getMessage());
+                }
+
+                int status = response.getStatus();
+                if (status >= 200 && status < 300) break; // success — fall through to response parsing
+                lastStatus = status;
+                lastBody = safeRead(response);
+                try { response.close(); } catch (Exception ignore) {}
+                response = null;
+                if (status != 400 || !isPeriodClosedError(lastBody)) {
+                    log.error("voucher not posted successfully to e-conomics. Expenseuuid: " + expense.getUseruuid() + ", status: " + status + ", details: " + lastBody);
+                    throw new ExpenseUploadException("Voucher not posted successfully to e-conomics", null, status, lastBody);
+                }
+            }
+            if (response == null) {
+                log.error("Voucher post failed after " + (MAX_PERIOD_SHIFT_DAYS + 1) + " period-shift attempts. Expenseuuid: " + expense.getUseruuid() + ", lastStatus: " + lastStatus + ", lastBody: " + lastBody);
+                throw new ExpenseUploadException(
+                        "Voucher post failed: closed period persists after " + MAX_PERIOD_SHIFT_DAYS + " day-shift retries",
+                        null, lastStatus, lastBody);
             }
 
-            // extract voucher number from response
             try (Response voucherResponse = response) {
-                if ((Objects.requireNonNull(voucherResponse).getStatus() > 199) & (voucherResponse.getStatus() < 300)) {
-                    ObjectMapper objectMapper = new ObjectMapper();
-                    String responseAsString = voucherResponse.readEntity(String.class);
-                    JsonNode root = objectMapper.readValue(responseAsString, JsonNode.class);
-                    JsonNode first = root.isArray() ? (!root.isEmpty() ? root.get(0) : null) : root;
-                    if (first == null || first.get("voucherNumber") == null) {
-                        log.error("Unexpected voucher POST response: " + responseAsString);
-                        throw new ExpenseUploadException("Unexpected voucher response from e-conomics", null, 502, responseAsString);
-                    }
-                    int voucherNumber = first.get("voucherNumber").asInt();
-                    expense.setVouchernumber(voucherNumber);
-                    // persist accountingYear (canonical URL form without any trailing letters) and journal too
-                    String fiscalYearName = voucher.getAccountingYear().getYear(); // e.g., 2025/2026 or 2025/2026a
-                    String urlYear = DateUtils.toEconomicsUrlYear(fiscalYearName);
-                    log.debugf("Storing accounting year for expense %s: fiscalYear=%s -> storedFormat=%s",
-                        expense.getUuid(), fiscalYearName, urlYear);
-                    expense.setAccountingyear(urlYear);
-                    expense.setJournalnumber(journal.getJournalNumber());
-
-                    //upload file to e-conomics voucher
-                    return sendFile(expense, expensefile, voucher);
-
-                } else {
-                    String errorDetails = safeRead(voucherResponse);
-                    log.error("voucher not posted successfully to e-conomics. Expenseuuid: " + expense.getUseruuid() + ", status: " + voucherResponse.getStatus() + ", details: " + errorDetails);
-                    throw new ExpenseUploadException("Voucher not posted successfully to e-conomics", null, voucherResponse.getStatus(), errorDetails);
+                ObjectMapper objectMapper = new ObjectMapper();
+                String responseAsString = voucherResponse.readEntity(String.class);
+                JsonNode root = objectMapper.readValue(responseAsString, JsonNode.class);
+                JsonNode first = root.isArray() ? (!root.isEmpty() ? root.get(0) : null) : root;
+                if (first == null || first.get("voucherNumber") == null) {
+                    log.error("Unexpected voucher POST response: " + responseAsString);
+                    throw new ExpenseUploadException("Unexpected voucher response from e-conomics", null, 502, responseAsString);
                 }
+                int voucherNumber = first.get("voucherNumber").asInt();
+                expense.setVouchernumber(voucherNumber);
+                // persist accountingYear (canonical URL form without any trailing letters) and journal too
+                String fiscalYearName = voucher.getAccountingYear().getYear(); // e.g., 2025/2026 or 2025/2026a
+                String urlYear = DateUtils.toEconomicsUrlYear(fiscalYearName);
+                log.debugf("Storing accounting year for expense %s: fiscalYear=%s -> storedFormat=%s",
+                    expense.getUuid(), fiscalYearName, urlYear);
+                expense.setAccountingyear(urlYear);
+                expense.setJournalnumber(journal.getJournalNumber());
+
+                //upload file to e-conomics voucher
+                return sendFile(expense, expensefile, voucher);
             }
         }
     }
@@ -276,16 +328,24 @@ public class  EconomicsService {
     }
 
     public Voucher buildJSONRequest(Expense expense, UserAccount userAccount, Journal journal, String text){
+        return buildJSONRequestWithDate(expense, userAccount, journal, text, LocalDate.now());
+    }
+
+    /**
+     * Builds the voucher JSON payload with an explicit entry date. The accounting year
+     * is derived from this date (not today's date) so closed-period auto-shifts that
+     * cross the fiscal year boundary land in the correct year.
+     */
+    public Voucher buildJSONRequestWithDate(Expense expense, UserAccount userAccount, Journal journal, String text, LocalDate voucherDate){
 
         ContraAccount contraAccount = new ContraAccount(userAccount.getEconomics());
         ExpenseAccount expenseaccount = new ExpenseAccount(Integer.parseInt(expense.getAccount()));
         Company company = getCompanyFromExpense(expense);
-        String fiscalYearName = DateUtils.getFiscalYearName(DateUtils.getCurrentFiscalStartDate(), company.getUuid());
+        String fiscalYearName = DateUtils.getFiscalYearName(DateUtils.fiscalYearStart(voucherDate), company.getUuid());
         AccountingYear accountingYear = new AccountingYear(fiscalYearName);
         log.debug("Using accounting year " + fiscalYearName + " for company " + company.getUuid());
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-        String date = dateFormat.format(new Date());
+        String date = voucherDate.format(DateTimeFormatter.ISO_LOCAL_DATE);
 
         FinanceVoucher financeVoucher1 = new FinanceVoucher(expenseaccount, text, expense.getAmount(), contraAccount, date);
         List<FinanceVoucher> financeVouchers = new ArrayList<>();

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSupplierResolverTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSupplierResolverTest.java
@@ -1,0 +1,125 @@
+package dk.trustworks.intranet.aggregates.invoice.economics.supplier;
+
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto.SupplierDto;
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.dto.SuppliersPage;
+import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver;
+import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver.Tokens;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EconomicsSupplierResolverTest {
+
+    @InjectMocks EconomicsSupplierResolver resolver;
+
+    @Mock EconomicsAgreementResolver agreementResolver;
+    @Mock EconomicsSuppliersApiClient suppliersApi;
+
+    private static final String DEBTOR_UUID = "debtor-1";
+    private static final String ISSUER_CVR = "44232855";
+
+    private void agreementTokens() {
+        when(agreementResolver.tokens(DEBTOR_UUID))
+                .thenReturn(new Tokens("app-secret", "agreement-grant"));
+    }
+
+    private SuppliersPage page(SupplierDto... items) {
+        SuppliersPage p = new SuppliersPage();
+        p.setCollection(List.of(items));
+        return p;
+    }
+
+    private SupplierDto supplier(int number, String cvr) {
+        SupplierDto s = new SupplierDto();
+        s.setSupplierNumber(number);
+        s.setCorporateIdentificationNumber(cvr);
+        return s;
+    }
+
+    @Test
+    void single_match_returns_supplier_number() {
+        agreementTokens();
+        when(suppliersApi.findByFilter("app-secret", "agreement-grant",
+                "corporateIdentificationNumber$eq:" + ISSUER_CVR))
+                .thenReturn(page(supplier(50007, ISSUER_CVR)));
+
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, ISSUER_CVR);
+
+        assertTrue(result.isPresent());
+        assertEquals(50007, result.get());
+    }
+
+    @Test
+    void zero_matches_returns_empty() {
+        agreementTokens();
+        when(suppliersApi.findByFilter(anyString(), anyString(), anyString()))
+                .thenReturn(page());
+
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, ISSUER_CVR);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void multiple_matches_returns_empty() {
+        agreementTokens();
+        when(suppliersApi.findByFilter(anyString(), anyString(), anyString()))
+                .thenReturn(page(supplier(50007, ISSUER_CVR), supplier(50008, ISSUER_CVR)));
+
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, ISSUER_CVR);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void null_cvr_returns_empty_without_api_call() {
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, null);
+
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(suppliersApi);
+        verifyNoInteractions(agreementResolver);
+    }
+
+    @Test
+    void blank_cvr_returns_empty_without_api_call() {
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, "   ");
+
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(suppliersApi);
+        verifyNoInteractions(agreementResolver);
+    }
+
+    @Test
+    void api_exception_returns_empty() {
+        agreementTokens();
+        when(suppliersApi.findByFilter(anyString(), anyString(), anyString()))
+                .thenThrow(new WebApplicationException(Response.serverError().build()));
+
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, ISSUER_CVR);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void agreement_resolver_failure_returns_empty() {
+        when(agreementResolver.tokens(DEBTOR_UUID))
+                .thenThrow(new IllegalStateException("no integration keys"));
+
+        Optional<Integer> result = resolver.resolveByCvr(DEBTOR_UUID, ISSUER_CVR);
+
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(suppliersApi);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceTest.java
@@ -1,11 +1,16 @@
 package dk.trustworks.intranet.expenseservice.services;
 
 import dk.trustworks.intranet.aggregates.invoice.economics.book.EconomicsBookingApiClient;
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.EconomicsSupplierResolver;
 import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
 import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver;
 import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver.Tokens;
 import dk.trustworks.intranet.aggregates.invoice.services.InvoicePdfS3Service;
 import dk.trustworks.intranet.expenseservice.exceptions.PdfNotYetRenderedException;
+import dk.trustworks.intranet.expenseservice.remote.dto.economics.Journal;
+import dk.trustworks.intranet.expenseservice.remote.dto.economics.SupplierInvoice;
+import dk.trustworks.intranet.expenseservice.remote.dto.economics.Voucher;
+import dk.trustworks.intranet.financeservice.model.IntegrationKey;
 import dk.trustworks.intranet.model.Company;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
@@ -37,6 +42,7 @@ class EconomicsInvoiceServiceTest {
     @Mock InvoicePdfS3Service invoicePdfS3Service;
     @Mock EconomicsBookingApiClient bookingApi;
     @Mock EconomicsAgreementResolver agreementResolver;
+    @Mock EconomicsSupplierResolver supplierResolver;
 
     @Test
     void loadInvoicePdfBytes_reads_from_s3_when_storage_key_present() throws IOException {
@@ -130,5 +136,111 @@ class EconomicsInvoiceServiceTest {
         inv.setCompany(company);
         inv.setEconomicsBookedNumber(bookedNumber);
         return inv;
+    }
+
+    private Invoice internalInvoiceWithCvr(String invoiceUuid,
+                                           String issuerUuid,
+                                           String issuerCvr,
+                                           String debtorUuid) {
+        Invoice inv = new Invoice();
+        inv.setUuid(invoiceUuid);
+        inv.setInvoicenumber(20240315);
+        inv.setClientname("Trustworks A/S");
+        inv.setGrandTotal(12500.00);
+        inv.setInvoicedate(java.time.LocalDate.of(2025, 2, 14));
+
+        Company issuer = new Company();
+        issuer.setUuid(issuerUuid);
+        issuer.setName("Trustworks A/S");
+        issuer.setCvr(issuerCvr);
+        inv.setCompany(issuer);
+
+        inv.setDebtorCompanyuuid(debtorUuid);
+
+        return inv;
+    }
+
+    @Test
+    void buildJSONRequest_internalJournal_enrichesWhenSupplierResolved() {
+        Invoice inv = internalInvoiceWithCvr("inv-int-1", "issuer-1", "44232855", "debtor-1");
+
+        IntegrationKey.IntegrationKeyValue keys = new IntegrationKey.IntegrationKeyValue(
+                "https://restapi.e-conomic.com",
+                "app-secret",
+                "agreement-grant",
+                /*expenseJournalNumber*/ 1,
+                /*invoiceJournalNumber*/ 5,
+                /*invoiceAccountNumber*/ 2101,
+                /*internalJournalNumber*/ 7,
+                /*invoiceProductNumber*/ 1);
+
+        Company debtor = new Company();
+        debtor.setUuid("debtor-1");
+        debtor.setName("Trustworks NO AS");
+
+        Journal journal = new Journal(7);  // internal journal
+        when(supplierResolver.resolveByCvr("debtor-1", "44232855"))
+                .thenReturn(java.util.Optional.of(50007));
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "text", keys, debtor);
+
+        java.util.List<SupplierInvoice> supplierInvoices = voucher.getEntries().getSupplierInvoices();
+        assertNotNull(supplierInvoices);
+        assertEquals(1, supplierInvoices.size());
+        SupplierInvoice si = supplierInvoices.get(0);
+        assertNotNull(si.getSupplier(), "supplier should be set");
+        assertEquals(50007, si.getSupplier().getSupplierNumber());
+        assertNotNull(si.getContraVatAccount(), "contraVatAccount should be set");
+        assertEquals("I25", si.getContraVatAccount().getVatCode());
+        // Customer-invoice list must be null in the supplier-journal branch
+        assertNull(voucher.getEntries().getManualCustomerInvoices());
+    }
+
+    @Test
+    void buildJSONRequest_internalJournal_omitsEnrichmentWhenResolverEmpty() {
+        Invoice inv = internalInvoiceWithCvr("inv-int-2", "issuer-1", "44232855", "debtor-1");
+
+        IntegrationKey.IntegrationKeyValue keys = new IntegrationKey.IntegrationKeyValue(
+                "https://restapi.e-conomic.com",
+                "app-secret",
+                "agreement-grant",
+                1, 5, 2101, 7, 1);
+
+        Company debtor = new Company();
+        debtor.setUuid("debtor-1");
+        debtor.setName("Trustworks NO AS");
+
+        Journal journal = new Journal(7);
+        when(supplierResolver.resolveByCvr("debtor-1", "44232855"))
+                .thenReturn(java.util.Optional.empty());
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "text", keys, debtor);
+
+        SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
+        assertNull(si.getSupplier(), "supplier must remain unset when resolver returns empty");
+        assertNull(si.getContraVatAccount(), "contraVatAccount must remain unset when resolver returns empty");
+    }
+
+    @Test
+    void buildJSONRequest_customerJournal_doesNotInvokeResolver() {
+        Invoice inv = internalInvoiceWithCvr("inv-cust-1", "issuer-1", "44232855", "debtor-1");
+
+        IntegrationKey.IntegrationKeyValue keys = new IntegrationKey.IntegrationKeyValue(
+                "https://restapi.e-conomic.com",
+                "app-secret",
+                "agreement-grant",
+                1, 5, 2101, 7, 1);
+
+        Company issuerAsTarget = new Company();
+        issuerAsTarget.setUuid("issuer-1");
+        issuerAsTarget.setName("Trustworks A/S");
+
+        Journal journal = new Journal(5);  // customer journal (NOT internal)
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "text", keys, issuerAsTarget);
+
+        assertNull(voucher.getEntries().getSupplierInvoices());
+        assertNotNull(voucher.getEntries().getManualCustomerInvoices());
+        verifyNoInteractions(supplierResolver);
     }
 }

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsPeriodClosedShiftTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsPeriodClosedShiftTest.java
@@ -1,0 +1,69 @@
+package dk.trustworks.intranet.expenseservice.services;
+
+import dk.trustworks.intranet.expenseservice.model.Expense;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the closed-period auto-shift contract: the detector recognises e-conomic's
+ * closed-period error variants, and the shift idempotency key is distinct from both
+ * the standard and orphan-retry keys so e-conomic's cache treats it as fresh.
+ */
+class EconomicsPeriodClosedShiftTest {
+
+    private EconomicsService serviceFor(String envId) {
+        EconomicsService s = new EconomicsService();
+        s.environmentId = envId;
+        return s;
+    }
+
+    @Test
+    void period_closed_error_detected_on_known_errorcodes() {
+        EconomicsService s = serviceFor("production");
+
+        assertTrue(s.isPeriodClosedError("{\"errorCode\":\"AccountingYearClosed\",\"status\":400}"));
+        assertTrue(s.isPeriodClosedError("{\"errorCode\":\"EntryDateInClosedPeriod\",\"status\":400}"));
+        assertTrue(s.isPeriodClosedError("{\"errorCode\":\"DateInClosedPeriod\",\"status\":400}"));
+        assertTrue(s.isPeriodClosedError("{\"errorCode\":\"PeriodClosed\",\"status\":400}"));
+        assertTrue(s.isPeriodClosedError("{\"errorCode\":\"ClosedAccountingYear\",\"status\":400}"));
+    }
+
+    @Test
+    void period_closed_detector_ignores_other_400s() {
+        EconomicsService s = serviceFor("production");
+
+        assertFalse(s.isPeriodClosedError(null));
+        assertFalse(s.isPeriodClosedError(""));
+        assertFalse(s.isPeriodClosedError("{\"errorCode\":\"URLChanged\",\"status\":400}"));
+        assertFalse(s.isPeriodClosedError("{\"errorCode\":\"ValidationFailed\",\"status\":400}"));
+    }
+
+    @Test
+    void period_shift_key_distinct_from_standard_and_orphan_keys() {
+        EconomicsService s = serviceFor("production");
+        Expense e = new Expense();
+        e.setUuid("abc-123");
+
+        String standard = s.buildIdempotencyKey(e);
+        String shift1 = s.buildPeriodShiftIdempotencyKey(e, 1);
+        String shift7 = s.buildPeriodShiftIdempotencyKey(e, 7);
+
+        assertEquals("production-expense-abc-123", standard);
+        assertEquals("production-expense-abc-123-period-shift-1", shift1);
+        assertEquals("production-expense-abc-123-period-shift-7", shift7);
+    }
+
+    @Test
+    void period_shift_key_is_environment_scoped() {
+        Expense e = new Expense();
+        e.setUuid("abc-123");
+
+        assertEquals("staging-expense-abc-123-period-shift-3",
+                serviceFor("staging").buildPeriodShiftIdempotencyKey(e, 3));
+        assertEquals("production-expense-abc-123-period-shift-3",
+                serviceFor("production").buildPeriodShiftIdempotencyKey(e, 3));
+    }
+}


### PR DESCRIPTION
## Summary
Promotes 2 commits from `staging` to `master` (production).

1. **PR #62** — Stamp supplier number and VAT code I25 on INTERNAL invoice e-conomic upload
   - Best-effort enrichment of the debtor-side `SupplierInvoice` voucher; never blocks finalization.
   - No DB migration, no integration_keys change, no application.yml change.
   - Unit tests: 16/16 (7 resolver + 9 service).
2. **`b6827556`** — `feat(expense): auto-shift voucher date on closed-period rejection` (already on staging from a separate workstream).

## Post-deploy probe
- [ ] `/api/health` returns 200 against api.trustworks.dk after deploy completes.
- [ ] First INTERNAL invoice finalized in production: confirm in the debtor's e-conomic that the draft voucher has the supplier line + VAT code I25 on 2101 + PDF attached.
- [ ] If the WARN log line `INTERNAL invoice <uuid>: no supplier in debtor <name> e-conomic for CVR <cvr>` appears, the supplier master data in that debtor's e-conomic needs a one-time fix — voucher still posts without enrichment (fallback to today's behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)