### PR TITLE
test(finance): align OpexDistributionRefreshBatchletTest with verification-mode startup

### DIFF
--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchletTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchletTest.java
@@ -3,8 +3,6 @@ package dk.trustworks.intranet.aggregates.finance.jobs;
 import dk.trustworks.intranet.aggregates.finance.services.OpexDistributionRefreshService;
 import dk.trustworks.intranet.aggregates.finance.services.OpexDistributionRefreshService.RefreshOutcome;
 import dk.trustworks.intranet.communicationsservice.services.SlackService;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,9 +40,7 @@ class OpexDistributionRefreshBatchletTest {
 
     @Mock OpexDistributionRefreshService refreshService;
     @Mock SlackService slackService;
-    @Mock EntityManager em;
     @Mock ManagedExecutor managedExecutor;
-    @Mock Query query;
 
     OpexDistributionRefreshBatchlet batchlet;
 
@@ -53,7 +49,6 @@ class OpexDistributionRefreshBatchletTest {
         batchlet = new OpexDistributionRefreshBatchlet();
         batchlet.refreshService = refreshService;
         batchlet.slackService = slackService;
-        batchlet.em = em;
         batchlet.managedExecutor = managedExecutor;
         batchlet.opsAlertChannel = CHANNEL;
     }
@@ -104,24 +99,14 @@ class OpexDistributionRefreshBatchletTest {
     }
 
     @Test
-    void onStart_emptyTable_submitsAsyncRefresh() {
-        when(em.createNativeQuery(anyString())).thenReturn(query);
-        when(query.getSingleResult()).thenReturn(0L);
-
+    void onStart_alwaysSubmitsAsyncRefresh() {
+        // Verification-mode startup: refresh fires on every boot so we can
+        // observe the nightly path after deploy. Reverted to "only when empty"
+        // in PR 2 once the read path is flipped.
         batchlet.onStart(null);
 
         verify(managedExecutor, times(1)).submit(org.mockito.ArgumentMatchers.<Runnable>any());
         verify(refreshService, never()).refresh();
-    }
-
-    @Test
-    void onStart_populatedTable_doesNotTriggerRefresh() {
-        when(em.createNativeQuery(anyString())).thenReturn(query);
-        when(query.getSingleResult()).thenReturn(123L);
-
-        batchlet.onStart(null);
-
-        verify(managedExecutor, never()).submit(org.mockito.ArgumentMatchers.<Runnable>any());
     }
 
     @Test


### PR DESCRIPTION
## Summary

PR #66 introduced a test compile error: it removed \`OpexDistributionRefreshBatchlet.em\` (no longer needed by \`onStart()\`) but the test still set \`batchlet.em = em\`. This blocks the staging build.

## Fix

- Drop \`@Mock EntityManager em\` / \`@Mock Query query\` and their imports
- Replace the two onStart tests (empty vs populated) with one asserting \`onStart\` always submits the async refresh (verification-mode behavior PR #66 introduced)

These onStart tests get re-added in PR 2 once the read path is flipped and onStart reverts to "only when empty".

## Test plan

- [x] \`./mvnw test -Dtest=OpexDistributionRefreshBatchletTest\` — 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)