### PR TITLE
fix(finance): unbreak opex-distribution nightly refresh — tx timeout + verification mode startup

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
@@ -8,7 +8,6 @@ import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
-import jakarta.persistence.EntityManager;
 import lombok.extern.jbosslog.JBossLog;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.context.ManagedExecutor;
@@ -44,9 +43,6 @@ public class OpexDistributionRefreshBatchlet {
     SlackService slackService;
 
     @Inject
-    EntityManager em;
-
-    @Inject
     ManagedExecutor managedExecutor;
 
     @ConfigProperty(name = "slack.opsAlertChannel", defaultValue = "C0B2VQ2CFU1")
@@ -70,25 +66,21 @@ public class OpexDistributionRefreshBatchlet {
     }
 
     /**
-     * Cold-start guard: if the table is empty on app boot, fire a one-shot
-     * async refresh so the EBITDA endpoint isn't broken until the next
-     * scheduled run.
+     * Startup refresh: fires a one-shot async refresh on every boot so we can
+     * verify the nightly batch path immediately after deploy without waiting
+     * for the next 03:30 UTC cycle. Reverted to "only when empty" in PR 2
+     * once the read path is flipped and confidence in the refresh is high.
      */
     void onStart(@Observes StartupEvent ev) {
-        long rowCount = ((Number) em.createNativeQuery(
-                "SELECT COUNT(*) FROM fact_opex_distribution_mat")
-                .getSingleResult()).longValue();
-        if (rowCount == 0) {
-            log.warnf("fact_opex_distribution_mat is empty on startup — triggering one-shot refresh asynchronously");
-            managedExecutor.submit(() -> {
-                try {
-                    refreshService.refresh();
-                } catch (Exception e) {
-                    log.errorf(e, "startup one-shot refresh failed");
-                    fireSlackAlertIfNeeded(e);
-                }
-            });
-        }
+        log.warnf("Triggering one-shot fact_opex_distribution_mat refresh asynchronously on startup (verification mode)");
+        managedExecutor.submit(() -> {
+            try {
+                refreshService.refresh();
+            } catch (Exception e) {
+                log.errorf(e, "startup one-shot refresh failed");
+                fireSlackAlertIfNeeded(e);
+            }
+        });
     }
 
     void fireSlackAlertIfNeeded(Exception e) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,13 @@ quarkus:
       leak-detection-interval: PT5M
     username: ${USERNAME:root}
     password: ${PASSWORD:1606}
+  transaction-manager:
+    # OpexDistributionRefreshService.refresh() loads ~165k rows from finance_details +
+    # fact_user_day and inserts 321 rows in one prepared statement — real duration is
+    # 56-60s. The Narayana default of 60s is too tight; staging (1 vCPU) blows past it
+    # while production (2 vCPU) succeeds by ~4s. 600s gives generous headroom without
+    # masking pathological regressions.
+    default-transaction-timeout: 600s
   hibernate-orm:
     jdbc:
       statement-batch-size: 32


### PR DESCRIPTION
## Summary

PR 1's nightly refresh of `fact_opex_distribution_mat` failed on staging at 2026-05-13 03:31 UTC with `jakarta.transaction.RollbackException: ARJUNA016102: The transaction is not active!`. Root cause: the workload genuinely takes 56-60s and the Narayana default tx timeout is 60s.

- Production (2 vCPU) finished in 56.36s — succeeded with a 4s margin
- Staging (1 vCPU) exceeded 60s — tx rolled back, table stays stale
- Slack alert path also broken on staging (`tokenKey=mother` → channel `C0B2VQ2CFU1` returns `invalid_auth`) so the failure was silent

## Fix

1. **`quarkus.transaction-manager.default-transaction-timeout: 600s`** — gives ~10x headroom over the typical workload without masking real regressions.
2. **`onStart()` fires the refresh unconditionally** — so we can verify the fix on next deploy instead of waiting 24h for the next 03:30 UTC cycle. Reverted to "only when empty" in PR 2 once the read path is flipped.

## Test plan

- [x] `./mvnw compile` passes
- [ ] Merge to staging, wait ~17 min for ECS deploy
- [ ] Probe `/health/ready` — `opex-distribution-freshness` should show `oldest_refreshed_at` within the last few minutes
- [ ] CloudWatch shows `Refreshed fact_opex_distribution_mat: deleted=321 inserted=321 took=<~60000>ms` without the rollback

Once green, PR 2 (Tasks 10-15: flip read path) can land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)