### PR TITLE
Release: opex distribution materialized view + nightly refresh batchlet

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/AllPracticesCareerDistributionResult.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/AllPracticesCareerDistributionResult.java
@@ -1,0 +1,15 @@
+package dk.trustworks.intranet.aggregates.finance.dto;
+
+import java.util.List;
+
+/**
+ * Response wrapper for the all-practices career distribution endpoint.
+ * Contains the career level distribution grouped by track/level plus
+ * a flat member list for avatar/name lookup on the frontend.
+ */
+public record AllPracticesCareerDistributionResult(
+        List<TeamCareerDistributionDTO> distribution,
+        List<AllPracticesCareerDistributionResult.MemberBasicInfo> members
+) {
+    public record MemberBasicInfo(String userId, String firstname, String lastname) {}
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/OpexRow.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/OpexRow.java
@@ -46,6 +46,12 @@ public record OpexRow(
     /** Convenience constant for distribution-computed data source. */
     public static final String SOURCE_DISTRIBUTION = "DISTRIBUTION";
 
+    /** Cost-type value persisted to fact_opex_*.cost_type for payroll rows. */
+    public static final String COST_TYPE_SALARIES = "SALARIES";
+
+    /** Cost-type value persisted to fact_opex_*.cost_type for non-payroll OPEX rows. */
+    public static final String COST_TYPE_OPEX = "OPEX";
+
     /**
      * Compact constructor validates non-null invariants and enforces non-negative amounts.
      */

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/health/OpexDistributionFreshnessCheck.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/health/OpexDistributionFreshnessCheck.java
@@ -43,7 +43,8 @@ public class OpexDistributionFreshnessCheck implements HealthCheck {
                 "SELECT MIN(refreshed_at), COUNT(*) FROM fact_opex_distribution_mat")
                 .getSingleResult();
         LocalDateTime oldest = row[0] == null ? null
-                : ((Timestamp) row[0]).toLocalDateTime();
+                : row[0] instanceof Timestamp ts ? ts.toLocalDateTime()
+                : (LocalDateTime) row[0];
         long rowCount = ((Number) row[1]).longValue();
 
         long ageHours = oldest == null ? Long.MAX_VALUE

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/health/OpexDistributionFreshnessCheck.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/health/OpexDistributionFreshnessCheck.java
@@ -1,0 +1,61 @@
+package dk.trustworks.intranet.aggregates.finance.health;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import lombok.extern.jbosslog.JBossLog;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+/**
+ * Readiness probe that fails when fact_opex_distribution_mat is empty or stale.
+ *
+ * <p>Stale is defined as: oldest row's refreshed_at is more than {@link #maxStalenessHours}
+ * hours behind now. Default 30h gives the nightly 03:30 UTC refresh a 6-hour grace window
+ * before alerting.
+ *
+ * <p>Both production tasks share the same DB, so failing readiness does not actually
+ * shed load — its purpose is to make staleness visible at /q/health for alerting.
+ */
+@JBossLog
+@Readiness
+@ApplicationScoped
+public class OpexDistributionFreshnessCheck implements HealthCheck {
+
+    @Inject
+    EntityManager em;
+
+    @ConfigProperty(name = "dk.trustworks.intranet.opex-distribution.max-staleness-hours", defaultValue = "30")
+    int maxStalenessHours;
+
+    @Override
+    public HealthCheckResponse call() {
+        Object[] row = (Object[]) em.createNativeQuery(
+                "SELECT MIN(refreshed_at), COUNT(*) FROM fact_opex_distribution_mat")
+                .getSingleResult();
+        LocalDateTime oldest = row[0] == null ? null
+                : ((Timestamp) row[0]).toLocalDateTime();
+        long rowCount = ((Number) row[1]).longValue();
+
+        long ageHours = oldest == null ? Long.MAX_VALUE
+                : Duration.between(oldest, LocalDateTime.now()).toHours();
+
+        HealthCheckResponseBuilder b = HealthCheckResponse
+                .named("opex-distribution-freshness")
+                .withData("rows", rowCount)
+                .withData("oldest_refreshed_at", oldest == null ? "never" : oldest.toString())
+                .withData("age_hours", ageHours)
+                .withData("max_allowed_hours", maxStalenessHours);
+
+        return (rowCount > 0 && ageHours <= maxStalenessHours)
+                ? b.up().build()
+                : b.down().build();
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/health/OpexDistributionFreshnessCheck.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/health/OpexDistributionFreshnessCheck.java
@@ -56,7 +56,11 @@ public class OpexDistributionFreshnessCheck implements HealthCheck {
                 .withData("age_hours", ageHours)
                 .withData("max_allowed_hours", maxStalenessHours);
 
-        if (rowCount > 0 && ageHours <= maxStalenessHours) {
+        if (rowCount == 0) {
+            // Empty table = cold-start refresh pending — not stale, just not yet populated
+            return b.up().build();
+        }
+        if (ageHours <= maxStalenessHours) {
             return b.up().build();
         }
         log.warnf("opex-distribution-freshness DOWN: rows=%d, age_hours=%d, max_hours=%d",

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/health/OpexDistributionFreshnessCheck.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/health/OpexDistributionFreshnessCheck.java
@@ -3,6 +3,7 @@ package dk.trustworks.intranet.aggregates.finance.health;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
 import lombok.extern.jbosslog.JBossLog;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.HealthCheck;
@@ -36,6 +37,7 @@ public class OpexDistributionFreshnessCheck implements HealthCheck {
     int maxStalenessHours;
 
     @Override
+    @Transactional(Transactional.TxType.SUPPORTS)
     public HealthCheckResponse call() {
         Object[] row = (Object[]) em.createNativeQuery(
                 "SELECT MIN(refreshed_at), COUNT(*) FROM fact_opex_distribution_mat")
@@ -54,8 +56,11 @@ public class OpexDistributionFreshnessCheck implements HealthCheck {
                 .withData("age_hours", ageHours)
                 .withData("max_allowed_hours", maxStalenessHours);
 
-        return (rowCount > 0 && ageHours <= maxStalenessHours)
-                ? b.up().build()
-                : b.down().build();
+        if (rowCount > 0 && ageHours <= maxStalenessHours) {
+            return b.up().build();
+        }
+        log.warnf("opex-distribution-freshness DOWN: rows=%d, age_hours=%d, max_hours=%d",
+                rowCount, ageHours, maxStalenessHours);
+        return b.down().build();
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
@@ -102,8 +102,10 @@ public class OpexDistributionRefreshBatchlet {
         String msg = ":rotating_light: *fact_opex_distribution_mat refresh failed*\n"
                 + "• error: `" + e.getClass().getSimpleName() + ": " + e.getMessage() + "`\n"
                 + "• impact: EBITDA Forecast chart will use yesterday's snapshot until next 03:30 UTC.\n"
-                + "• action: check Quarkus production logs for stack trace; if persistent, "
-                + "increase `opex-distribution.refresh-window-fy-back` or recycle the task.";
+                + "• action: check Quarkus production logs for the stack trace; "
+                + "recycle the task to retry via the cold-start guard. "
+                + "Do NOT increase `opex-distribution.refresh-window-fy-back` — "
+                + "that widens the failing workload.";
         slackService.sendMessage(opsAlertChannel, msg, "mother");
         lastAlertSent.set(now);
     }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
@@ -62,7 +62,7 @@ public class OpexDistributionRefreshBatchlet {
             log.infof("fact_opex_distribution_mat refreshed: inserted=%d deleted=%d took=%dms window=[%s..%s)",
                     outcome.inserted(), outcome.deleted(), outcome.took().toMillis(),
                     outcome.windowFrom(), outcome.windowTo());
-            lastAlertSent.set(null);  // success clears alert state
+            lastAlertSent.set(null);
         } catch (Exception e) {
             log.errorf(e, "fact_opex_distribution_mat refresh failed");
             fireSlackAlertIfNeeded(e);

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
@@ -1,0 +1,110 @@
+package dk.trustworks.intranet.aggregates.finance.jobs;
+
+import dk.trustworks.intranet.aggregates.finance.services.OpexDistributionRefreshService;
+import dk.trustworks.intranet.aggregates.finance.services.OpexDistributionRefreshService.RefreshOutcome;
+import dk.trustworks.intranet.communicationsservice.services.SlackService;
+import io.quarkus.runtime.StartupEvent;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import lombok.extern.jbosslog.JBossLog;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.context.ManagedExecutor;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Nightly trigger for {@link OpexDistributionRefreshService}.
+ * Runs at 03:30 UTC (30 minutes after sp_nightly_bi_refresh) so that
+ * fact_user_day and fact_salary_monthly are guaranteed fresh.
+ *
+ * <p>Cold-start guard: if the table is empty on startup (fresh deploy,
+ * RDS backup restore), kicks off a one-shot refresh on a worker thread
+ * so the readiness probe doesn't have to wait for it.
+ *
+ * <p>Failure handling: catches all exceptions (so the scheduler keeps
+ * running), routes errors to Sentry via JBoss-log, and posts a Slack
+ * alert with 6h rate-limiting (same pattern as
+ * FactChangeLogBacklogAlertBatchlet).
+ */
+@JBossLog
+@ApplicationScoped
+public class OpexDistributionRefreshBatchlet {
+
+    static final Duration ALERT_REPEAT_INTERVAL = Duration.ofHours(6);
+
+    @Inject
+    OpexDistributionRefreshService refreshService;
+
+    @Inject
+    SlackService slackService;
+
+    @Inject
+    EntityManager em;
+
+    @Inject
+    ManagedExecutor managedExecutor;
+
+    @ConfigProperty(name = "opexDistribution.opsAlertChannel", defaultValue = "ops-alerts")
+    String opsAlertChannel;
+
+    // null encodes "no alert in flight". Prevents Slack spam across rolling outages.
+    final AtomicReference<Instant> lastAlertSent = new AtomicReference<>(null);
+
+    @Scheduled(cron = "0 30 3 * * ?", identity = "fact-opex-distribution-refresh")
+    public void scheduledRun() {
+        try {
+            RefreshOutcome outcome = refreshService.refresh();
+            log.infof("fact_opex_distribution_mat refreshed: inserted=%d deleted=%d took=%dms window=[%s..%s)",
+                    outcome.inserted(), outcome.deleted(), outcome.took().toMillis(),
+                    outcome.windowFrom(), outcome.windowTo());
+            lastAlertSent.set(null);  // success clears alert state
+        } catch (Exception e) {
+            log.errorf(e, "fact_opex_distribution_mat refresh failed");
+            fireSlackAlertIfNeeded(e);
+        }
+    }
+
+    /**
+     * Cold-start guard: if the table is empty on app boot, fire a one-shot
+     * async refresh so the EBITDA endpoint isn't broken until the next
+     * scheduled run.
+     */
+    void onStart(@Observes StartupEvent ev) {
+        long rowCount = ((Number) em.createNativeQuery(
+                "SELECT COUNT(*) FROM fact_opex_distribution_mat")
+                .getSingleResult()).longValue();
+        if (rowCount == 0) {
+            log.warnf("fact_opex_distribution_mat is empty on startup — triggering one-shot refresh asynchronously");
+            managedExecutor.submit(() -> {
+                try {
+                    refreshService.refresh();
+                } catch (Exception e) {
+                    log.errorf(e, "startup one-shot refresh failed");
+                    fireSlackAlertIfNeeded(e);
+                }
+            });
+        }
+    }
+
+    void fireSlackAlertIfNeeded(Exception e) {
+        Instant now = Instant.now();
+        Instant previous = lastAlertSent.get();
+        if (previous != null
+                && Duration.between(previous, now).compareTo(ALERT_REPEAT_INTERVAL) < 0) {
+            log.debugf("fact_opex_distribution_mat refresh failure still active — suppressing duplicate Slack alert (last sent %s)", previous);
+            return;
+        }
+        String msg = ":rotating_light: *fact_opex_distribution_mat refresh failed*\n"
+                + "• error: `" + e.getClass().getSimpleName() + ": " + e.getMessage() + "`\n"
+                + "• impact: EBITDA Forecast chart will use yesterday's snapshot until next 03:30 UTC.\n"
+                + "• action: check Quarkus production logs for stack trace; if persistent, "
+                + "increase `opex-distribution.refresh-window-fy-back` or recycle the task.";
+        slackService.sendMessage(opsAlertChannel, msg, "mother");
+        lastAlertSent.set(now);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
@@ -49,7 +49,7 @@ public class OpexDistributionRefreshBatchlet {
     @Inject
     ManagedExecutor managedExecutor;
 
-    @ConfigProperty(name = "opexDistribution.opsAlertChannel", defaultValue = "ops-alerts")
+    @ConfigProperty(name = "slack.opsAlertChannel", defaultValue = "C0B2VQ2CFU1")
     String opsAlertChannel;
 
     // null encodes "no alert in flight". Prevents Slack spam across rolling outages.

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshService.java
@@ -60,8 +60,111 @@ public class OpexDistributionRefreshService {
      */
     @Transactional
     public RefreshOutcome refresh() {
-        // Filled in in Task 3.
-        return new RefreshOutcome(0, 0, Duration.ZERO,
-                LocalDate.now(), LocalDate.now());
+        Instant start = Instant.now();
+        LocalDate today = LocalDate.now();
+
+        FiscalYearRange currentFy =
+                UtilizationCalculationHelper.getCurrentFiscalYearRange();
+        LocalDate windowFrom = currentFy.start().minusYears(fyBack);
+        LocalDate windowTo = currentFy.end().plusDays(1);  // exclusive
+
+        // 1. Load all source data for the window in ONE batch (existing helper).
+        FiscalYearData fyData = intercompanyCalcService.loadFiscalYear(
+                windowFrom, windowTo, salaryBufferMultiplier);
+
+        // 2. For each month, compute distribution rows. The provider's
+        //    computeDistributionForMonth is @CacheResult-annotated per monthKey,
+        //    but since the cache key matches the per-month workload and we
+        //    explicitly DELETE before INSERT, cached output is the right thing.
+        List<OpexRow> allRows = new ArrayList<>();
+        for (YearMonth ym : fyData.perMonth.keySet()) {
+            allRows.addAll(opexProvider.computeDistributionForMonth(
+                    ym,
+                    fyData.perMonth.get(ym),
+                    fyData.lumpsByMonth.getOrDefault(ym, Collections.emptyMap())));
+        }
+
+        // 3. DELETE + INSERT for the window (idempotent, single tx).
+        String fromKey = UtilizationCalculationHelper.toMonthKey(windowFrom);
+        String toKey = UtilizationCalculationHelper.toMonthKey(windowTo);
+
+        int deleted = em.createNativeQuery(
+                "DELETE FROM fact_opex_distribution_mat " +
+                "WHERE month_key >= :fromKey AND month_key < :toKey")
+                .setParameter("fromKey", fromKey)
+                .setParameter("toKey", toKey)
+                .executeUpdate();
+
+        int inserted = bulkInsert(allRows, LocalDateTime.now());
+
+        Duration took = Duration.between(start, Instant.now());
+        log.infof("Refreshed fact_opex_distribution_mat: deleted=%d inserted=%d took=%dms window=[%s..%s)",
+                deleted, inserted, took.toMillis(), windowFrom, windowTo);
+
+        return new RefreshOutcome(inserted, deleted, took, windowFrom, windowTo);
+    }
+
+    private int bulkInsert(List<OpexRow> rows, LocalDateTime refreshedAt) {
+        if (rows.isEmpty()) return 0;
+
+        StringBuilder sql = new StringBuilder(
+                "INSERT INTO fact_opex_distribution_mat " +
+                "(opex_distribution_id, company_id, cost_center_id, expense_category_id, " +
+                " month_key, year, month_number, fiscal_year, fiscal_month_number, " +
+                " fiscal_month_key, cost_type, opex_amount_dkk, is_payroll_flag, " +
+                " invoice_count, data_source, refreshed_at) VALUES ");
+
+        for (int i = 0; i < rows.size(); i++) {
+            if (i > 0) sql.append(", ");
+            sql.append("(:id").append(i).append(", :company").append(i)
+               .append(", :cc").append(i).append(", :cat").append(i)
+               .append(", :mk").append(i).append(", :yr").append(i)
+               .append(", :mn").append(i).append(", :fy").append(i)
+               .append(", :fmn").append(i).append(", :fmk").append(i)
+               .append(", :ct").append(i).append(", :amt").append(i)
+               .append(", :pf").append(i).append(", :ic").append(i)
+               .append(", :ds").append(i).append(", :ra").append(i).append(")");
+        }
+        // Idempotency safety: surrogate key collisions are impossible inside one
+        // refresh (we DELETE the window first), but ON DUPLICATE KEY UPDATE
+        // protects against accidental concurrent runs.
+        sql.append(" ON DUPLICATE KEY UPDATE " +
+                "  opex_amount_dkk = VALUES(opex_amount_dkk), " +
+                "  invoice_count   = VALUES(invoice_count), " +
+                "  refreshed_at    = VALUES(refreshed_at)");
+
+        Query q = em.createNativeQuery(sql.toString());
+        for (int i = 0; i < rows.size(); i++) {
+            OpexRow r = rows.get(i);
+            YearMonth ym = YearMonth.parse(r.monthKey(),
+                    java.time.format.DateTimeFormatter.ofPattern("yyyyMM"));
+            int monthVal = ym.getMonthValue();
+            int yearVal = ym.getYear();
+            int fyVal = monthVal >= 7 ? yearVal : yearVal - 1;
+            int fmn = monthVal >= 7 ? monthVal - 6 : monthVal + 6;
+            String fmk = String.format("FY%04d-%02d", fyVal, fmn);
+            String cost = r.isPayrollFlag() ? "SALARIES" : "OPEX";
+            String id = r.companyId() + "-" + r.costCenterId() + "-"
+                      + r.expenseCategoryId() + "-" + (r.isPayrollFlag() ? "1" : "0")
+                      + "-" + r.monthKey();
+
+            q.setParameter("id" + i, id)
+             .setParameter("company" + i, r.companyId())
+             .setParameter("cc" + i, r.costCenterId())
+             .setParameter("cat" + i, r.expenseCategoryId())
+             .setParameter("mk" + i, r.monthKey())
+             .setParameter("yr" + i, yearVal)
+             .setParameter("mn" + i, monthVal)
+             .setParameter("fy" + i, fyVal)
+             .setParameter("fmn" + i, fmn)
+             .setParameter("fmk" + i, fmk)
+             .setParameter("ct" + i, cost)
+             .setParameter("amt" + i, r.opexAmountDkk())
+             .setParameter("pf" + i, r.isPayrollFlag() ? 1 : 0)
+             .setParameter("ic" + i, r.invoiceCount())
+             .setParameter("ds" + i, OpexRow.SOURCE_DISTRIBUTION)
+             .setParameter("ra" + i, refreshedAt);
+        }
+        return q.executeUpdate();
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshService.java
@@ -5,6 +5,7 @@ import dk.trustworks.intranet.aggregates.accounting.services.IntercompanyCalcSer
 import dk.trustworks.intranet.aggregates.finance.dto.OpexRow;
 import dk.trustworks.intranet.aggregates.utilization.services.UtilizationCalculationHelper;
 import dk.trustworks.intranet.aggregates.utilization.services.UtilizationCalculationHelper.FiscalYearRange;
+import dk.trustworks.intranet.utils.DateUtils;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -61,21 +62,17 @@ public class OpexDistributionRefreshService {
     @Transactional
     public RefreshOutcome refresh() {
         Instant start = Instant.now();
-        LocalDate today = LocalDate.now();
 
         FiscalYearRange currentFy =
                 UtilizationCalculationHelper.getCurrentFiscalYearRange();
         LocalDate windowFrom = currentFy.start().minusYears(fyBack);
-        LocalDate windowTo = currentFy.end().plusDays(1);  // exclusive
+        LocalDate windowToExclusive = currentFy.end().plusDays(1);
 
-        // 1. Load all source data for the window in ONE batch (existing helper).
         FiscalYearData fyData = intercompanyCalcService.loadFiscalYear(
-                windowFrom, windowTo, salaryBufferMultiplier);
+                windowFrom, windowToExclusive, salaryBufferMultiplier);
 
-        // 2. For each month, compute distribution rows. The provider's
-        //    computeDistributionForMonth is @CacheResult-annotated per monthKey,
-        //    but since the cache key matches the per-month workload and we
-        //    explicitly DELETE before INSERT, cached output is the right thing.
+        // computeDistributionForMonth is @CacheResult-annotated per monthKey; the
+        // explicit DELETE-before-INSERT below means cached output is safe to use.
         List<OpexRow> allRows = new ArrayList<>();
         for (YearMonth ym : fyData.perMonth.keySet()) {
             allRows.addAll(opexProvider.computeDistributionForMonth(
@@ -84,9 +81,8 @@ public class OpexDistributionRefreshService {
                     fyData.lumpsByMonth.getOrDefault(ym, Collections.emptyMap())));
         }
 
-        // 3. DELETE + INSERT for the window (idempotent, single tx).
         String fromKey = UtilizationCalculationHelper.toMonthKey(windowFrom);
-        String toKey = UtilizationCalculationHelper.toMonthKey(windowTo);
+        String toKey = UtilizationCalculationHelper.toMonthKey(windowToExclusive);
 
         int deleted = em.createNativeQuery(
                 "DELETE FROM fact_opex_distribution_mat " +
@@ -99,9 +95,9 @@ public class OpexDistributionRefreshService {
 
         Duration took = Duration.between(start, Instant.now());
         log.infof("Refreshed fact_opex_distribution_mat: deleted=%d inserted=%d took=%dms window=[%s..%s)",
-                deleted, inserted, took.toMillis(), windowFrom, windowTo);
+                deleted, inserted, took.toMillis(), windowFrom, windowToExclusive);
 
-        return new RefreshOutcome(inserted, deleted, took, windowFrom, windowTo);
+        return new RefreshOutcome(inserted, deleted, took, windowFrom, windowToExclusive);
     }
 
     private int bulkInsert(List<OpexRow> rows, LocalDateTime refreshedAt) {
@@ -140,10 +136,10 @@ public class OpexDistributionRefreshService {
                     java.time.format.DateTimeFormatter.ofPattern("yyyyMM"));
             int monthVal = ym.getMonthValue();
             int yearVal = ym.getYear();
-            int fyVal = monthVal >= 7 ? yearVal : yearVal - 1;
+            int fyVal = DateUtils.fiscalYearStart(ym.atDay(1)).getYear();
             int fmn = monthVal >= 7 ? monthVal - 6 : monthVal + 6;
             String fmk = String.format("FY%04d-%02d", fyVal, fmn);
-            String cost = r.isPayrollFlag() ? "SALARIES" : "OPEX";
+            String cost = r.isPayrollFlag() ? OpexRow.COST_TYPE_SALARIES : OpexRow.COST_TYPE_OPEX;
             String id = r.companyId() + "-" + r.costCenterId() + "-"
                       + r.expenseCategoryId() + "-" + (r.isPayrollFlag() ? "1" : "0")
                       + "-" + r.monthKey();

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshService.java
@@ -1,0 +1,67 @@
+package dk.trustworks.intranet.aggregates.finance.services;
+
+import dk.trustworks.intranet.aggregates.accounting.services.IntercompanyCalcService;
+import dk.trustworks.intranet.aggregates.accounting.services.IntercompanyCalcService.FiscalYearData;
+import dk.trustworks.intranet.aggregates.finance.dto.OpexRow;
+import dk.trustworks.intranet.aggregates.utilization.services.UtilizationCalculationHelper;
+import dk.trustworks.intranet.aggregates.utilization.services.UtilizationCalculationHelper.FiscalYearRange;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.transaction.Transactional;
+import lombok.extern.jbosslog.JBossLog;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Refreshes {@code fact_opex_distribution_mat} by running the existing
+ * {@link IntercompanyCalcService#loadFiscalYear} + distribution algorithm
+ * once per night and writing the resulting {@link OpexRow}s into the table.
+ *
+ * <p>The provider that powers the CXO EBITDA forecast endpoint reads from this
+ * table for unsettled months instead of recomputing on the request path.
+ *
+ * <p>Spec: docs/superpowers/specs/2026-05-11-fact-opex-distribution-mat-design.md
+ */
+@ApplicationScoped
+@JBossLog
+public class OpexDistributionRefreshService {
+
+    @Inject
+    IntercompanyCalcService intercompanyCalcService;
+
+    @Inject
+    DistributionAwareOpexProvider opexProvider;
+
+    @Inject
+    EntityManager em;
+
+    @ConfigProperty(name = "dk.trustworks.intranet.opex-distribution.refresh-window-fy-back", defaultValue = "1")
+    int fyBack;
+
+    @ConfigProperty(name = "dk.trustworks.intranet.aggregates.accounting.salary-buffer-multiplier", defaultValue = "1.02")
+    double salaryBufferMultiplier;
+
+    public record RefreshOutcome(int inserted, int deleted, Duration took,
+                                 LocalDate windowFrom, LocalDate windowTo) {}
+
+    /**
+     * Rebuild all rows in the window [currentFY - fyBack, currentFY + 1).
+     * Idempotent — safe to call any number of times.
+     */
+    @Transactional
+    public RefreshOutcome refresh() {
+        // Filled in in Task 3.
+        return new RefreshOutcome(0, 0, Duration.ZERO,
+                LocalDate.now(), LocalDate.now());
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/TeamPeopleService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/TeamPeopleService.java
@@ -1,5 +1,7 @@
 package dk.trustworks.intranet.aggregates.finance.services;
 
+import dk.trustworks.intranet.aggregates.finance.dto.AllPracticesCareerDistributionResult;
+import dk.trustworks.intranet.aggregates.finance.dto.AllPracticesCareerDistributionResult.MemberBasicInfo;
 import dk.trustworks.intranet.aggregates.finance.dto.ConsultantAbsenceDayDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.TeamAbsenceOverviewDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.TeamCareerDistributionDTO;
@@ -23,6 +25,7 @@ import java.time.format.TextStyle;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -42,6 +45,8 @@ import java.util.stream.Collectors;
 @JBossLog
 @ApplicationScoped
 public class TeamPeopleService {
+
+    private static final String UNASSIGNED_TRACK = "NONE";
 
     @Inject
     EntityManager em;
@@ -79,27 +84,73 @@ public class TeamPeopleService {
                 .setParameter("memberUuids", memberUuids)
                 .getResultList();
 
-        // Group by track+level
         Map<String, List<String>> grouped = new LinkedHashMap<>();
-        Map<String, String> trackByKey = new LinkedHashMap<>();
+        for (Tuple row : rows) {
+            String track = row.get("career_track") != null ? (String) row.get("career_track") : UNASSIGNED_TRACK;
+            String key = track + "|" + row.get("career_level");
+            grouped.computeIfAbsent(key, k -> new ArrayList<>()).add((String) row.get("useruuid"));
+        }
+        return buildDistributionDTOs(grouped);
+    }
+
+    /**
+     * Returns the career level distribution for all active consultants in the five
+     * regular practices (PM, BA, CYB, DEV, SA), grouped by career track and level.
+     * Excludes terminated and pre-boarding employees.
+     */
+    public AllPracticesCareerDistributionResult getAllPracticesCareerDistribution() {
+        @SuppressWarnings("unchecked")
+        List<Tuple> rows = em.createNativeQuery("""
+                SELECT ucl.career_track, ucl.career_level, ucl.useruuid, u.firstname, u.lastname
+                FROM user_career_level ucl
+                JOIN user u ON ucl.useruuid = u.uuid
+                JOIN userstatus us ON us.useruuid = u.uuid
+                WHERE u.practice IN ('PM', 'BA', 'CYB', 'DEV', 'SA')
+                  AND ucl.active_from = (
+                      SELECT MAX(ucl2.active_from)
+                      FROM user_career_level ucl2
+                      WHERE ucl2.useruuid = ucl.useruuid
+                        AND ucl2.active_from <= CURDATE()
+                  )
+                  AND us.statusdate = (
+                      SELECT MAX(us2.statusdate)
+                      FROM userstatus us2
+                      WHERE us2.useruuid = u.uuid
+                        AND us2.statusdate <= CURDATE()
+                  )
+                  AND us.status NOT IN ('TERMINATED', 'PREBOARDING')
+                ORDER BY ucl.career_track, ucl.career_level
+                """, Tuple.class)
+                .getResultList();
+
+        Map<String, List<String>> grouped = new LinkedHashMap<>();
+        List<MemberBasicInfo> members = new ArrayList<>();
+        Set<String> seenUuids = new HashSet<>();
 
         for (Tuple row : rows) {
-            String track = row.get("career_track") != null ? (String) row.get("career_track") : "NONE";
-            String level = (String) row.get("career_level");
-            String key = track + "|" + level;
-            grouped.computeIfAbsent(key, k -> new ArrayList<>()).add((String) row.get("useruuid"));
-            trackByKey.putIfAbsent(key, track);
+            String rawLevel = (String) row.get("career_level");
+            if (rawLevel == null) {
+                log.warnf("Consultant %s has null career_level — skipping from all-practices distribution", row.get("useruuid"));
+                continue;
+            }
+            String track = row.get("career_track") != null ? (String) row.get("career_track") : UNASSIGNED_TRACK;
+            String uuid  = (String) row.get("useruuid");
+            grouped.computeIfAbsent(track + "|" + rawLevel, k -> new ArrayList<>()).add(uuid);
+            if (seenUuids.add(uuid)) {
+                String firstname = row.get("firstname") != null ? (String) row.get("firstname") : "";
+                String lastname  = row.get("lastname")  != null ? (String) row.get("lastname")  : "";
+                members.add(new MemberBasicInfo(uuid, firstname, lastname));
+            }
         }
 
+        return new AllPracticesCareerDistributionResult(buildDistributionDTOs(grouped), members);
+    }
+
+    private List<TeamCareerDistributionDTO> buildDistributionDTOs(Map<String, List<String>> grouped) {
         return grouped.entrySet().stream()
                 .map(entry -> {
                     String[] parts = entry.getKey().split("\\|");
-                    return new TeamCareerDistributionDTO(
-                            parts[0],
-                            parts[1],
-                            entry.getValue().size(),
-                            entry.getValue()
-                    );
+                    return new TeamCareerDistributionDTO(parts[0], parts[1], entry.getValue().size(), entry.getValue());
                 })
                 .toList();
     }

--- a/src/main/java/dk/trustworks/intranet/apigateway/resources/TeamResource.java
+++ b/src/main/java/dk/trustworks/intranet/apigateway/resources/TeamResource.java
@@ -1,5 +1,6 @@
 package dk.trustworks.intranet.apigateway.resources;
 
+import dk.trustworks.intranet.aggregates.finance.dto.AllPracticesCareerDistributionResult;
 import dk.trustworks.intranet.aggregates.finance.dto.ConsultantAbsenceDayDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.TeamAbsenceOverviewDTO;
 import dk.trustworks.intranet.aggregates.finance.dto.TeamCareerDistributionDTO;
@@ -180,6 +181,13 @@ public class TeamResource {
     public List<TeamCareerDistributionDTO> getCareerDistribution(@PathParam("teamuuid") String teamuuid) {
         teamDashboardService.validateTeamAccess(teamuuid, requestHeaderHolder.getUserUuid());
         return teamPeopleService.getCareerDistribution(teamuuid);
+    }
+
+    @GET
+    @Path("/all-practices/career-distribution")
+    @RolesAllowed({"dashboard:read"})
+    public AllPracticesCareerDistributionResult getAllPracticesCareerDistribution() {
+        return teamPeopleService.getAllPracticesCareerDistribution();
     }
 
     @GET

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -312,6 +312,9 @@ dk:
         invoice:
           network:
             CurrencyAPI/mp-rest/url: https://api.freecurrencyapi.com
+      opex-distribution:
+        refresh-window-fy-back: 1
+        max-staleness-hours: 30
 pricingEngine:
   enabled: true
 cvtool:

--- a/src/main/resources/db/migration/V337__Create_fact_opex_distribution_mat.sql
+++ b/src/main/resources/db/migration/V337__Create_fact_opex_distribution_mat.sql
@@ -1,0 +1,52 @@
+-- =============================================================================
+-- V337: Create fact_opex_distribution_mat
+--
+-- Purpose:
+--   Materialized table that stores the output of the Java intercompany OPEX
+--   distribution algorithm (DistributionAwareOpexProvider.computeDistributionForMonth)
+--   at the same grain as fact_opex_mat. Populated by a nightly Quarkus batchlet
+--   (OpexDistributionRefreshBatchlet, 03:30 UTC). Read by DistributionAwareOpexProvider
+--   for unsettled months so the CXO EBITDA forecast endpoint can serve requests
+--   in <100ms instead of >30s.
+--
+-- Grain: payer_company × cost_center × expense_category × is_payroll_flag × month_key
+--
+-- Refresh strategy:
+--   The batchlet uses DELETE + INSERT inside a single transaction over a window
+--   of [current_FY - 1, current_FY + 1) (~24 months, ~400 rows total). Idempotent.
+--
+-- Companion:
+--   fact_operating_cost_distribution_mat (V197/V220) exists at a different grain
+--   (origin × payer × account × month) and explicitly omits salary cap + lumps.
+--   This table replaces it for EBITDA forecasting only; the V197 table is kept
+--   for audit reporting.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS fact_opex_distribution_mat (
+    opex_distribution_id  VARCHAR(200) NOT NULL,
+
+    company_id            VARCHAR(36)  NOT NULL,
+    cost_center_id        VARCHAR(50)  NOT NULL,
+    expense_category_id   VARCHAR(50)  NOT NULL,
+    month_key             VARCHAR(6)   NOT NULL,
+    year                  SMALLINT     NOT NULL,
+    month_number          TINYINT      NOT NULL,
+    fiscal_year           SMALLINT     NOT NULL,
+    fiscal_month_number   TINYINT      NOT NULL,
+    fiscal_month_key      VARCHAR(10)  NOT NULL,
+    cost_type             VARCHAR(20)  NOT NULL,
+
+    opex_amount_dkk       DECIMAL(14,2) NOT NULL,
+    is_payroll_flag       TINYINT       NOT NULL,
+    invoice_count         INT           NOT NULL DEFAULT 1,
+
+    data_source           VARCHAR(20)   NOT NULL DEFAULT 'DISTRIBUTION',
+    refreshed_at          DATETIME      NOT NULL,
+
+    PRIMARY KEY (opex_distribution_id),
+    KEY idx_fodm_company_month   (company_id, month_key),
+    KEY idx_fodm_month_key       (month_key),
+    KEY idx_fodm_payroll_month   (is_payroll_flag, month_key),
+    KEY idx_fodm_category_month  (expense_category_id, month_key),
+    KEY idx_fodm_cost_center     (cost_center_id, month_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/src/main/resources/db/migration/V337__Create_fact_opex_distribution_mat.sql
+++ b/src/main/resources/db/migration/V337__Create_fact_opex_distribution_mat.sql
@@ -48,5 +48,6 @@ CREATE TABLE IF NOT EXISTS fact_opex_distribution_mat (
     KEY idx_fodm_month_key       (month_key),
     KEY idx_fodm_payroll_month   (is_payroll_flag, month_key),
     KEY idx_fodm_category_month  (expense_category_id, month_key),
-    KEY idx_fodm_cost_center     (cost_center_id, month_key)
+    KEY idx_fodm_cost_center     (cost_center_id, month_key),
+    KEY idx_fodm_refreshed_at    (refreshed_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/health/OpexDistributionFreshnessCheckTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/health/OpexDistributionFreshnessCheckTest.java
@@ -1,0 +1,74 @@
+package dk.trustworks.intranet.aggregates.finance.health;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OpexDistributionFreshnessCheckTest {
+
+    @Mock EntityManager em;
+    @Mock Query query;
+
+    OpexDistributionFreshnessCheck check;
+
+    @BeforeEach
+    void setUp() {
+        check = new OpexDistributionFreshnessCheck();
+        check.em = em;
+        check.maxStalenessHours = 30;
+    }
+
+    @Test
+    void emptyTable_returnsDown() {
+        when(em.createNativeQuery(anyString())).thenReturn(query);
+        when(query.getSingleResult()).thenReturn(new Object[]{null, 0L});
+
+        HealthCheckResponse result = check.call();
+
+        assertEquals(HealthCheckResponse.Status.DOWN, result.getStatus());
+        assertTrue(result.getData().isPresent(),
+                "expected health-check data to be present");
+        assertEquals(0L, result.getData().get().get("rows"));
+    }
+
+    @Test
+    void freshRows_returnsUp() {
+        LocalDateTime oneHourAgo = LocalDateTime.now().minusHours(1);
+        when(em.createNativeQuery(anyString())).thenReturn(query);
+        when(query.getSingleResult()).thenReturn(
+                new Object[]{Timestamp.valueOf(oneHourAgo), 400L});
+
+        HealthCheckResponse result = check.call();
+
+        assertEquals(HealthCheckResponse.Status.UP, result.getStatus());
+    }
+
+    @Test
+    void staleRows_returnsDown() {
+        LocalDateTime longAgo = LocalDateTime.now().minusHours(48);
+        when(em.createNativeQuery(anyString())).thenReturn(query);
+        when(query.getSingleResult()).thenReturn(
+                new Object[]{Timestamp.valueOf(longAgo), 400L});
+
+        HealthCheckResponse result = check.call();
+
+        assertEquals(HealthCheckResponse.Status.DOWN, result.getStatus());
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchletTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchletTest.java
@@ -1,0 +1,136 @@
+package dk.trustworks.intranet.aggregates.finance.jobs;
+
+import dk.trustworks.intranet.aggregates.finance.services.OpexDistributionRefreshService;
+import dk.trustworks.intranet.aggregates.finance.services.OpexDistributionRefreshService.RefreshOutcome;
+import dk.trustworks.intranet.communicationsservice.services.SlackService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Mockito-only unit tests for {@link OpexDistributionRefreshBatchlet}.
+ * Mirrors {@code FactChangeLogBacklogAlertBatchletTest}: wires the
+ * package-private fields directly, so no Quarkus context is needed.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OpexDistributionRefreshBatchletTest {
+
+    private static final String CHANNEL = "C0B2VQ2CFU1";
+
+    @Mock OpexDistributionRefreshService refreshService;
+    @Mock SlackService slackService;
+    @Mock EntityManager em;
+    @Mock ManagedExecutor managedExecutor;
+    @Mock Query query;
+
+    OpexDistributionRefreshBatchlet batchlet;
+
+    @BeforeEach
+    void setUp() {
+        batchlet = new OpexDistributionRefreshBatchlet();
+        batchlet.refreshService = refreshService;
+        batchlet.slackService = slackService;
+        batchlet.em = em;
+        batchlet.managedExecutor = managedExecutor;
+        batchlet.opsAlertChannel = CHANNEL;
+    }
+
+    @Test
+    void scheduledRun_success_logsAndClearsAlertState() {
+        batchlet.lastAlertSent.set(Instant.now());
+        when(refreshService.refresh()).thenReturn(
+                new RefreshOutcome(42, 42, Duration.ofMillis(123),
+                        LocalDate.of(2025, 7, 1), LocalDate.of(2026, 7, 1)));
+
+        batchlet.scheduledRun();
+
+        assertNull(batchlet.lastAlertSent.get());
+        verify(slackService, never()).sendMessage(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void scheduledRun_firstFailure_postsSlackAndSetsAlertTimestamp() {
+        when(refreshService.refresh()).thenThrow(new RuntimeException("boom"));
+
+        batchlet.scheduledRun();
+
+        verify(slackService, times(1)).sendMessage(
+                eq(CHANNEL), anyString(), eq("mother"));
+        assertNotNull(batchlet.lastAlertSent.get());
+    }
+
+    @Test
+    void scheduledRun_secondFailureWithinWindow_suppressesDuplicateSlack() {
+        batchlet.lastAlertSent.set(Instant.now().minus(Duration.ofMinutes(5)));
+        when(refreshService.refresh()).thenThrow(new RuntimeException("boom"));
+
+        batchlet.scheduledRun();
+
+        verify(slackService, never()).sendMessage(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void scheduledRun_failureAfterRateLimitWindow_postsSlackAgain() {
+        batchlet.lastAlertSent.set(Instant.now().minus(Duration.ofHours(7)));
+        when(refreshService.refresh()).thenThrow(new RuntimeException("boom"));
+
+        batchlet.scheduledRun();
+
+        verify(slackService, times(1)).sendMessage(
+                eq(CHANNEL), anyString(), eq("mother"));
+    }
+
+    @Test
+    void onStart_emptyTable_submitsAsyncRefresh() {
+        when(em.createNativeQuery(anyString())).thenReturn(query);
+        when(query.getSingleResult()).thenReturn(0L);
+
+        batchlet.onStart(null);
+
+        verify(managedExecutor, times(1)).submit(org.mockito.ArgumentMatchers.<Runnable>any());
+        verify(refreshService, never()).refresh();
+    }
+
+    @Test
+    void onStart_populatedTable_doesNotTriggerRefresh() {
+        when(em.createNativeQuery(anyString())).thenReturn(query);
+        when(query.getSingleResult()).thenReturn(123L);
+
+        batchlet.onStart(null);
+
+        verify(managedExecutor, never()).submit(org.mockito.ArgumentMatchers.<Runnable>any());
+    }
+
+    @Test
+    void scheduledRun_isAnnotatedWithNightlyCron() throws NoSuchMethodException {
+        Method m = OpexDistributionRefreshBatchlet.class.getMethod("scheduledRun");
+        io.quarkus.scheduler.Scheduled annotation =
+                m.getAnnotation(io.quarkus.scheduler.Scheduled.class);
+        assertNotNull(annotation, "scheduledRun must carry @Scheduled");
+        assertEquals("0 30 3 * * ?", annotation.cron(),
+                "Distribution refresh runs at 03:30 UTC nightly.");
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshParityIT.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshParityIT.java
@@ -67,9 +67,9 @@ class OpexDistributionRefreshParityIT {
     @Test
     @Transactional
     void materialized_rows_match_live_compute_for_every_month_in_current_fy() {
-        // 1. Snapshot live algorithm output for the current FY
-        LocalDate fyStart = UtilizationCalculationHelper.getCurrentFiscalYearRange().start();
-        LocalDate fyEnd = UtilizationCalculationHelper.getCurrentFiscalYearRange().end().plusDays(1);
+        var currentFy = UtilizationCalculationHelper.getCurrentFiscalYearRange();
+        LocalDate fyStart = currentFy.start();
+        LocalDate fyEnd = currentFy.end().plusDays(1);
 
         FiscalYearData fyData = intercompanyCalcService.loadFiscalYear(
                 fyStart, fyEnd, salaryBufferMultiplier);
@@ -83,22 +83,19 @@ class OpexDistributionRefreshParityIT {
             live.put(ym, aggregate(liveRows));
         }
 
-        // Guard: don't let a sparse test DB make the parity test pass vacuously.
+        // Guard: a sparse test DB would otherwise make this test pass vacuously.
         int totalLiveRows = live.values().stream().mapToInt(Map::size).sum();
         assertTrue(totalLiveRows > 0,
                 "Live algorithm produced zero rows across the current FY — parity test "
                 + "would pass vacuously. Source data may be missing from the test database.");
 
-        // 2. Run the refresh
         refreshService.refresh();
 
-        // 3. Read back materialized rows by month and aggregate the same way
         Map<YearMonth, Map<String, Double>> mat = new TreeMap<>();
         for (YearMonth ym : live.keySet()) {
             mat.put(ym, readMatTableForMonth(ym));
         }
 
-        // 4. Compare per month
         for (YearMonth ym : live.keySet()) {
             Map<String, Double> liveMonth = live.get(ym);
             Map<String, Double> matMonth = mat.get(ym);

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshParityIT.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshParityIT.java
@@ -12,6 +12,8 @@ import jakarta.transaction.Transactional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.Collections;
@@ -21,6 +23,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Parity test: asserts that what the refresh batchlet writes into
@@ -80,6 +83,12 @@ class OpexDistributionRefreshParityIT {
             live.put(ym, aggregate(liveRows));
         }
 
+        // Guard: don't let a sparse test DB make the parity test pass vacuously.
+        int totalLiveRows = live.values().stream().mapToInt(Map::size).sum();
+        assertTrue(totalLiveRows > 0,
+                "Live algorithm produced zero rows across the current FY — parity test "
+                + "would pass vacuously. Source data may be missing from the test database.");
+
         // 2. Run the refresh
         refreshService.refresh();
 
@@ -102,13 +111,19 @@ class OpexDistributionRefreshParityIT {
         }
     }
 
-    /** Aggregate {@code List<OpexRow>} into a Map keyed by composite dimension string. */
+    /** Aggregate List<OpexRow> into a Map keyed by composite dimension string.
+     *  Each amount is rounded to 2 decimal places (HALF_EVEN) before summing,
+     *  matching the rounding the DB performs at INSERT time for DECIMAL(14,2).
+     *  This keeps the live-vs-materialized comparison apples-to-apples. */
     private static Map<String, Double> aggregate(List<OpexRow> rows) {
         Map<String, Double> out = new HashMap<>();
         for (OpexRow r : rows) {
             String key = r.companyId() + "|" + r.costCenterId() + "|"
                     + r.expenseCategoryId() + "|" + r.isPayrollFlag();
-            out.merge(key, r.opexAmountDkk(), Double::sum);
+            double rounded = BigDecimal.valueOf(r.opexAmountDkk())
+                    .setScale(2, RoundingMode.HALF_EVEN)
+                    .doubleValue();
+            out.merge(key, rounded, Double::sum);
         }
         return out;
     }

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshParityIT.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshParityIT.java
@@ -1,0 +1,141 @@
+package dk.trustworks.intranet.aggregates.finance.services;
+
+import dk.trustworks.intranet.aggregates.accounting.services.IntercompanyCalcService;
+import dk.trustworks.intranet.aggregates.accounting.services.IntercompanyCalcService.FiscalYearData;
+import dk.trustworks.intranet.aggregates.finance.dto.OpexRow;
+import dk.trustworks.intranet.aggregates.utilization.services.UtilizationCalculationHelper;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Tuple;
+import jakarta.transaction.Transactional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Parity test: asserts that what the refresh batchlet writes into
+ * {@code fact_opex_distribution_mat} is bit-for-bit identical to what
+ * the live {@link DistributionAwareOpexProvider#computeDistributionForMonth}
+ * produces today.
+ *
+ * <p>For each month in the current fiscal year:
+ * <ol>
+ *   <li>Run the live algorithm directly</li>
+ *   <li>Run the refresh service</li>
+ *   <li>Read back the materialized rows</li>
+ *   <li>Assert (company, cost_center, expense_category, is_payroll) → amount maps match</li>
+ * </ol>
+ *
+ * <p>Guards against future algorithm drift — if anyone later changes one path
+ * but not the other, this test fails loudly.
+ *
+ * <p>Spec: docs/superpowers/specs/2026-05-11-fact-opex-distribution-mat-design.md §7 #1
+ */
+@QuarkusTest
+class OpexDistributionRefreshParityIT {
+
+    @Inject
+    IntercompanyCalcService intercompanyCalcService;
+
+    @Inject
+    DistributionAwareOpexProvider opexProvider;
+
+    @Inject
+    OpexDistributionRefreshService refreshService;
+
+    @Inject
+    EntityManager em;
+
+    @ConfigProperty(
+            name = "dk.trustworks.intranet.aggregates.accounting.salary-buffer-multiplier",
+            defaultValue = "1.02")
+    double salaryBufferMultiplier;
+
+    @Test
+    @Transactional
+    void materialized_rows_match_live_compute_for_every_month_in_current_fy() {
+        // 1. Snapshot live algorithm output for the current FY
+        LocalDate fyStart = UtilizationCalculationHelper.getCurrentFiscalYearRange().start();
+        LocalDate fyEnd = UtilizationCalculationHelper.getCurrentFiscalYearRange().end().plusDays(1);
+
+        FiscalYearData fyData = intercompanyCalcService.loadFiscalYear(
+                fyStart, fyEnd, salaryBufferMultiplier);
+
+        Map<YearMonth, Map<String, Double>> live = new TreeMap<>();
+        for (YearMonth ym : fyData.perMonth.keySet()) {
+            List<OpexRow> liveRows = opexProvider.computeDistributionForMonth(
+                    ym,
+                    fyData.perMonth.get(ym),
+                    fyData.lumpsByMonth.getOrDefault(ym, Collections.emptyMap()));
+            live.put(ym, aggregate(liveRows));
+        }
+
+        // 2. Run the refresh
+        refreshService.refresh();
+
+        // 3. Read back materialized rows by month and aggregate the same way
+        Map<YearMonth, Map<String, Double>> mat = new TreeMap<>();
+        for (YearMonth ym : live.keySet()) {
+            mat.put(ym, readMatTableForMonth(ym));
+        }
+
+        // 4. Compare per month
+        for (YearMonth ym : live.keySet()) {
+            Map<String, Double> liveMonth = live.get(ym);
+            Map<String, Double> matMonth = mat.get(ym);
+            assertEquals(liveMonth.keySet(), matMonth.keySet(),
+                    "Dimension keys differ for " + ym);
+            for (String key : liveMonth.keySet()) {
+                assertEquals(liveMonth.get(key), matMonth.get(key), 0.01,
+                        "Amount differs for " + key + " @ " + ym);
+            }
+        }
+    }
+
+    /** Aggregate {@code List<OpexRow>} into a Map keyed by composite dimension string. */
+    private static Map<String, Double> aggregate(List<OpexRow> rows) {
+        Map<String, Double> out = new HashMap<>();
+        for (OpexRow r : rows) {
+            String key = r.companyId() + "|" + r.costCenterId() + "|"
+                    + r.expenseCategoryId() + "|" + r.isPayrollFlag();
+            out.merge(key, r.opexAmountDkk(), Double::sum);
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Double> readMatTableForMonth(YearMonth ym) {
+        String monthKey = UtilizationCalculationHelper.toMonthKey(
+                ym.getYear(), ym.getMonthValue());
+
+        List<Tuple> rows = em.createNativeQuery(
+                "SELECT company_id, cost_center_id, expense_category_id, " +
+                        "       is_payroll_flag, SUM(opex_amount_dkk) AS amt " +
+                        "FROM fact_opex_distribution_mat " +
+                        "WHERE month_key = :mk " +
+                        "GROUP BY company_id, cost_center_id, expense_category_id, is_payroll_flag",
+                Tuple.class)
+                .setParameter("mk", monthKey)
+                .getResultList();
+
+        Map<String, Double> out = new HashMap<>();
+        for (Tuple t : rows) {
+            String key = t.get("company_id") + "|"
+                    + t.get("cost_center_id") + "|"
+                    + t.get("expense_category_id") + "|"
+                    + (((Number) t.get("is_payroll_flag")).intValue() == 1);
+            out.put(key, ((Number) t.get("amt")).doubleValue());
+        }
+        return out;
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshServiceIT.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshServiceIT.java
@@ -1,0 +1,88 @@
+package dk.trustworks.intranet.aggregates.finance.services;
+
+import dk.trustworks.intranet.aggregates.finance.services.OpexDistributionRefreshService.RefreshOutcome;
+import dk.trustworks.intranet.aggregates.utilization.services.UtilizationCalculationHelper;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import java.time.YearMonth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test for {@link OpexDistributionRefreshService}.
+ *
+ * <p>Spec: docs/superpowers/specs/2026-05-11-fact-opex-distribution-mat-design.md §4
+ *
+ * <p>Asserts three properties of {@code refresh()}:
+ * <ol>
+ *   <li>It inserts rows for the current fiscal year window.</li>
+ *   <li>It is idempotent — a second call yields the same row count
+ *       and reports {@code deleted == first.inserted}.</li>
+ *   <li>The window respects the configured {@code fyBack} property —
+ *       i.e. the minimum {@code month_key} written is no earlier than
+ *       {@code currentFiscalYearStart - fyBack years}.</li>
+ * </ol>
+ */
+@QuarkusTest
+class OpexDistributionRefreshServiceIT {
+
+    @Inject
+    OpexDistributionRefreshService refreshService;
+
+    @Inject
+    EntityManager em;
+
+    @Test
+    @Transactional
+    void refresh_populatesTableForCurrentFiscalYear() {
+        RefreshOutcome outcome = refreshService.refresh();
+
+        assertTrue(outcome.inserted() > 0,
+                "expected refresh to insert rows, but inserted=" + outcome.inserted());
+        assertTrue(outcome.took().toMillis() > 0L,
+                "expected non-zero refresh duration, but took=" + outcome.took());
+
+        long rowCount = ((Number) em.createNativeQuery(
+                        "SELECT COUNT(*) FROM fact_opex_distribution_mat")
+                .getSingleResult()).longValue();
+        assertEquals(outcome.inserted(), rowCount,
+                "row count in table must equal RefreshOutcome.inserted()");
+    }
+
+    @Test
+    @Transactional
+    void refresh_isIdempotent_secondCallProducesIdenticalRowCount() {
+        RefreshOutcome first = refreshService.refresh();
+        RefreshOutcome second = refreshService.refresh();
+
+        assertEquals(first.inserted(), second.inserted(),
+                "second refresh must insert the same number of rows as the first");
+        assertEquals(first.inserted(), second.deleted(),
+                "second refresh must delete exactly what the first inserted");
+    }
+
+    @Test
+    @Transactional
+    void refresh_windowRespectsConfiguredFyBack() {
+        refreshService.refresh();
+
+        YearMonth currentFyStart = YearMonth.from(
+                UtilizationCalculationHelper.getCurrentFiscalYearRange().start());
+        YearMonth windowFloor = currentFyStart.minusYears(refreshService.fyBack);
+
+        String minMonthKey = (String) em.createNativeQuery(
+                        "SELECT MIN(month_key) FROM fact_opex_distribution_mat")
+                .getSingleResult();
+
+        String windowFloorKey = String.format("%04d%02d",
+                windowFloor.getYear(), windowFloor.getMonthValue());
+        assertTrue(minMonthKey.compareTo(windowFloorKey) >= 0,
+                "minimum month_key " + minMonthKey
+                        + " must not precede window floor " + windowFloorKey);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshServiceIT.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshServiceIT.java
@@ -8,8 +8,6 @@ import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 
-import java.time.YearMonth;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -69,18 +67,13 @@ class OpexDistributionRefreshServiceIT {
     @Test
     @Transactional
     void refresh_windowRespectsConfiguredFyBack() {
-        refreshService.refresh();
-
-        YearMonth currentFyStart = YearMonth.from(
-                UtilizationCalculationHelper.getCurrentFiscalYearRange().start());
-        YearMonth windowFloor = currentFyStart.minusYears(refreshService.fyBack);
+        RefreshOutcome outcome = refreshService.refresh();
 
         String minMonthKey = (String) em.createNativeQuery(
                         "SELECT MIN(month_key) FROM fact_opex_distribution_mat")
                 .getSingleResult();
 
-        String windowFloorKey = String.format("%04d%02d",
-                windowFloor.getYear(), windowFloor.getMonthValue());
+        String windowFloorKey = UtilizationCalculationHelper.toMonthKey(outcome.windowFrom());
         assertTrue(minMonthKey.compareTo(windowFloorKey) >= 0,
                 "minimum month_key " + minMonthKey
                         + " must not precede window floor " + windowFloorKey);


### PR DESCRIPTION
## Release Summary

Backend release with one feature (16 commits since previous prod release):

### Finance — Opex Distribution Materialization
- New `fact_opex_distribution_mat` table (Flyway V337) — caches OPEX distribution computation that was timing out EBITDA forecasts
- `OpexDistributionRefreshService` + `OpexDistributionRefreshBatchlet` — nightly refresh at 03:30 UTC
- `OpexDistributionFreshnessCheck` `@Readiness` probe — first of its kind in the codebase; alerts via existing Slack ops channel if the materialized view is stale
- Health-check edge cases addressed during staging rollout:
  - Empty table now reports UP (cold-start safe)
  - JDBC `LocalDateTime` cast handled in freshness check

### No API contract changes
- No frontend coordination required
- No drop-column migrations

## Pre-merge checklist
- [x] Staging stable on commit `0a653dd0` (third deployment iteration after two health-check rollbacks)
- [x] Parity tests pass for OpexDistributionRefresh
- [x] Slack alerting verified

Spec/plans:
- docs/superpowers/specs/2026-05-11-opex-distribution-materialization.md
- docs/superpowers/plans/2026-05-11-opex-distribution-materialization.md