### PR TITLE
fix(finance): remove glAmount<0 clamp in OPEX distribution (Phase 5 / EBITDA chart)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/accounting/services/IntercompanyCalcService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/accounting/services/IntercompanyCalcService.java
@@ -166,8 +166,7 @@ public class IntercompanyCalcService {
         final boolean isShared = aaSrc.isShared();
         final boolean isSalary = aaSrc.isSalary();
 
-        // GL clamp < 0 -> 0
-        if (glAmount.compareTo(BigDecimal.ZERO) < 0) glAmount = BigDecimal.ZERO;
+        // glAmount is signed: refunds/reversals flow through as negative originRemainder.
         glAmount = glAmount.setScale(SCALE, RM);
 
         // lumps deles ikke

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/OpexRow.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/OpexRow.java
@@ -54,7 +54,9 @@ public record OpexRow(
     public static final String COST_TYPE_OPEX = "OPEX";
 
     /**
-     * Compact constructor validates non-null invariants and enforces non-negative amounts.
+     * Compact constructor validates non-null invariants. {@code opexAmountDkk}
+     * is signed — negative values represent net-negative monthly aggregates
+     * (refunds, reversals) on non-shared/non-salary accounts.
      */
     public OpexRow {
         if (companyId == null || companyId.isBlank()) {
@@ -68,9 +70,6 @@ public record OpexRow(
         }
         if (monthKey == null || monthKey.length() != 6) {
             throw new IllegalArgumentException("monthKey must be a 6-character YYYYMM string, got: " + monthKey);
-        }
-        if (opexAmountDkk < 0.0) {
-            throw new IllegalArgumentException("opexAmountDkk must not be negative, got: " + opexAmountDkk);
         }
         if (dataSource == null || dataSource.isBlank()) {
             throw new IllegalArgumentException("dataSource must not be blank");

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/OpexRow.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/OpexRow.java
@@ -24,7 +24,8 @@ public record OpexRow(
         /** Month key in YYYYMM format (e.g., "202601"). */
         String monthKey,
 
-        /** OPEX amount in DKK (always non-negative). */
+        /** OPEX amount in DKK. Signed — net-negative monthly aggregates (refunds, reversals)
+         *  propagate as negative cost on the origin company. */
         double opexAmountDkk,
 
         /** Number of GL entries contributing to this row (from fact_opex_mat or estimated as 1 for distribution). */

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/DistributionAwareOpexProvider.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/DistributionAwareOpexProvider.java
@@ -268,7 +268,7 @@ public class DistributionAwareOpexProvider {
         List<OpexRow> result = new ArrayList<>(rows.size());
         for (Tuple row : rows) {
             double amount = row.get("opex_amount") != null ? ((Number) row.get("opex_amount")).doubleValue() : 0.0;
-            if (amount <= 0.0) continue;
+            if (amount == 0.0) continue;
             result.add(new OpexRow(
                     (String) row.get("company_id"),
                     (String) row.get("cost_center_id"),
@@ -338,7 +338,7 @@ public class DistributionAwareOpexProvider {
         for (Tuple row : rows) {
             double amount = row.get("opex_amount") != null
                     ? ((Number) row.get("opex_amount")).doubleValue() : 0.0;
-            if (amount <= 0.0) continue;
+            if (amount == 0.0) continue;
             result.add(new OpexRow(
                     (String) row.get("company_id"),
                     (String) row.get("cost_center_id"),

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshService.java
@@ -263,11 +263,11 @@ public class OpexDistributionRefreshService {
                                 share.baseToShare.multiply(ratio).setScale(IntercompanyCalcService.SCALE, IntercompanyCalcService.RM)
                         );
                     }
-                    if (payerUuid.equals(originUuid) && share.originRemainder.compareTo(BigDecimal.ZERO) > 0) {
+                    if (payerUuid.equals(originUuid) && share.originRemainder.compareTo(BigDecimal.ZERO) != 0) {
                         allocated = allocated.add(share.originRemainder);
                     }
 
-                    if (allocated.compareTo(BigDecimal.ZERO) <= 0) continue;
+                    if (allocated.compareTo(BigDecimal.ZERO) == 0) continue;
 
                     // Accumulate: payerUuid → costCenterId → expenseCategoryId → isPayroll → amount
                     accumulator
@@ -293,7 +293,7 @@ public class OpexDistributionRefreshService {
                         boolean isPayroll = prEntry.getKey();
                         double amount = prEntry.getValue();
 
-                        if (amount <= 0.0) continue;
+                        if (amount == 0.0) continue;
 
                         rows.add(new OpexRow(
                                 payerUuid,

--- a/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/finance/services/OpexDistributionRefreshServiceTest.java
@@ -8,6 +8,8 @@ import dk.trustworks.intranet.financeservice.model.AccountingCategory;
 import dk.trustworks.intranet.financeservice.model.enums.CostType;
 import dk.trustworks.intranet.model.Company;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
@@ -28,19 +30,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests verifying that OPEX distribution preserves the signed sign of GL
- * aggregates inside {@code computeDistributionRowsForMonth} — i.e. that the
- * {@code gl.abs()} call removed in Phase 2 of the EBITDA chart reconciliation
- * no longer inflates refunds/credit-memo entries.
+ * aggregates inside {@code computeDistributionRowsForMonth}. Two end-to-end
+ * invariants are locked in:
  *
- * <p>The previous behaviour wrapped the per-account GL aggregate in
- * {@code .abs()} before calling
- * {@link IntercompanyCalcService#computeDistributionLegacyShareForAccount},
- * which meant negative GL entries (refunds, reversals) were treated as
- * additional positive costs in {@code fact_opex_distribution_mat}. Removing
- * the wrapper allows the downstream method's existing {@code <0 -> 0} clamp
- * (line 170 of IntercompanyCalcService) to correctly suppress net-negative
- * buckets while still letting positive entries net against negatives within
- * a single account.
+ * <ol>
+ *   <li>The upstream {@code gl.abs()} wrapper (removed in Phase 2 of the
+ *       EBITDA chart reconciliation) does not return — refunds inside a
+ *       month's GL aggregate net against same-account costs rather than
+ *       being abs-inflated into phantom positive cost.</li>
+ *   <li>Net-negative GL aggregates propagate as negative {@code originRemainder}
+ *       on the origin company (Phase 5 — clamp at IntercompanyCalcService:170
+ *       removed). For non-shared / non-salary accounts (where the legacy share
+ *       path doesn't engage), the entire negative GL falls into
+ *       {@code originRemainder} and materialises as a single negative-amount
+ *       row on the origin company.</li>
+ * </ol>
  *
  * <p>Tests use a fully synthetic in-memory {@link MonthData} (no DB) and
  * invoke the package-private {@code computeDistributionRowsForMonth} via
@@ -52,7 +56,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * No DB I/O occurs — all inputs to the method under test are built in memory.
  */
 @QuarkusTest
+@TestProfile(OpexDistributionRefreshServiceTest.Profile.class)
 class OpexDistributionRefreshServiceTest {
+
+    public static class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.s3.devservices.enabled", "false",
+                    "cvtool.username", "test-placeholder",
+                    "cvtool.password", "test-placeholder"
+            );
+        }
+    }
 
     private static final YearMonth TEST_MONTH = YearMonth.of(2099, 1);
 
@@ -141,16 +157,17 @@ class OpexDistributionRefreshServiceTest {
     }
 
     // -----------------------------------------------------------------------
-    // Test 3: OPEX account with only net-negative postings — result must be
-    //         0 (suppressed). The downstream guard in
-    //         IntercompanyCalcService.computeDistributionLegacyShareForAccount
-    //         clamps {@code glAmount < 0 -> 0} (line 170), so baseToShare and
-    //         originRemainder both become 0; the {@code allocated <= 0 continue}
-    //         guard in computeDistributionRowsForMonth (line 272) then drops
-    //         the row entirely.
+    // Test 3: OPEX account with only net-negative postings (e.g. Barsel.dk
+    //         maternity-allowance refunds on account 3597) — result must be
+    //         a single negative-amount row on the origin company.
+    //
+    //         For shared=false, salary=false accounts the legacy share path
+    //         doesn't engage (baseToShare stays 0), so the entire negative
+    //         GL falls into originRemainder and materialises as one row
+    //         on the origin company. Group total conserved.
     // -----------------------------------------------------------------------
     @Test
-    void opexAccount_netNegative_isSuppressed() throws Exception {
+    void opexAccount_netNegative_propagatesAsRefund() throws Exception {
         Company company = synthCompany("c-opex-neg");
         AccountingAccount opexAccount = synthAccount(company, 4200,
                 CostType.OPEX, /* shared */ false, /* salary */ false);
@@ -165,14 +182,42 @@ class OpexDistributionRefreshServiceTest {
 
         List<OpexRow> rows = invokeComputeDistributionRowsForMonth(TEST_MONTH, md, Map.of());
 
-        // Net-negative bucket → clamped to 0 by IntercompanyCalcService,
-        // then dropped by the allocated<=0 continue guard. No row materialised.
-        // With the old gl.abs() this would have produced a +500 phantom cost row.
         double total = rows.stream().mapToDouble(OpexRow::opexAmountDkk).sum();
-        assertEquals(0.0, total, 0.001,
-                "Net-negative OPEX bucket must be suppressed, not abs-inflated into a +500 phantom cost");
-        assertFalse(rows.stream().anyMatch(r -> r.opexAmountDkk() > 0.0),
-                "Net-negative OPEX bucket must materialise no positive-amount rows");
+        assertEquals(-500.0, total, 0.5,
+                "Net-negative OPEX bucket must propagate as a -500 refund, not be clamped to zero");
+        assertEquals(1, rows.size(),
+                "Net-negative non-shared OPEX bucket must produce exactly one row on origin");
+        assertEquals(company.getUuid(), rows.get(0).companyId(),
+                "Negative OPEX must stay with origin company (legacy share path doesn't engage)");
+        assertFalse(rows.get(0).isPayrollFlag(),
+                "Non-salary account row must not be flagged as payroll");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 4: Production-shaped scenario — TW A/S Lønrefusion sygeforsikring
+    //         (account 3597) July 2025 = -247,025.38 DKK (Barsel.dk +
+    //         Barselsdagpenge refunds). Verifies that the production residual
+    //         driver flows through end-to-end as a single negative row.
+    // -----------------------------------------------------------------------
+    @Test
+    void opexAccount_lonrefusionRefund_flowsToOrigin() throws Exception {
+        Company twas = synthCompany("tw-as");
+        AccountingAccount lonrefusion = synthAccount(twas, 3597,
+                CostType.OPEX, /* shared */ false, /* salary */ false);
+        AccountingCategory category = synthCategory(OPEX_GROUPNAME, lonrefusion);
+
+        Map<Integer, BigDecimal> glRow = new HashMap<>();
+        glRow.put(lonrefusion.getAccountCode(), BigDecimal.valueOf(-247_025.38));
+        Map<String, Map<Integer, BigDecimal>> gl = new HashMap<>();
+        gl.put(twas.getUuid(), glRow);
+
+        MonthData md = synthMonthData(List.of(twas), List.of(category), gl, Map.of());
+
+        List<OpexRow> rows = invokeComputeDistributionRowsForMonth(TEST_MONTH, md, Map.of());
+
+        double total = rows.stream().mapToDouble(OpexRow::opexAmountDkk).sum();
+        assertEquals(-247_025.38, total, 0.01,
+                "Barsel.dk refund must flow through as exact -247,025.38 negative cost");
     }
 
     // =======================================================================


### PR DESCRIPTION
## Summary

- Removes the `glAmount < 0 → 0` clamp at `IntercompanyCalcService.java:170` and relaxes 5 downstream `<= 0` guards to `== 0`, so net-negative GL aggregates (Barsel.dk maternity refunds, lunch contributions, Fri telefon tax adjustments) propagate to `fact_opex_distribution_mat` as negative-amount rows on the origin company instead of being silently zeroed.
- Closes ~1.71M DKK of the 1.24M residual EBITDA gap remaining after Phase 4. Combined with the +0.18M pension classification residual, expected post-fix bias is ~–0.29M (slight under-state vs e-conomic).
- All production net-negative driver accounts (3597 Lønrefusion, 3586 Frokost, 3530 Fri telefon, etc.) have `shared=0` AND `salary=0` — the legacy share path doesn't engage and refunds stay with origin. Group totals conserved; per-payer-company breakdowns unaffected.

## Files changed

- `IntercompanyCalcService.java:169-171` — clamp deleted
- `OpexDistributionRefreshService.java:266, 270, 296` — 3 guards relaxed (`> 0` → `!= 0`; `<= 0 continue` → `== 0 continue`)
- `DistributionAwareOpexProvider.java:271, 341` — 2 read-path guards relaxed
- `OpexRow.java` — Javadoc updated to reflect signed semantics
- `OpexDistributionRefreshServiceTest.java` — test 3 flipped (`isSuppressed` → `propagatesAsRefund`), test 4 added with production-shaped Barsel.dk scenario (–247,025.38 DKK), `@TestProfile` added for cvtool config

## Spec

`docs/superpowers/analysis/2026-05-16-opex-clamp-removal-analysis.md` (local-only — docs/ is not versioned in this repo)

## Test plan

- [x] Local `./mvnw compile -q` clean
- [x] Local `./mvnw test-compile -q` clean
- [ ] Staging deploy + force `fact_opex_distribution_mat` refresh
- [ ] Conservation query on staging: `SUM(fact_opex_distribution_mat.opex_amount_dkk)` per month equals `SUM(finance_details.amount)` joined to OPEX/SALARIES accounts for the same period
- [ ] Visual EBITDA chart spot-check on staging — YTD drops ~1.71M
- [ ] Production deploy + force refresh
- [ ] Final EBITDA chart spot-check on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)