### PR TITLE
Release: opex-distribution materialized read path (PR 1 patch + PR 2)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
@@ -8,7 +8,6 @@ import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
-import jakarta.persistence.EntityManager;
 import lombok.extern.jbosslog.JBossLog;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.context.ManagedExecutor;
@@ -44,9 +43,6 @@ public class OpexDistributionRefreshBatchlet {
     SlackService slackService;
 
     @Inject
-    EntityManager em;
-
-    @Inject
     ManagedExecutor managedExecutor;
 
     @ConfigProperty(name = "slack.opsAlertChannel", defaultValue = "C0B2VQ2CFU1")
@@ -70,25 +66,21 @@ public class OpexDistributionRefreshBatchlet {
     }
 
     /**
-     * Cold-start guard: if the table is empty on app boot, fire a one-shot
-     * async refresh so the EBITDA endpoint isn't broken until the next
-     * scheduled run.
+     * Startup refresh: fires a one-shot async refresh on every boot so we can
+     * verify the nightly batch path immediately after deploy without waiting
+     * for the next 03:30 UTC cycle. Reverted to "only when empty" in PR 2
+     * once the read path is flipped and confidence in the refresh is high.
      */
     void onStart(@Observes StartupEvent ev) {
-        long rowCount = ((Number) em.createNativeQuery(
-                "SELECT COUNT(*) FROM fact_opex_distribution_mat")
-                .getSingleResult()).longValue();
-        if (rowCount == 0) {
-            log.warnf("fact_opex_distribution_mat is empty on startup — triggering one-shot refresh asynchronously");
-            managedExecutor.submit(() -> {
-                try {
-                    refreshService.refresh();
-                } catch (Exception e) {
-                    log.errorf(e, "startup one-shot refresh failed");
-                    fireSlackAlertIfNeeded(e);
-                }
-            });
-        }
+        log.warnf("Triggering one-shot fact_opex_distribution_mat refresh asynchronously on startup (verification mode)");
+        managedExecutor.submit(() -> {
+            try {
+                refreshService.refresh();
+            } catch (Exception e) {
+                log.errorf(e, "startup one-shot refresh failed");
+                fireSlackAlertIfNeeded(e);
+            }
+        });
     }
 
     void fireSlackAlertIfNeeded(Exception e) {

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchlet.java
@@ -8,6 +8,7 @@ import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 import lombok.extern.jbosslog.JBossLog;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.context.ManagedExecutor;
@@ -45,6 +46,9 @@ public class OpexDistributionRefreshBatchlet {
     @Inject
     ManagedExecutor managedExecutor;
 
+    @Inject
+    EntityManager em;
+
     @ConfigProperty(name = "slack.opsAlertChannel", defaultValue = "C0B2VQ2CFU1")
     String opsAlertChannel;
 
@@ -66,21 +70,25 @@ public class OpexDistributionRefreshBatchlet {
     }
 
     /**
-     * Startup refresh: fires a one-shot async refresh on every boot so we can
-     * verify the nightly batch path immediately after deploy without waiting
-     * for the next 03:30 UTC cycle. Reverted to "only when empty" in PR 2
-     * once the read path is flipped and confidence in the refresh is high.
+     * Cold-start guard: if the table is empty on app boot, fire a one-shot
+     * async refresh so the EBITDA endpoint isn't broken until the next
+     * scheduled run.
      */
     void onStart(@Observes StartupEvent ev) {
-        log.warnf("Triggering one-shot fact_opex_distribution_mat refresh asynchronously on startup (verification mode)");
-        managedExecutor.submit(() -> {
-            try {
-                refreshService.refresh();
-            } catch (Exception e) {
-                log.errorf(e, "startup one-shot refresh failed");
-                fireSlackAlertIfNeeded(e);
-            }
-        });
+        long rowCount = ((Number) em.createNativeQuery(
+                "SELECT COUNT(*) FROM fact_opex_distribution_mat")
+                .getSingleResult()).longValue();
+        if (rowCount == 0) {
+            log.warnf("fact_opex_distribution_mat is empty on startup — triggering one-shot refresh asynchronously");
+            managedExecutor.submit(() -> {
+                try {
+                    refreshService.refresh();
+                } catch (Exception e) {
+                    log.errorf(e, "startup one-shot refresh failed");
+                    fireSlackAlertIfNeeded(e);
+                }
+            });
+        }
     }
 
     void fireSlackAlertIfNeeded(Exception e) {

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
@@ -59,9 +59,6 @@ import lombok.extern.jbosslog.JBossLog;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
-import io.quarkus.cache.CacheKey;
-import io.quarkus.cache.CacheResult;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -1249,14 +1246,13 @@ public class CxoFinanceResource {
      */
     @GET
     @Path("/expected-accumulated-ebitda")
-    @CacheResult(cacheName = "expected-accumulated-ebitda")
     public List<MonthlyAccumulatedEbitdaDTO> getExpectedAccumulatedEBITDA(
-            @CacheKey @QueryParam("asOfDate") String asOfDateStr,
-            @CacheKey @QueryParam("sectors") String sectors,
-            @CacheKey @QueryParam("serviceLines") String serviceLines,
-            @CacheKey @QueryParam("contractTypes") String contractTypes,
-            @CacheKey @QueryParam("clientId") String clientId,
-            @CacheKey @QueryParam("companyIds") String companyIds) {
+            @QueryParam("asOfDate") String asOfDateStr,
+            @QueryParam("sectors") String sectors,
+            @QueryParam("serviceLines") String serviceLines,
+            @QueryParam("contractTypes") String contractTypes,
+            @QueryParam("clientId") String clientId,
+            @QueryParam("companyIds") String companyIds) {
 
         log.debugf("GET /finance/cxo/expected-accumulated-ebitda: asOfDate=%s, sectors=%s, serviceLines=%s, contractTypes=%s, clientId=%s, companyIds=%s",
                 asOfDateStr, sectors, serviceLines, contractTypes, clientId, companyIds);

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/DistributionAwareOpexProvider.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/DistributionAwareOpexProvider.java
@@ -336,6 +336,77 @@ public class DistributionAwareOpexProvider {
         return result;
     }
 
+    /**
+     * Reads OPEX rows for the given months from {@code fact_opex_distribution_mat}.
+     * Mirror of {@link #queryFactOpexMat}, but for distribution-computed rows that
+     * the nightly batchlet writes. Result rows carry {@code OpexRow.SOURCE_DISTRIBUTION}.
+     *
+     * <p>Callers (in particular {@link #getDistributionAwareOpex}) decide which
+     * months go to which table based on settlement state.
+     */
+    @SuppressWarnings("unchecked")
+    private List<OpexRow> queryFactOpexDistributionMat(
+            String fromMonthKey,
+            String toMonthKey,
+            Set<String> companyIds,
+            Set<String> costCenters,
+            Set<String> expenseCategories) {
+
+        StringBuilder sql = new StringBuilder(
+                "SELECT company_id, cost_center_id, expense_category_id, cost_type, month_key, " +
+                "  SUM(opex_amount_dkk) AS opex_amount, " +
+                "  SUM(invoice_count) AS invoice_count, " +
+                "  MAX(is_payroll_flag) AS is_payroll " +
+                "FROM fact_opex_distribution_mat " +
+                "WHERE month_key >= :fromMonthKey AND month_key <= :toMonthKey "
+        );
+
+        if (companyIds != null && !companyIds.isEmpty()) {
+            sql.append("AND company_id IN (:companyIds) ");
+        }
+        if (costCenters != null && !costCenters.isEmpty()) {
+            sql.append("AND cost_center_id IN (:costCenters) ");
+        }
+        if (expenseCategories != null && !expenseCategories.isEmpty()) {
+            sql.append("AND expense_category_id IN (:expenseCategories) ");
+        }
+        sql.append("GROUP BY company_id, cost_center_id, expense_category_id, cost_type, month_key " +
+                   "ORDER BY month_key ASC");
+
+        var query = em.createNativeQuery(sql.toString(), Tuple.class);
+        query.setParameter("fromMonthKey", fromMonthKey);
+        query.setParameter("toMonthKey", toMonthKey);
+        if (companyIds != null && !companyIds.isEmpty()) {
+            query.setParameter("companyIds", companyIds);
+        }
+        if (costCenters != null && !costCenters.isEmpty()) {
+            query.setParameter("costCenters", costCenters);
+        }
+        if (expenseCategories != null && !expenseCategories.isEmpty()) {
+            query.setParameter("expenseCategories", expenseCategories);
+        }
+
+        List<Tuple> rows = query.getResultList();
+        List<OpexRow> result = new ArrayList<>(rows.size());
+        for (Tuple row : rows) {
+            double amount = row.get("opex_amount") != null
+                    ? ((Number) row.get("opex_amount")).doubleValue() : 0.0;
+            if (amount <= 0.0) continue;
+            result.add(new OpexRow(
+                    (String) row.get("company_id"),
+                    (String) row.get("cost_center_id"),
+                    (String) row.get("expense_category_id"),
+                    (String) row.get("month_key"),
+                    amount,
+                    row.get("invoice_count") != null
+                            ? ((Number) row.get("invoice_count")).intValue() : 0,
+                    "SALARIES".equals(row.get("cost_type")),
+                    OpexRow.SOURCE_DISTRIBUTION
+            ));
+        }
+        return result;
+    }
+
     // -----------------------------------------------------------------------
     // Current FY: distribution computation
     // -----------------------------------------------------------------------

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/DistributionAwareOpexProvider.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/DistributionAwareOpexProvider.java
@@ -1,29 +1,15 @@
 package dk.trustworks.intranet.aggregates.finance.services;
 
-import dk.trustworks.intranet.aggregates.accounting.services.IntercompanyCalcService;
-import dk.trustworks.intranet.aggregates.accounting.services.IntercompanyCalcService.MonthData;
-import dk.trustworks.intranet.aggregates.accounting.services.IntercompanyCalcService.ShareAmounts;
 import dk.trustworks.intranet.aggregates.finance.dto.OpexRow;
-import dk.trustworks.intranet.financeservice.model.AccountingAccount;
-import dk.trustworks.intranet.financeservice.model.AccountingCategory;
-import dk.trustworks.intranet.financeservice.model.enums.CostType;
-import dk.trustworks.intranet.model.Company;
-import io.quarkus.cache.CacheKey;
-import io.quarkus.cache.CacheResult;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Tuple;
 import lombok.extern.jbosslog.JBossLog;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,9 +19,10 @@ import java.util.TreeMap;
  * Settlement-aware OPEX data provider that unifies two data sources per month:
  * <ol>
  *   <li><b>Unsettled months</b>: months for which no finalized INTERNAL_SERVICE invoice exists
- *       — {@code fact_opex_mat} still reflects raw pre-distribution GL, so this provider computes
- *       distribution via {@link IntercompanyCalcService} so each company sees its allocated
- *       share of shared expenses.</li>
+ *       — {@code fact_opex_mat} still reflects raw pre-distribution GL, so this provider reads
+ *       from {@code fact_opex_distribution_mat} (populated nightly by
+ *       {@link OpexDistributionRefreshService}) where each company sees its allocated share of
+ *       shared expenses.</li>
  *   <li><b>Settled months</b>: months with at least one finalized INTERNAL_SERVICE invoice
  *       (status != DRAFT) — settlement is already booked in the GL via the resulting voucher,
  *       so this provider queries {@code fact_opex_mat} directly (raw GL).</li>
@@ -51,65 +38,15 @@ import java.util.TreeMap;
  * sometimes monthly, sometimes lumped at year-end, sometimes skipped entirely (e.g. due to cash
  * position). The settlement-presence check makes the chart correct regardless of cadence.
  *
- * <p>Category mapping logic is intentionally kept in sync with the {@code category_mapping} CTE in
- * {@code V205__Recreate_fact_opex_with_cost_type.sql}. Any change to V205 must be reflected here
- * and vice versa. Account filtering uses {@code cost_type IN (OPEX, SALARIES)} instead of the
- * brittle account-code-range filter [3000, 6000) that was removed in V205.
+ * <p>Prior to PR 2 this provider also computed the distribution algorithm inline on every
+ * request, which made the EBITDA forecast endpoint a >30s cold-path. The algorithm now lives in
+ * {@link OpexDistributionRefreshService} and runs nightly; this class reads the materialized
+ * output and stays on the hot read path. Category mapping logic and {@code OPEX_COST_TYPES} have
+ * therefore moved to the refresh service alongside the compute methods.
  */
 @ApplicationScoped
 @JBossLog
 public class DistributionAwareOpexProvider {
-
-    // -----------------------------------------------------------------------
-    // Category mapping — MUST match V125__fact_opex.sql category_mapping CTE
-    // -----------------------------------------------------------------------
-
-    /**
-     * Maps accounting_categories.groupname (stored as AccountingCategory.accountname in Java)
-     * to the expense_category_id dimension used by fact_opex.
-     *
-     * Matches exactly the CASE expression in V125 category_mapping CTE.
-     */
-    private static final Map<String, String> GROUPNAME_TO_EXPENSE_CATEGORY;
-
-    /**
-     * Maps accounting_categories.groupname to cost_center_id dimension.
-     *
-     * Matches exactly the CASE expression in V125 category_mapping CTE.
-     */
-    private static final Map<String, String> GROUPNAME_TO_COST_CENTER;
-
-    static {
-        Map<String, String> ec = new HashMap<>();
-        ec.put("Delte services",                      "PEOPLE_NON_BILLABLE");
-        ec.put("Salgsfremmende omkostninger",          "SALES_MARKETING");
-        ec.put("Lokaleomkostninger",                   "OFFICE_FACILITIES");
-        ec.put("Variable omkostninger",                "TOOLS_SOFTWARE");
-        ec.put("\u00D8vrige administrationsomk. i alt", "OTHER_OPEX");  // Øvrige administrationsomk. i alt
-        GROUPNAME_TO_EXPENSE_CATEGORY = Collections.unmodifiableMap(ec);
-
-        Map<String, String> cc = new HashMap<>();
-        cc.put("Delte services",                      "HR_ADMIN");
-        cc.put("Salgsfremmende omkostninger",          "SALES");
-        cc.put("Lokaleomkostninger",                   "FACILITIES");
-        cc.put("Variable omkostninger",                "INTERNAL_IT");
-        cc.put("\u00D8vrige administrationsomk. i alt", "ADMIN");       // Øvrige administrationsomk. i alt
-        GROUPNAME_TO_COST_CENTER = Collections.unmodifiableMap(cc);
-    }
-
-    /**
-     * Cost types included in the OPEX distribution. Matches the filter in V205 fact_opex.
-     * OPEX and SALARIES are the two types that flow through the distribution algorithm.
-     * DIRECT_COSTS, REVENUE, IGNORE, and OTHER are excluded.
-     */
-    private static final Set<CostType> OPEX_COST_TYPES = Set.of(CostType.OPEX, CostType.SALARIES);
-
-    /** Salary buffer multiplier — same config property used by AccountingResource. */
-    @ConfigProperty(name = "dk.trustworks.intranet.aggregates.accounting.salary-buffer-multiplier", defaultValue = "1.02")
-    double salaryBufferMultiplier;
-
-    @Inject
-    IntercompanyCalcService intercompanyCalcService;
 
     @Inject
     EntityManager em;
@@ -121,8 +58,9 @@ public class DistributionAwareOpexProvider {
     /**
      * Returns OPEX rows for the given month range and optional filters.
      *
-     * <p>Months in the current fiscal year are served via the distribution algorithm.
-     * Months in a previous fiscal year are served from {@code fact_opex_mat} (raw GL).
+     * <p>Months with a finalized INTERNAL_SERVICE invoice are served from
+     * {@code fact_opex_mat} (raw GL). All other months are served from
+     * {@code fact_opex_distribution_mat} which the nightly refresh batch populates.
      *
      * @param fromMonthKey     start month inclusive, format YYYYMM
      * @param toMonthKey       end month inclusive, format YYYYMM
@@ -138,50 +76,59 @@ public class DistributionAwareOpexProvider {
             Set<String> costCenters,
             Set<String> expenseCategories) {
 
-        log.debugf("getDistributionAwareOpex: from=%s to=%s companies=%s", fromMonthKey, toMonthKey, companyIds);
+        log.debugf("getDistributionAwareOpex: from=%s to=%s companies=%s",
+                fromMonthKey, toMonthKey, companyIds);
 
         YearMonth from = parseMonthKey(fromMonthKey);
         YearMonth to   = parseMonthKey(toMonthKey);
 
         Set<YearMonth> settledMonths = findSettledMonths(from, to);
 
-        List<YearMonth> unsettledMonths = new ArrayList<>();
-        List<YearMonth> rawGlMonths     = new ArrayList<>();
-
+        // Build contiguous-range monthKey strings for the two paths. The settled
+        // path queries fact_opex_mat by [min, max] range; the unsettled path queries
+        // fact_opex_distribution_mat the same way. We use min..max (not a list) because:
+        //   - it preserves the IN-clause-free SQL shape we already have for fact_opex_mat
+        //   - filter by `WHERE month_key IN settledKeys` inline after the fetch handles
+        //     the rare non-contiguous case
+        List<String> settledKeys   = new ArrayList<>();
+        List<String> unsettledKeys = new ArrayList<>();
         for (YearMonth ym = from; !ym.isAfter(to); ym = ym.plusMonths(1)) {
-            if (settledMonths.contains(ym)) {
-                rawGlMonths.add(ym);
-            } else {
-                unsettledMonths.add(ym);
-            }
+            (settledMonths.contains(ym) ? settledKeys : unsettledKeys)
+                    .add(formatMonthKey(ym));
         }
 
         List<OpexRow> result = new ArrayList<>();
-
-        // Settled months: raw GL from fact_opex_mat (a single contiguous range query is fine —
-        // any unsettled gaps inside the range simply contribute zero rows from fact_opex_mat
-        // because the INTERNAL_SERVICE voucher hasn't been booked, but we still query distribution
-        // for those months separately below)
-        if (!rawGlMonths.isEmpty()) {
-            String prevFrom = formatMonthKey(rawGlMonths.getFirst());
-            String prevTo   = formatMonthKey(rawGlMonths.getLast());
-            // Filter results to settled months only — covers the case of non-contiguous settlement
-            List<OpexRow> rawRows = queryFactOpexMat(prevFrom, prevTo, companyIds, costCenters, expenseCategories);
+        if (!settledKeys.isEmpty()) {
+            String prevFrom = settledKeys.getFirst();
+            String prevTo   = settledKeys.getLast();
+            List<OpexRow> rawRows = queryFactOpexMat(prevFrom, prevTo,
+                    companyIds, costCenters, expenseCategories);
+            // Keep only settled months (covers the non-contiguous case).
             for (OpexRow row : rawRows) {
-                YearMonth ym = parseMonthKey(row.monthKey());
-                if (settledMonths.contains(ym)) {
+                if (settledMonths.contains(parseMonthKey(row.monthKey()))) {
+                    result.add(row);
+                }
+            }
+        }
+        if (!unsettledKeys.isEmpty()) {
+            String distFrom = unsettledKeys.getFirst();
+            String distTo   = unsettledKeys.getLast();
+            List<OpexRow> distRows = queryFactOpexDistributionMat(distFrom, distTo,
+                    companyIds, costCenters, expenseCategories);
+            // Same non-contiguous filter, in case a settled month sits between
+            // two unsettled ones.
+            Set<YearMonth> unsettledSet = new HashSet<>();
+            for (YearMonth ym = from; !ym.isAfter(to); ym = ym.plusMonths(1)) {
+                if (!settledMonths.contains(ym)) unsettledSet.add(ym);
+            }
+            for (OpexRow row : distRows) {
+                if (unsettledSet.contains(parseMonthKey(row.monthKey()))) {
                     result.add(row);
                 }
             }
         }
 
-        // Unsettled months: distribution algorithm, batch-loaded for efficiency
-        if (!unsettledMonths.isEmpty()) {
-            result.addAll(computeDistributionForMonths(unsettledMonths, companyIds, costCenters, expenseCategories));
-        }
-
-        // Sort by monthKey ascending so callers get chronological order
-        result.sort((a, b) -> a.monthKey().compareTo(b.monthKey()));
+        result.sort(java.util.Comparator.comparing(OpexRow::monthKey));
         return result;
     }
 
@@ -262,7 +209,7 @@ public class DistributionAwareOpexProvider {
                 .setParameter("toKey", toKey)
                 .getResultList();
 
-        Set<YearMonth> result = new java.util.HashSet<>();
+        Set<YearMonth> result = new HashSet<>();
         for (Object[] row : rows) {
             int yr = ((Number) row[0]).intValue();
             int mn = ((Number) row[1]).intValue();
@@ -272,7 +219,7 @@ public class DistributionAwareOpexProvider {
     }
 
     // -----------------------------------------------------------------------
-    // Previous FY: query fact_opex_mat
+    // Settled months: query fact_opex_mat
     // -----------------------------------------------------------------------
 
     @SuppressWarnings("unchecked")
@@ -405,256 +352,6 @@ public class DistributionAwareOpexProvider {
             ));
         }
         return result;
-    }
-
-    // -----------------------------------------------------------------------
-    // Current FY: distribution computation
-    // -----------------------------------------------------------------------
-
-    /**
-     * Batch-loads fiscal year data via {@link IntercompanyCalcService#loadFiscalYear} and
-     * computes distribution for each requested month.
-     *
-     * <p>Using the batch loader avoids separate GL + availability queries per month, which
-     * would be prohibitively expensive when 12 months are requested in a single page load.
-     */
-    private List<OpexRow> computeDistributionForMonths(
-            List<YearMonth> months,
-            Set<String> companyIds,
-            Set<String> costCenters,
-            Set<String> expenseCategories) {
-
-        YearMonth first = months.getFirst();
-        YearMonth last  = months.getLast();
-
-        LocalDate batchFrom = first.atDay(1);
-        LocalDate batchTo   = last.plusMonths(1).atDay(1);  // exclusive
-
-        log.debugf("Loading FY batch for distribution: %s – %s (%d months)", batchFrom, batchTo, months.size());
-
-        IntercompanyCalcService.FiscalYearData fyData =
-                intercompanyCalcService.loadFiscalYear(batchFrom, batchTo, salaryBufferMultiplier);
-
-        List<OpexRow> result = new ArrayList<>();
-        for (YearMonth ym : months) {
-            MonthData md = fyData.perMonth.get(ym);
-            if (md == null) {
-                log.warnf("No MonthData found for %s in FiscalYearData — skipping", ym);
-                continue;
-            }
-            Map<String, BigDecimal> lumps = fyData.lumpsByMonth.getOrDefault(ym, Collections.emptyMap());
-            List<OpexRow> monthRows = computeDistributionForMonth(ym, md, lumps);
-            result.addAll(applyFilters(monthRows, companyIds, costCenters, expenseCategories));
-        }
-        return result;
-    }
-
-    /**
-     * Computes distribution-adjusted OPEX rows for a single month.
-     *
-     * <p>This method is cached per monthKey to avoid redundant recomputation when the same
-     * month is queried by multiple CXO endpoints in a single page load.
-     * The 5-minute TTL matches the {@code sp_incremental_bi_refresh} frequency.
-     *
-     * <p>Note: {@code @CacheResult} only caches on the method arguments as cache key.
-     * The cache key here is {@code monthKey} (the first argument). Since all data for a month
-     * is derived from the same GL snapshot, caching per monthKey is correct.
-     *
-     * <p>The method delegates computation details to
-     * {@link #computeDistributionRowsForMonth(YearMonth, MonthData, Map)}
-     * to keep the cached method signature simple.
-     */
-    @CacheResult(cacheName = "distribution-opex")
-    public List<OpexRow> computeDistributionForMonth(
-            @CacheKey YearMonth monthKey,
-            MonthData md,
-            Map<String, BigDecimal> lumpsByAccount) {
-        return computeDistributionRowsForMonth(monthKey, md, lumpsByAccount);
-    }
-
-    /**
-     * Core distribution logic for one month.
-     *
-     * <p>Algorithm:
-     * <ol>
-     *   <li>For each origin company × account where {@code cost_type IN (OPEX, SALARIES)}:
-     *       <ul>
-     *         <li>Compute {@link ShareAmounts} via
-     *             {@link IntercompanyCalcService#computeDistributionLegacyShareForAccount}</li>
-     *         <li>For each payer company: allocated = baseToShare * payerRatio
-     *             + (if payer==origin: originRemainder)</li>
-     *       </ul>
-     *   <li>Map each (origin, payer, account) to OPEX category dimensions using
-     *       {@link #resolveExpenseCategory} and {@link #resolveCostCenter}.</li>
-     *   <li>Aggregate per (payerCompany × costCenter × expenseCategory × month).</li>
-     * </ol>
-     *
-     * <p>The {@code staffRemainingByCompany} map is mutated by
-     * {@code computeDistributionLegacyShareForAccount} to implement salary pool capping.
-     * A fresh mutable copy is created per month call to avoid cross-call contamination.
-     */
-    private List<OpexRow> computeDistributionRowsForMonth(
-            YearMonth ym,
-            MonthData md,
-            Map<String, BigDecimal> lumpsByAccount) {
-
-        String monthKeyStr = formatMonthKey(ym);
-
-        // Salary pool cap state — must be mutable and reset per month (legacy semantics)
-        Map<String, BigDecimal> staffRemainingByCompany = new HashMap<>(md.staffBaseBI102);
-
-        // Accumulator: payerUuid → costCenterId → expenseCategoryId → isPayroll → amount.
-        // isPayroll is a key dimension so SALARIES accounts cannot contaminate the OPEX
-        // total inside categories that mix both cost types (e.g. "Delte services" maps
-        // 84 OPEX accounts and 3 SALARIES accounts into PEOPLE_NON_BILLABLE).
-        Map<String, Map<String, Map<String, Map<Boolean, Double>>>> accumulator = new HashMap<>();
-
-        for (AccountingCategory category : md.categories) {
-            String groupname = category.getAccountname();  // maps to groupname column
-
-            String expenseCategoryId = resolveExpenseCategory(groupname);
-            String costCenterId      = resolveCostCenter(groupname);
-
-            for (AccountingAccount account : category.getAccounts()) {
-
-                // Filter by cost_type: only OPEX and SALARIES accounts participate in distribution.
-                // Replaces the brittle account-code range [3000, 6000) and EXCLUDED_GROUPNAMES.
-                // Matches the filter in V205 fact_opex (aa.cost_type IN ('OPEX', 'SALARIES')).
-                if (!OPEX_COST_TYPES.contains(account.getCostType())) continue;
-
-                String originUuid = account.getCompany().getUuid();
-
-                BigDecimal gl = md.glByCompanyAccountRange
-                        .getOrDefault(originUuid, Collections.emptyMap())
-                        .getOrDefault(account.getAccountCode(), BigDecimal.ZERO);
-
-                // Use absolute value to match V125 fact_opex which uses SUM(ABS(amount)).
-                // Credit/reversal entries (negative GL) still contribute to OPEX totals.
-                gl = gl.abs();
-
-                BigDecimal lump = lumpsByAccount.getOrDefault(account.getUuid(), BigDecimal.ZERO);
-
-                ShareAmounts share = intercompanyCalcService.computeDistributionLegacyShareForAccount(
-                        md, account, originUuid, gl, lump, staffRemainingByCompany);
-
-                boolean isPayroll = account.isSalary();
-
-                for (Company payer : md.companies) {
-                    String payerUuid = payer.getUuid();
-                    BigDecimal ratio = md.ratioByCompany.getOrDefault(payerUuid, BigDecimal.ZERO);
-
-                    BigDecimal allocated = BigDecimal.ZERO;
-
-                    if (share.baseToShare.compareTo(BigDecimal.ZERO) > 0) {
-                        allocated = allocated.add(
-                                share.baseToShare.multiply(ratio).setScale(IntercompanyCalcService.SCALE, IntercompanyCalcService.RM)
-                        );
-                    }
-                    if (payerUuid.equals(originUuid) && share.originRemainder.compareTo(BigDecimal.ZERO) > 0) {
-                        allocated = allocated.add(share.originRemainder);
-                    }
-
-                    if (allocated.compareTo(BigDecimal.ZERO) <= 0) continue;
-
-                    // Accumulate: payerUuid → costCenterId → expenseCategoryId → isPayroll → amount
-                    accumulator
-                            .computeIfAbsent(payerUuid, k -> new HashMap<>())
-                            .computeIfAbsent(costCenterId, k -> new HashMap<>())
-                            .computeIfAbsent(expenseCategoryId, k -> new HashMap<>())
-                            .merge(isPayroll, allocated.doubleValue(), Double::sum);
-                }
-            }
-        }
-
-        // Flatten accumulator → OpexRow list. Each (payer, costCenter, expenseCategory)
-        // can produce up to two rows — one with isPayroll=true and one with isPayroll=false —
-        // mirroring how fact_opex_mat keeps SALARIES and OPEX rows separate by cost_type.
-        List<OpexRow> rows = new ArrayList<>();
-        for (var payerEntry : accumulator.entrySet()) {
-            String payerUuid = payerEntry.getKey();
-            for (var ccEntry : payerEntry.getValue().entrySet()) {
-                String costCenterId = ccEntry.getKey();
-                for (var catEntry : ccEntry.getValue().entrySet()) {
-                    String expenseCategoryId = catEntry.getKey();
-                    for (var prEntry : catEntry.getValue().entrySet()) {
-                        boolean isPayroll = prEntry.getKey();
-                        double amount = prEntry.getValue();
-
-                        if (amount <= 0.0) continue;
-
-                        rows.add(new OpexRow(
-                                payerUuid,
-                                costCenterId,
-                                expenseCategoryId,
-                                monthKeyStr,
-                                amount,
-                                1,  // distribution rows don't have individual GL entry counts
-                                isPayroll,
-                                OpexRow.SOURCE_DISTRIBUTION
-                        ));
-                    }
-                }
-            }
-        }
-
-        log.debugf("Distribution computed for %s: %d rows across %d companies",
-                monthKeyStr, rows.size(), md.companies.size());
-        return rows;
-    }
-
-    // -----------------------------------------------------------------------
-    // Category mapping helpers
-    // -----------------------------------------------------------------------
-
-    /**
-     * Maps the category groupname (DB: accounting_categories.groupname,
-     * Java: AccountingCategory.accountname) to expense_category_id.
-     *
-     * <p>Defaults to "OTHER_OPEX" for unknown groupnames, matching V125 ELSE clause.
-     */
-    private static String resolveExpenseCategory(String groupname) {
-        return GROUPNAME_TO_EXPENSE_CATEGORY.getOrDefault(groupname, "OTHER_OPEX");
-    }
-
-    /**
-     * Maps the category groupname to cost_center_id.
-     *
-     * <p>Defaults to "GENERAL" for unknown groupnames, matching V125 ELSE clause.
-     */
-    private static String resolveCostCenter(String groupname) {
-        return GROUPNAME_TO_COST_CENTER.getOrDefault(groupname, "GENERAL");
-    }
-
-    // -----------------------------------------------------------------------
-    // Post-fetch filtering
-    // -----------------------------------------------------------------------
-
-    /**
-     * Applies optional dimension filters to a list of OpexRow values.
-     *
-     * <p>Filtering is done in Java rather than in SQL for the distribution path,
-     * because distribution computes all companies and categories in one pass.
-     */
-    private static List<OpexRow> applyFilters(
-            List<OpexRow> rows,
-            Set<String> companyIds,
-            Set<String> costCenters,
-            Set<String> expenseCategories) {
-
-        if ((companyIds == null || companyIds.isEmpty())
-                && (costCenters == null || costCenters.isEmpty())
-                && (expenseCategories == null || expenseCategories.isEmpty())) {
-            return rows;
-        }
-
-        List<OpexRow> filtered = new ArrayList<>(rows.size());
-        for (OpexRow row : rows) {
-            if (companyIds != null && !companyIds.isEmpty() && !companyIds.contains(row.companyId())) continue;
-            if (costCenters != null && !costCenters.isEmpty() && !costCenters.contains(row.costCenterId())) continue;
-            if (expenseCategories != null && !expenseCategories.isEmpty() && !expenseCategories.contains(row.expenseCategoryId())) continue;
-            filtered.add(row);
-        }
-        return filtered;
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshService.java
@@ -2,9 +2,15 @@ package dk.trustworks.intranet.aggregates.finance.services;
 
 import dk.trustworks.intranet.aggregates.accounting.services.IntercompanyCalcService;
 import dk.trustworks.intranet.aggregates.accounting.services.IntercompanyCalcService.FiscalYearData;
+import dk.trustworks.intranet.aggregates.accounting.services.IntercompanyCalcService.MonthData;
+import dk.trustworks.intranet.aggregates.accounting.services.IntercompanyCalcService.ShareAmounts;
 import dk.trustworks.intranet.aggregates.finance.dto.OpexRow;
 import dk.trustworks.intranet.aggregates.utilization.services.UtilizationCalculationHelper;
 import dk.trustworks.intranet.aggregates.utilization.services.UtilizationCalculationHelper.FiscalYearRange;
+import dk.trustworks.intranet.financeservice.model.AccountingAccount;
+import dk.trustworks.intranet.financeservice.model.AccountingCategory;
+import dk.trustworks.intranet.financeservice.model.enums.CostType;
+import dk.trustworks.intranet.model.Company;
 import dk.trustworks.intranet.utils.DateUtils;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -14,6 +20,7 @@ import jakarta.transaction.Transactional;
 import lombok.extern.jbosslog.JBossLog;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -21,7 +28,10 @@ import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Refreshes {@code fact_opex_distribution_mat} by running the existing
@@ -31,17 +41,69 @@ import java.util.List;
  * <p>The provider that powers the CXO EBITDA forecast endpoint reads from this
  * table for unsettled months instead of recomputing on the request path.
  *
+ * <p>The distribution algorithm itself lives here (moved from
+ * {@link DistributionAwareOpexProvider} in PR 2) so the hot read path and the
+ * nightly write path are no longer coupled: the provider does pure SQL reads
+ * and this service is the only place that runs the distribution math.
+ *
+ * <p>Category mapping logic is intentionally kept in sync with the
+ * {@code category_mapping} CTE in {@code V205__Recreate_fact_opex_with_cost_type.sql}.
+ * Any change to V205 must be reflected here and vice versa. Account filtering uses
+ * {@code cost_type IN (OPEX, SALARIES)} instead of the brittle account-code-range
+ * filter [3000, 6000) that was removed in V205.
+ *
  * <p>Spec: docs/superpowers/specs/2026-05-11-fact-opex-distribution-mat-design.md
  */
 @ApplicationScoped
 @JBossLog
 public class OpexDistributionRefreshService {
 
-    @Inject
-    IntercompanyCalcService intercompanyCalcService;
+    // -----------------------------------------------------------------------
+    // Category mapping — MUST match V125__fact_opex.sql category_mapping CTE
+    // -----------------------------------------------------------------------
+
+    /**
+     * Maps accounting_categories.groupname (stored as AccountingCategory.accountname in Java)
+     * to the expense_category_id dimension used by fact_opex.
+     *
+     * Matches exactly the CASE expression in V125 category_mapping CTE.
+     */
+    private static final Map<String, String> GROUPNAME_TO_EXPENSE_CATEGORY;
+
+    /**
+     * Maps accounting_categories.groupname to cost_center_id dimension.
+     *
+     * Matches exactly the CASE expression in V125 category_mapping CTE.
+     */
+    private static final Map<String, String> GROUPNAME_TO_COST_CENTER;
+
+    static {
+        Map<String, String> ec = new HashMap<>();
+        ec.put("Delte services",                      "PEOPLE_NON_BILLABLE");
+        ec.put("Salgsfremmende omkostninger",          "SALES_MARKETING");
+        ec.put("Lokaleomkostninger",                   "OFFICE_FACILITIES");
+        ec.put("Variable omkostninger",                "TOOLS_SOFTWARE");
+        ec.put("Øvrige administrationsomk. i alt", "OTHER_OPEX");  // Øvrige administrationsomk. i alt
+        GROUPNAME_TO_EXPENSE_CATEGORY = Collections.unmodifiableMap(ec);
+
+        Map<String, String> cc = new HashMap<>();
+        cc.put("Delte services",                      "HR_ADMIN");
+        cc.put("Salgsfremmende omkostninger",          "SALES");
+        cc.put("Lokaleomkostninger",                   "FACILITIES");
+        cc.put("Variable omkostninger",                "INTERNAL_IT");
+        cc.put("Øvrige administrationsomk. i alt", "ADMIN");       // Øvrige administrationsomk. i alt
+        GROUPNAME_TO_COST_CENTER = Collections.unmodifiableMap(cc);
+    }
+
+    /**
+     * Cost types included in the OPEX distribution. Matches the filter in V205 fact_opex.
+     * OPEX and SALARIES are the two types that flow through the distribution algorithm.
+     * DIRECT_COSTS, REVENUE, IGNORE, and OTHER are excluded.
+     */
+    private static final Set<CostType> OPEX_COST_TYPES = Set.of(CostType.OPEX, CostType.SALARIES);
 
     @Inject
-    DistributionAwareOpexProvider opexProvider;
+    IntercompanyCalcService intercompanyCalcService;
 
     @Inject
     EntityManager em;
@@ -71,15 +133,8 @@ public class OpexDistributionRefreshService {
         FiscalYearData fyData = intercompanyCalcService.loadFiscalYear(
                 windowFrom, windowToExclusive, salaryBufferMultiplier);
 
-        // computeDistributionForMonth is @CacheResult-annotated per monthKey; the
-        // explicit DELETE-before-INSERT below means cached output is safe to use.
-        List<OpexRow> allRows = new ArrayList<>();
-        for (YearMonth ym : fyData.perMonth.keySet()) {
-            allRows.addAll(opexProvider.computeDistributionForMonth(
-                    ym,
-                    fyData.perMonth.get(ym),
-                    fyData.lumpsByMonth.getOrDefault(ym, Collections.emptyMap())));
-        }
+        List<YearMonth> allMonths = new ArrayList<>(fyData.perMonth.keySet());
+        List<OpexRow> allRows = computeDistributionForMonths(allMonths, fyData);
 
         String fromKey = UtilizationCalculationHelper.toMonthKey(windowFrom);
         String toKey = UtilizationCalculationHelper.toMonthKey(windowToExclusive);
@@ -99,6 +154,195 @@ public class OpexDistributionRefreshService {
 
         return new RefreshOutcome(inserted, deleted, took, windowFrom, windowToExclusive);
     }
+
+    // -----------------------------------------------------------------------
+    // Distribution algorithm — sole owner of the math. Package-private so the
+    // parity test in this same package can verify the algorithm's output
+    // matches what we materialize.
+    // -----------------------------------------------------------------------
+
+    /**
+     * Batch-loads fiscal year data via {@link IntercompanyCalcService#loadFiscalYear} and
+     * computes distribution for each requested month. The {@code fyData} parameter is
+     * required pre-loaded by the caller — that lets {@link #refresh()} share one
+     * batch load with the algorithm.
+     *
+     * <p>No filters are applied here — the refresh always materializes every row.
+     * Filtering happens on the read path inside {@link DistributionAwareOpexProvider}.
+     */
+    List<OpexRow> computeDistributionForMonths(
+            List<YearMonth> months,
+            FiscalYearData fyData) {
+        List<OpexRow> result = new ArrayList<>();
+        for (YearMonth ym : months) {
+            IntercompanyCalcService.MonthData md = fyData.perMonth.get(ym);
+            if (md == null) {
+                log.warnf("No MonthData found for %s in FiscalYearData — skipping", ym);
+                continue;
+            }
+            Map<String, BigDecimal> lumps = fyData.lumpsByMonth
+                    .getOrDefault(ym, Collections.emptyMap());
+            result.addAll(computeDistributionRowsForMonth(ym, md, lumps));
+        }
+        return result;
+    }
+
+    /**
+     * Core distribution logic for one month.
+     *
+     * <p>Algorithm:
+     * <ol>
+     *   <li>For each origin company × account where {@code cost_type IN (OPEX, SALARIES)}:
+     *       <ul>
+     *         <li>Compute {@link ShareAmounts} via
+     *             {@link IntercompanyCalcService#computeDistributionLegacyShareForAccount}</li>
+     *         <li>For each payer company: allocated = baseToShare * payerRatio
+     *             + (if payer==origin: originRemainder)</li>
+     *       </ul>
+     *   <li>Map each (origin, payer, account) to OPEX category dimensions using
+     *       {@link #resolveExpenseCategory} and {@link #resolveCostCenter}.</li>
+     *   <li>Aggregate per (payerCompany × costCenter × expenseCategory × month).</li>
+     * </ol>
+     *
+     * <p>The {@code staffRemainingByCompany} map is mutated by
+     * {@code computeDistributionLegacyShareForAccount} to implement salary pool capping.
+     * A fresh mutable copy is created per month call to avoid cross-call contamination.
+     */
+    private List<OpexRow> computeDistributionRowsForMonth(
+            YearMonth ym,
+            MonthData md,
+            Map<String, BigDecimal> lumpsByAccount) {
+
+        String monthKeyStr = formatMonthKey(ym);
+
+        // Salary pool cap state — must be mutable and reset per month (legacy semantics)
+        Map<String, BigDecimal> staffRemainingByCompany = new HashMap<>(md.staffBaseBI102);
+
+        // Accumulator: payerUuid → costCenterId → expenseCategoryId → isPayroll → amount.
+        // isPayroll is a key dimension so SALARIES accounts cannot contaminate the OPEX
+        // total inside categories that mix both cost types (e.g. "Delte services" maps
+        // 84 OPEX accounts and 3 SALARIES accounts into PEOPLE_NON_BILLABLE).
+        Map<String, Map<String, Map<String, Map<Boolean, Double>>>> accumulator = new HashMap<>();
+
+        for (AccountingCategory category : md.categories) {
+            String groupname = category.getAccountname();  // maps to groupname column
+
+            String expenseCategoryId = resolveExpenseCategory(groupname);
+            String costCenterId      = resolveCostCenter(groupname);
+
+            for (AccountingAccount account : category.getAccounts()) {
+
+                // Filter by cost_type: only OPEX and SALARIES accounts participate in distribution.
+                // Replaces the brittle account-code range [3000, 6000) and EXCLUDED_GROUPNAMES.
+                // Matches the filter in V205 fact_opex (aa.cost_type IN ('OPEX', 'SALARIES')).
+                if (!OPEX_COST_TYPES.contains(account.getCostType())) continue;
+
+                String originUuid = account.getCompany().getUuid();
+
+                BigDecimal gl = md.glByCompanyAccountRange
+                        .getOrDefault(originUuid, Collections.emptyMap())
+                        .getOrDefault(account.getAccountCode(), BigDecimal.ZERO);
+
+                // Use absolute value to match V125 fact_opex which uses SUM(ABS(amount)).
+                // Credit/reversal entries (negative GL) still contribute to OPEX totals.
+                gl = gl.abs();
+
+                BigDecimal lump = lumpsByAccount.getOrDefault(account.getUuid(), BigDecimal.ZERO);
+
+                ShareAmounts share = intercompanyCalcService.computeDistributionLegacyShareForAccount(
+                        md, account, originUuid, gl, lump, staffRemainingByCompany);
+
+                boolean isPayroll = account.isSalary();
+
+                for (Company payer : md.companies) {
+                    String payerUuid = payer.getUuid();
+                    BigDecimal ratio = md.ratioByCompany.getOrDefault(payerUuid, BigDecimal.ZERO);
+
+                    BigDecimal allocated = BigDecimal.ZERO;
+
+                    if (share.baseToShare.compareTo(BigDecimal.ZERO) > 0) {
+                        allocated = allocated.add(
+                                share.baseToShare.multiply(ratio).setScale(IntercompanyCalcService.SCALE, IntercompanyCalcService.RM)
+                        );
+                    }
+                    if (payerUuid.equals(originUuid) && share.originRemainder.compareTo(BigDecimal.ZERO) > 0) {
+                        allocated = allocated.add(share.originRemainder);
+                    }
+
+                    if (allocated.compareTo(BigDecimal.ZERO) <= 0) continue;
+
+                    // Accumulate: payerUuid → costCenterId → expenseCategoryId → isPayroll → amount
+                    accumulator
+                            .computeIfAbsent(payerUuid, k -> new HashMap<>())
+                            .computeIfAbsent(costCenterId, k -> new HashMap<>())
+                            .computeIfAbsent(expenseCategoryId, k -> new HashMap<>())
+                            .merge(isPayroll, allocated.doubleValue(), Double::sum);
+                }
+            }
+        }
+
+        // Flatten accumulator → OpexRow list. Each (payer, costCenter, expenseCategory)
+        // can produce up to two rows — one with isPayroll=true and one with isPayroll=false —
+        // mirroring how fact_opex_mat keeps SALARIES and OPEX rows separate by cost_type.
+        List<OpexRow> rows = new ArrayList<>();
+        for (var payerEntry : accumulator.entrySet()) {
+            String payerUuid = payerEntry.getKey();
+            for (var ccEntry : payerEntry.getValue().entrySet()) {
+                String costCenterId = ccEntry.getKey();
+                for (var catEntry : ccEntry.getValue().entrySet()) {
+                    String expenseCategoryId = catEntry.getKey();
+                    for (var prEntry : catEntry.getValue().entrySet()) {
+                        boolean isPayroll = prEntry.getKey();
+                        double amount = prEntry.getValue();
+
+                        if (amount <= 0.0) continue;
+
+                        rows.add(new OpexRow(
+                                payerUuid,
+                                costCenterId,
+                                expenseCategoryId,
+                                monthKeyStr,
+                                amount,
+                                1,  // distribution rows don't have individual GL entry counts
+                                isPayroll,
+                                OpexRow.SOURCE_DISTRIBUTION
+                        ));
+                    }
+                }
+            }
+        }
+
+        log.debugf("Distribution computed for %s: %d rows across %d companies",
+                monthKeyStr, rows.size(), md.companies.size());
+        return rows;
+    }
+
+    /**
+     * Maps the category groupname (DB: accounting_categories.groupname,
+     * Java: AccountingCategory.accountname) to expense_category_id.
+     *
+     * <p>Defaults to "OTHER_OPEX" for unknown groupnames, matching V125 ELSE clause.
+     */
+    private static String resolveExpenseCategory(String groupname) {
+        return GROUPNAME_TO_EXPENSE_CATEGORY.getOrDefault(groupname, "OTHER_OPEX");
+    }
+
+    /**
+     * Maps the category groupname to cost_center_id.
+     *
+     * <p>Defaults to "GENERAL" for unknown groupnames, matching V125 ELSE clause.
+     */
+    private static String resolveCostCenter(String groupname) {
+        return GROUPNAME_TO_COST_CENTER.getOrDefault(groupname, "GENERAL");
+    }
+
+    private static String formatMonthKey(YearMonth ym) {
+        return String.format("%04d%02d", ym.getYear(), ym.getMonthValue());
+    }
+
+    // -----------------------------------------------------------------------
+    // Bulk insert
+    // -----------------------------------------------------------------------
 
     private int bulkInsert(List<OpexRow> rows, LocalDateTime refreshedAt) {
         if (rows.isEmpty()) return 0;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,13 @@ quarkus:
       leak-detection-interval: PT5M
     username: ${USERNAME:root}
     password: ${PASSWORD:1606}
+  transaction-manager:
+    # OpexDistributionRefreshService.refresh() loads ~165k rows from finance_details +
+    # fact_user_day and inserts 321 rows in one prepared statement — real duration is
+    # 56-60s. The Narayana default of 60s is too tight; staging (1 vCPU) blows past it
+    # while production (2 vCPU) succeeds by ~4s. 600s gives generous headroom without
+    # masking pathological regressions.
+    default-transaction-timeout: 600s
   hibernate-orm:
     jdbc:
       statement-batch-size: 32

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -177,15 +177,9 @@ quarkus:
       consultant-allocation:
         expire-after-write: 1H  # Consultant allocation cache (1 hour TTL)
         maximum-size: 1000  # Maximum number of allocation entries
-      expected-accumulated-ebitda:
-        expire-after-write: 5M  # EBITDA chart cold-path takes ~minutes; cache the full response
-        maximum-size: 200       # ~200 distinct (asOfDate, filter) combinations is generous
       page-registry:
         expire-after-write: 5M  # Page registry cache (5 min TTL for quick updates)
         maximum-size: 100  # Small table - only ~20-50 pages expected
-      distribution-opex:
-        expire-after-write: 5M  # Distribution OPEX cache - matches sp_incremental_bi_refresh frequency
-        maximum-size: 60  # One entry per month; 60 covers 5 years of monthly data
       cvr-lookup:
         expire-after-write: 24H  # CVR data rarely changes; cache for 24h to conserve 50/day quota
         maximum-size: 500  # Max cached CVR lookups

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchletTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchletTest.java
@@ -3,8 +3,6 @@ package dk.trustworks.intranet.aggregates.finance.jobs;
 import dk.trustworks.intranet.aggregates.finance.services.OpexDistributionRefreshService;
 import dk.trustworks.intranet.aggregates.finance.services.OpexDistributionRefreshService.RefreshOutcome;
 import dk.trustworks.intranet.communicationsservice.services.SlackService;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,9 +40,7 @@ class OpexDistributionRefreshBatchletTest {
 
     @Mock OpexDistributionRefreshService refreshService;
     @Mock SlackService slackService;
-    @Mock EntityManager em;
     @Mock ManagedExecutor managedExecutor;
-    @Mock Query query;
 
     OpexDistributionRefreshBatchlet batchlet;
 
@@ -53,7 +49,6 @@ class OpexDistributionRefreshBatchletTest {
         batchlet = new OpexDistributionRefreshBatchlet();
         batchlet.refreshService = refreshService;
         batchlet.slackService = slackService;
-        batchlet.em = em;
         batchlet.managedExecutor = managedExecutor;
         batchlet.opsAlertChannel = CHANNEL;
     }
@@ -104,24 +99,14 @@ class OpexDistributionRefreshBatchletTest {
     }
 
     @Test
-    void onStart_emptyTable_submitsAsyncRefresh() {
-        when(em.createNativeQuery(anyString())).thenReturn(query);
-        when(query.getSingleResult()).thenReturn(0L);
-
+    void onStart_alwaysSubmitsAsyncRefresh() {
+        // Verification-mode startup: refresh fires on every boot so we can
+        // observe the nightly path after deploy. Reverted to "only when empty"
+        // in PR 2 once the read path is flipped.
         batchlet.onStart(null);
 
         verify(managedExecutor, times(1)).submit(org.mockito.ArgumentMatchers.<Runnable>any());
         verify(refreshService, never()).refresh();
-    }
-
-    @Test
-    void onStart_populatedTable_doesNotTriggerRefresh() {
-        when(em.createNativeQuery(anyString())).thenReturn(query);
-        when(query.getSingleResult()).thenReturn(123L);
-
-        batchlet.onStart(null);
-
-        verify(managedExecutor, never()).submit(org.mockito.ArgumentMatchers.<Runnable>any());
     }
 
     @Test

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchletTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/jobs/OpexDistributionRefreshBatchletTest.java
@@ -3,6 +3,8 @@ package dk.trustworks.intranet.aggregates.finance.jobs;
 import dk.trustworks.intranet.aggregates.finance.services.OpexDistributionRefreshService;
 import dk.trustworks.intranet.aggregates.finance.services.OpexDistributionRefreshService.RefreshOutcome;
 import dk.trustworks.intranet.communicationsservice.services.SlackService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +43,8 @@ class OpexDistributionRefreshBatchletTest {
     @Mock OpexDistributionRefreshService refreshService;
     @Mock SlackService slackService;
     @Mock ManagedExecutor managedExecutor;
+    @Mock EntityManager em;
+    @Mock Query query;
 
     OpexDistributionRefreshBatchlet batchlet;
 
@@ -50,6 +54,7 @@ class OpexDistributionRefreshBatchletTest {
         batchlet.refreshService = refreshService;
         batchlet.slackService = slackService;
         batchlet.managedExecutor = managedExecutor;
+        batchlet.em = em;
         batchlet.opsAlertChannel = CHANNEL;
     }
 
@@ -99,14 +104,24 @@ class OpexDistributionRefreshBatchletTest {
     }
 
     @Test
-    void onStart_alwaysSubmitsAsyncRefresh() {
-        // Verification-mode startup: refresh fires on every boot so we can
-        // observe the nightly path after deploy. Reverted to "only when empty"
-        // in PR 2 once the read path is flipped.
+    void onStart_emptyTable_submitsAsyncRefresh() {
+        when(em.createNativeQuery(anyString())).thenReturn(query);
+        when(query.getSingleResult()).thenReturn(0L);
+
         batchlet.onStart(null);
 
         verify(managedExecutor, times(1)).submit(org.mockito.ArgumentMatchers.<Runnable>any());
         verify(refreshService, never()).refresh();
+    }
+
+    @Test
+    void onStart_populatedTable_doesNotTriggerRefresh() {
+        when(em.createNativeQuery(anyString())).thenReturn(query);
+        when(query.getSingleResult()).thenReturn(123L);
+
+        batchlet.onStart(null);
+
+        verify(managedExecutor, never()).submit(org.mockito.ArgumentMatchers.<Runnable>any());
     }
 
     @Test

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResourceEbitdaSmokeIT.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResourceEbitdaSmokeIT.java
@@ -1,0 +1,70 @@
+package dk.trustworks.intranet.aggregates.finance.resources;
+
+import dk.trustworks.intranet.aggregates.finance.services.OpexDistributionRefreshService;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.restassured.response.Response;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end smoke test for the EBITDA Forecast endpoint, exercising the new
+ * read-from-mat-table path introduced in PR 2. Locks in the user-visible
+ * perf goal so a future regression of the read path is caught in CI.
+ *
+ * <p>Spec: docs/superpowers/specs/2026-05-11-fact-opex-distribution-mat-design.md
+ * § 7 test #4.
+ */
+@QuarkusTest
+class CxoFinanceResourceEbitdaSmokeIT {
+
+    @Inject
+    OpexDistributionRefreshService refreshService;
+
+    @BeforeEach
+    @Transactional
+    void warmTable() {
+        refreshService.refresh();
+    }
+
+    @Test
+    @TestSecurity(user = "smoke-test", roles = {"dashboard:read"})
+    void getExpectedAccumulatedEBITDA_returns_12_data_points() {
+        Response r = given()
+                .when()
+                .get("/finance/cxo/expected-accumulated-ebitda")
+                .then()
+                .statusCode(200)
+                .extract().response();
+
+        assertEquals(12, r.jsonPath().getList(".").size(),
+                "EBITDA forecast must return 12 monthly data points");
+    }
+
+    @Test
+    @TestSecurity(user = "smoke-test", roles = {"dashboard:read"})
+    void getExpectedAccumulatedEBITDA_p95_under_2000ms() {
+        long[] timings = new long[20];
+        for (int i = 0; i < 20; i++) {
+            long start = System.nanoTime();
+            given()
+                    .when()
+                    .get("/finance/cxo/expected-accumulated-ebitda")
+                    .then()
+                    .statusCode(200);
+            timings[i] = (System.nanoTime() - start) / 1_000_000L;
+        }
+        Arrays.sort(timings);
+        long p95 = timings[19];  // p95 of 20 samples ≈ max
+        assertTrue(p95 < 2000L,
+                "EBITDA endpoint p95 was " + p95 + "ms (must be < 2000ms)");
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/DistributionAwareOpexProviderReadPathIT.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/DistributionAwareOpexProviderReadPathIT.java
@@ -1,0 +1,141 @@
+package dk.trustworks.intranet.aggregates.finance.services;
+
+import dk.trustworks.intranet.aggregates.finance.dto.OpexRow;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.YearMonth;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the read-path of {@link DistributionAwareOpexProvider}.
+ *
+ * <p>Spec: docs/superpowers/specs/2026-05-11-fact-opex-distribution-mat-design.md §5 (PR 2, Task 13)
+ *
+ * <p>These tests guard the settlement-aware routing introduced in Tasks 10–12:
+ * <ul>
+ *   <li>Unsettled months (no finalized INTERNAL_SERVICE invoice for the month) read
+ *       from {@code fact_opex_distribution_mat} → rows carry {@link OpexRow#SOURCE_DISTRIBUTION}.</li>
+ *   <li>Settled months read directly from {@code fact_opex_mat} → rows carry
+ *       {@link OpexRow#SOURCE_ERP_GL}.</li>
+ * </ul>
+ * The intent is to fail in CI if a future change accidentally re-introduces the old
+ * calendar-based switch or bypasses the materialized table on the hot path.
+ *
+ * <p>Uses JUnit Jupiter assertions because AssertJ is not on this project's classpath.
+ */
+@QuarkusTest
+class DistributionAwareOpexProviderReadPathIT {
+
+    @Inject
+    DistributionAwareOpexProvider provider;
+
+    @Inject
+    OpexDistributionRefreshService refreshService;
+
+    @Inject
+    EntityManager em;
+
+    @BeforeEach
+    @Transactional
+    void seedMatTable() {
+        refreshService.refresh();
+    }
+
+    @Test
+    void unsettledMonthRange_returnsRowsFromDistributionMat() {
+        // Current FY is fully unsettled (no INTERNAL_SERVICE invoices for it).
+        YearMonth currentMonth = YearMonth.now();
+        String mk = String.format("%04d%02d", currentMonth.getYear(), currentMonth.getMonthValue());
+
+        List<OpexRow> rows = provider.getDistributionAwareOpex(
+                mk, mk, null, null, null);
+
+        assertFalse(rows.isEmpty(), "current month should return distribution rows");
+        assertTrue(rows.stream().allMatch(r -> OpexRow.SOURCE_DISTRIBUTION.equals(r.dataSource())),
+                "all current-month rows must be SOURCE_DISTRIBUTION");
+    }
+
+    @Test
+    void settledMonthRange_returnsRowsFromFactOpexMat() {
+        // 2025-01 is settled (CREATED INTERNAL_SERVICE invoices exist per the
+        // production data inspected during brainstorming).
+        List<OpexRow> rows = provider.getDistributionAwareOpex(
+                "202501", "202501", null, null, null);
+
+        // Either the test DB has this month populated or it doesn't; allow
+        // empty but if non-empty, source must be ERP_GL.
+        if (!rows.isEmpty()) {
+            assertTrue(rows.stream().allMatch(r -> OpexRow.SOURCE_ERP_GL.equals(r.dataSource())),
+                    "settled months must come from fact_opex_mat");
+        }
+    }
+
+    @Test
+    void mixedWindow_returnsBothSources() {
+        // Jan 2025 (settled) → Jul 2025 (unsettled, FY start) — covers the boundary.
+        List<OpexRow> rows = provider.getDistributionAwareOpex(
+                "202501", "202507", null, null, null);
+
+        Set<String> sources = new HashSet<>();
+        for (OpexRow r : rows) sources.add(r.dataSource());
+
+        // The spec's stricter assertion (`doesNotContain("DISTRIBUTION_ONLY")`)
+        // is a misformed AssertJ check; the practical invariant is: Jan-Jun rows
+        // must never be SOURCE_DISTRIBUTION, even when the test DB lacks current-FY
+        // data (i.e. sources may be {} or {ERP_GL} or {ERP_GL, DISTRIBUTION}).
+        for (OpexRow r : rows) {
+            YearMonth ym = YearMonth.parse(r.monthKey(),
+                    java.time.format.DateTimeFormatter.ofPattern("yyyyMM"));
+            if (ym.getYear() == 2025 && ym.getMonthValue() <= 6) {
+                assertFalse(OpexRow.SOURCE_DISTRIBUTION.equals(r.dataSource()),
+                        "settled month " + ym + " must not be SOURCE_DISTRIBUTION");
+            }
+        }
+    }
+
+    @Test
+    void filterPushdown_byCompanyIds_narrowsResult() {
+        YearMonth currentMonth = YearMonth.now();
+        String mk = String.format("%04d%02d", currentMonth.getYear(), currentMonth.getMonthValue());
+        String trustworksAS = "d8894494-2fb4-4f72-9e05-e6032e6dd691";
+
+        List<OpexRow> all = provider.getDistributionAwareOpex(
+                mk, mk, null, null, null);
+        List<OpexRow> filtered = provider.getDistributionAwareOpex(
+                mk, mk, Set.of(trustworksAS), null, null);
+
+        assertTrue(filtered.size() <= all.size(),
+                "filtered must be a subset of unfiltered");
+        assertTrue(filtered.stream().allMatch(r -> trustworksAS.equals(r.companyId())),
+                "every filtered row must be for the requested company");
+    }
+
+    @Test
+    @Transactional
+    void emptyMatTable_unsettledMonth_returnsEmpty_notException() {
+        // Wipe to simulate cold-start / failed-refresh edge case.
+        em.createNativeQuery("DELETE FROM fact_opex_distribution_mat").executeUpdate();
+
+        YearMonth currentMonth = YearMonth.now();
+        String mk = String.format("%04d%02d", currentMonth.getYear(), currentMonth.getMonthValue());
+
+        List<OpexRow> rows = provider.getDistributionAwareOpex(
+                mk, mk, null, null, null);
+
+        // Zero rows, NO exception. The freshness health check alerts on this state.
+        assertTrue(rows.isEmpty(), "empty mat table must return empty list, not throw");
+
+        // Restore the table so subsequent tests in the same run have data.
+        refreshService.refresh();
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshParityIT.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshParityIT.java
@@ -16,7 +16,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.YearMonth;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,20 +27,25 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Parity test: asserts that what the refresh batchlet writes into
- * {@code fact_opex_distribution_mat} is bit-for-bit identical to what
- * the live {@link DistributionAwareOpexProvider#computeDistributionForMonth}
- * produces today.
+ * {@code fact_opex_distribution_mat} is bit-for-bit identical to what the
+ * in-memory distribution algorithm produces from the same {@code FiscalYearData}.
+ *
+ * <p>Since PR 2 moved {@code computeDistributionForMonth(s)} from the provider
+ * into {@link OpexDistributionRefreshService}, this test now verifies that the
+ * INSERT path doesn't corrupt the algorithm output — i.e. the rows we write to
+ * the table aggregate (per {company,costCenter,expenseCategory,isPayroll}) to
+ * the same totals the in-memory algorithm produces.
  *
  * <p>For each month in the current fiscal year:
  * <ol>
- *   <li>Run the live algorithm directly</li>
- *   <li>Run the refresh service</li>
+ *   <li>Run the algorithm directly via {@code computeDistributionForMonths}</li>
+ *   <li>Run the refresh service (DELETE + INSERT)</li>
  *   <li>Read back the materialized rows</li>
  *   <li>Assert (company, cost_center, expense_category, is_payroll) → amount maps match</li>
  * </ol>
  *
- * <p>Guards against future algorithm drift — if anyone later changes one path
- * but not the other, this test fails loudly.
+ * <p>Guards against future regressions in the bulk-insert mapping layer
+ * (column order, decimal scaling, monthKey conversion, etc.).
  *
  * <p>Spec: docs/superpowers/specs/2026-05-11-fact-opex-distribution-mat-design.md §7 #1
  */
@@ -49,9 +54,6 @@ class OpexDistributionRefreshParityIT {
 
     @Inject
     IntercompanyCalcService intercompanyCalcService;
-
-    @Inject
-    DistributionAwareOpexProvider opexProvider;
 
     @Inject
     OpexDistributionRefreshService refreshService;
@@ -74,13 +76,15 @@ class OpexDistributionRefreshParityIT {
         FiscalYearData fyData = intercompanyCalcService.loadFiscalYear(
                 fyStart, fyEnd, salaryBufferMultiplier);
 
+        List<YearMonth> months = new ArrayList<>(fyData.perMonth.keySet());
+        List<OpexRow> liveRows = refreshService.computeDistributionForMonths(months, fyData);
+
         Map<YearMonth, Map<String, Double>> live = new TreeMap<>();
-        for (YearMonth ym : fyData.perMonth.keySet()) {
-            List<OpexRow> liveRows = opexProvider.computeDistributionForMonth(
-                    ym,
-                    fyData.perMonth.get(ym),
-                    fyData.lumpsByMonth.getOrDefault(ym, Collections.emptyMap()));
-            live.put(ym, aggregate(liveRows));
+        for (OpexRow r : liveRows) {
+            YearMonth ym = YearMonth.parse(r.monthKey(),
+                    java.time.format.DateTimeFormatter.ofPattern("yyyyMM"));
+            live.computeIfAbsent(ym, k -> new HashMap<>())
+                .merge(dimensionKey(r), roundToCents(r.opexAmountDkk()), Double::sum);
         }
 
         // Guard: a sparse test DB would otherwise make this test pass vacuously.
@@ -108,21 +112,17 @@ class OpexDistributionRefreshParityIT {
         }
     }
 
-    /** Aggregate List<OpexRow> into a Map keyed by composite dimension string.
-     *  Each amount is rounded to 2 decimal places (HALF_EVEN) before summing,
-     *  matching the rounding the DB performs at INSERT time for DECIMAL(14,2).
-     *  This keeps the live-vs-materialized comparison apples-to-apples. */
-    private static Map<String, Double> aggregate(List<OpexRow> rows) {
-        Map<String, Double> out = new HashMap<>();
-        for (OpexRow r : rows) {
-            String key = r.companyId() + "|" + r.costCenterId() + "|"
-                    + r.expenseCategoryId() + "|" + r.isPayrollFlag();
-            double rounded = BigDecimal.valueOf(r.opexAmountDkk())
-                    .setScale(2, RoundingMode.HALF_EVEN)
-                    .doubleValue();
-            out.merge(key, rounded, Double::sum);
-        }
-        return out;
+    private static String dimensionKey(OpexRow r) {
+        return r.companyId() + "|" + r.costCenterId() + "|"
+                + r.expenseCategoryId() + "|" + r.isPayrollFlag();
+    }
+
+    /** Rounded to 2 decimal places (HALF_EVEN) to match what the DB performs
+     *  at INSERT time for DECIMAL(14,2). Keeps live-vs-materialized apples-to-apples. */
+    private static double roundToCents(double amount) {
+        return BigDecimal.valueOf(amount)
+                .setScale(2, RoundingMode.HALF_EVEN)
+                .doubleValue();
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Production promotion of two changes verified on staging:

### PR 1 patch (#66 + #67)
- Bump `quarkus.transaction-manager.default-transaction-timeout` to 600 s
- Fixes Narayana `ARJUNA016102` rollback caused by 56–60 s refresh workload running into the default 60 s tx timeout
- Verified on staging at 05:27 UTC — refresh completes cleanly in 62.75 s

### PR 2 (#68) — the actual EBITDA chart fix
- Flip `DistributionAwareOpexProvider.getDistributionAwareOpex` to read from `fact_opex_distribution_mat` for unsettled months instead of recomputing distribution on every request
- Move the compute algorithm into `OpexDistributionRefreshService` as private helpers
- Drop `@CacheResult` on `CxoFinanceResource.getExpectedAccumulatedEBITDA` and the `expected-accumulated-ebitda` / `distribution-opex` cache blocks from `application.yml`
- Adds `DistributionAwareOpexProviderReadPathIT` (5 tests) and `CxoFinanceResourceEbitdaSmokeIT` (p95 < 2 s)
- Verified end-to-end on staging — EBITDA Forecast chart loads in <2 s

## Test plan

- [x] Staging deploys ✅ (runs `25780100035` + `25782095611` both green)
- [x] Staging `/health/ready` reports `opex-distribution-freshness: UP`
- [x] Staging EBITDA chart loads in <2 s (user-confirmed)
- [ ] Production deploy completes
- [ ] Production `/health/ready` UP after deploy
- [ ] Production EBITDA chart loads in <2 s

## Rollback

Revert the merge commit. PR 1's mat table keeps being populated nightly, so the previous compute-on-request behavior is restored exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)