### PR TITLE
[codex] Implement expense AI question tree backend

### DIFF
--- a/src/main/java/dk/trustworks/intranet/expenseservice/dto/ExpenseClassificationDTOs.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/dto/ExpenseClassificationDTOs.java
@@ -1,0 +1,90 @@
+package dk.trustworks.intranet.expenseservice.dto;
+
+import java.util.List;
+
+public final class ExpenseClassificationDTOs {
+    private ExpenseClassificationDTOs() {}
+
+    public record Answer(
+            String nodeKey,
+            String answerKey,
+            String source,
+            Double confidence,
+            String evidence,
+            Boolean accepted
+    ) {}
+
+    public record ReceiptFacts(
+            String merchantName,
+            String date,
+            Double amount,
+            String currency,
+            String supplierCountry,
+            String visibleVatText,
+            List<String> lineItems,
+            String documentType
+    ) {}
+
+    public record AnalyzeRequest(String receiptBase64, String mimeType, String fileName) {}
+
+    public record AnalyzeResponse(
+            String analysisId,
+            String treeVersion,
+            ReceiptFacts receiptFacts,
+            List<Answer> proposedAnswers,
+            List<String> warnings,
+            String rawModelSummary
+    ) {}
+
+    public record OptionDTO(String answerKey, String label) {}
+
+    public record NodeDTO(
+            String nodeKey,
+            String prompt,
+            String answerSourcePolicy,
+            boolean required,
+            List<OptionDTO> options
+    ) {}
+
+    public record TreeResponse(String treeVersion, List<NodeDTO> nodes) {}
+
+    public record ResolveRequest(
+            String treeVersion,
+            String analysisId,
+            Boolean aiUsed,
+            Boolean aiIgnored,
+            List<Answer> answers,
+            List<Answer> ignoredAiAnswers
+    ) {}
+
+    public record ResolvedResult(
+            String resultKey,
+            String employeeLabel,
+            String employeeSummary,
+            String accountKey,
+            String accountNumber,
+            String accountName,
+            String taxTreatment,
+            boolean requiresFinanceReview
+    ) {}
+
+    public record ResolveResponse(
+            String state,
+            String treeVersion,
+            List<NodeDTO> unansweredNodes,
+            ResolvedResult result,
+            List<Answer> acceptedAnswers
+    ) {}
+
+    public record Submission(
+            String treeVersion,
+            String decisionResultKey,
+            String accountKey,
+            String analysisId,
+            Boolean aiUsed,
+            Boolean aiIgnored,
+            Boolean requiresFinanceReview,
+            List<Answer> answers,
+            List<Answer> ignoredAiAnswers
+    ) {}
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/events/ExpenseCreatedConsumer.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/events/ExpenseCreatedConsumer.java
@@ -7,6 +7,7 @@ import dk.trustworks.intranet.domain.user.entity.UserContactinfo;
 import dk.trustworks.intranet.dto.ExpenseFile;
 import dk.trustworks.intranet.expenseservice.model.Expense;
 import dk.trustworks.intranet.expenseservice.services.ExpenseAIValidationService;
+import dk.trustworks.intranet.expenseservice.services.ExpenseClassificationService;
 import dk.trustworks.intranet.expenseservice.services.ExpenseDecisionLogService;
 import dk.trustworks.intranet.expenseservice.services.ExpenseFileService;
 import dk.trustworks.intranet.expenseservice.services.ExpenseReviewRoutingService;
@@ -40,6 +41,9 @@ public class ExpenseCreatedConsumer {
 
     @Inject
     ExpenseDecisionLogService decisionLogs;
+
+    @Inject
+    ExpenseClassificationService classificationService;
 
     @Scheduled(every = "50m")
     public void expenseSyncJob() {
@@ -112,11 +116,22 @@ public class ExpenseCreatedConsumer {
         managedExpense.setAiValidationCount(managedExpense.getAiValidationCount() + 1);
 
         if (result.approved()) {
-            // Log the transition FIRST so recordAIApproval sees the pre-mutation state
-            decisionLogs.recordAIApproval(managedExpense);
-            // Approved → move to VALIDATED, clear any prior review state.
-            managedExpense.setStatus(ExpenseService.STATUS_VALIDATED);
-            managedExpense.setReviewState(null);
+            if (classificationService.requiresFinanceReview(managedExpense.getUuid())) {
+                // Log the transition FIRST so the pre-mutation state is captured.
+                decisionLogs.recordAIApprovalPendingFinanceReview(
+                        managedExpense,
+                        "AI approved the receipt, but the selected expense route requires Finance review.");
+                managedExpense.setStatus(ExpenseService.STATUS_CREATED);
+                managedExpense.setReviewState("PENDING_HR");
+                log.infof("Expense %s APPROVED by AI but routed to PENDING_HR due to classification fallback.",
+                        expense.getUuid());
+            } else {
+                // Log the transition FIRST so recordAIApproval sees the pre-mutation state
+                decisionLogs.recordAIApproval(managedExpense);
+                // Approved → move to VALIDATED, clear any prior review state.
+                managedExpense.setStatus(ExpenseService.STATUS_VALIDATED);
+                managedExpense.setReviewState(null);
+            }
             log.infof("Expense %s APPROVED by AI. Reason: %s", expense.getUuid(), result.reason());
         } else {
             // Rejected → stays in CREATED status; routed into a review state instead.

--- a/src/main/java/dk/trustworks/intranet/expenseservice/model/Expense.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/model/Expense.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import dk.trustworks.intranet.expenseservice.utils.LocalDateDeserializer;
 import dk.trustworks.intranet.expenseservice.utils.LocalDateSerializer;
+import dk.trustworks.intranet.expenseservice.dto.ExpenseClassificationDTOs;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.persistence.*;
 import lombok.Data;
@@ -65,6 +66,11 @@ public class Expense extends PanacheEntityBase {
     @ToString.Exclude
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String expensefile;
+
+    @Transient
+    @ToString.Exclude
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private ExpenseClassificationDTOs.Submission classification;
 
     @JsonIgnore
     private int vouchernumber;

--- a/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseAccountMapping.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseAccountMapping.java
@@ -1,0 +1,24 @@
+package dk.trustworks.intranet.expenseservice.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "expense_account_mapping")
+public class ExpenseAccountMapping extends PanacheEntityBase {
+    @Id
+    @JsonIgnore
+    public String uuid;
+    @Column(name = "account_key")
+    public String accountKey;
+    public String companyuuid;
+    @Column(name = "account_number")
+    public String accountNumber;
+    @Column(name = "account_name")
+    public String accountName;
+    public boolean active;
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseClassification.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseClassification.java
@@ -1,0 +1,43 @@
+package dk.trustworks.intranet.expenseservice.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "expense_classification")
+public class ExpenseClassification extends PanacheEntityBase {
+    @Id
+    public String uuid;
+    @Column(name = "expense_uuid")
+    public String expenseUuid;
+    public String useruuid;
+    @Column(name = "analysis_id")
+    public String analysisId;
+    @Column(name = "tree_version")
+    public String treeVersion;
+    @Column(name = "ai_used")
+    public boolean aiUsed;
+    @Column(name = "ai_ignored")
+    public boolean aiIgnored;
+    @Column(name = "decision_result_key")
+    public String decisionResultKey;
+    @Column(name = "account_key")
+    public String accountKey;
+    @Column(name = "account_number")
+    public String accountNumber;
+    @Column(name = "account_name")
+    public String accountName;
+    @Column(name = "requires_finance_review")
+    public boolean requiresFinanceReview;
+    @Column(name = "answers_json", columnDefinition = "json")
+    public String answersJson;
+    @Column(name = "ignored_ai_answers_json", columnDefinition = "json")
+    public String ignoredAiAnswersJson;
+    @Column(name = "created_at")
+    public LocalDateTime createdAt;
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseClassificationNode.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseClassificationNode.java
@@ -1,0 +1,28 @@
+package dk.trustworks.intranet.expenseservice.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "expense_classification_node")
+public class ExpenseClassificationNode extends PanacheEntityBase {
+    @Id
+    @JsonIgnore
+    public String uuid;
+    @Column(name = "tree_version")
+    public String treeVersion;
+    @Column(name = "node_key")
+    public String nodeKey;
+    public String prompt;
+    @Column(name = "answer_source_policy")
+    public String answerSourcePolicy;
+    public boolean required;
+    @Column(name = "sort_order")
+    public int sortOrder;
+    @Column(name = "visible_when_json", columnDefinition = "json")
+    public String visibleWhenJson;
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseClassificationOption.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseClassificationOption.java
@@ -1,0 +1,25 @@
+package dk.trustworks.intranet.expenseservice.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "expense_classification_option")
+public class ExpenseClassificationOption extends PanacheEntityBase {
+    @Id
+    @JsonIgnore
+    public String uuid;
+    @Column(name = "tree_version")
+    public String treeVersion;
+    @Column(name = "node_key")
+    public String nodeKey;
+    @Column(name = "answer_key")
+    public String answerKey;
+    public String label;
+    @Column(name = "sort_order")
+    public int sortOrder;
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseClassificationResult.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseClassificationResult.java
@@ -1,0 +1,34 @@
+package dk.trustworks.intranet.expenseservice.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "expense_classification_result")
+public class ExpenseClassificationResult extends PanacheEntityBase {
+    @Id
+    @JsonIgnore
+    public String uuid;
+    @Column(name = "tree_version")
+    public String treeVersion;
+    @Column(name = "result_key")
+    public String resultKey;
+    @Column(name = "employee_label")
+    public String employeeLabel;
+    @Column(name = "employee_summary")
+    public String employeeSummary;
+    @Column(name = "account_key")
+    public String accountKey;
+    @Column(name = "tax_treatment")
+    public String taxTreatment;
+    @Column(name = "requires_finance_review")
+    public boolean requiresFinanceReview;
+    @Column(name = "conditions_json", columnDefinition = "json")
+    public String conditionsJson;
+    @Column(name = "sort_order")
+    public int sortOrder;
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseClassificationTree.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseClassificationTree.java
@@ -1,0 +1,22 @@
+package dk.trustworks.intranet.expenseservice.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "expense_classification_tree")
+public class ExpenseClassificationTree extends PanacheEntityBase {
+    @Id
+    @Column(name = "tree_version")
+    public String treeVersion;
+    public boolean active;
+    @Column(name = "created_at")
+    public LocalDateTime createdAt;
+    @Column(name = "created_by")
+    public String createdBy;
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseReceiptAnalysis.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/model/ExpenseReceiptAnalysis.java
@@ -1,0 +1,30 @@
+package dk.trustworks.intranet.expenseservice.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "expense_receipt_analysis")
+public class ExpenseReceiptAnalysis extends PanacheEntityBase {
+    @Id
+    @Column(name = "analysis_id")
+    public String analysisId;
+    public String useruuid;
+    @Column(name = "tree_version")
+    public String treeVersion;
+    @Column(name = "created_at")
+    public LocalDateTime createdAt;
+    @Column(name = "receipt_facts_json", columnDefinition = "json")
+    public String receiptFactsJson;
+    @Column(name = "proposed_answers_json", columnDefinition = "json")
+    public String proposedAnswersJson;
+    @Column(name = "warnings_json", columnDefinition = "json")
+    public String warningsJson;
+    @Column(name = "raw_model_summary", columnDefinition = "TEXT")
+    public String rawModelSummary;
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/resources/ExpenseClassificationResource.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/resources/ExpenseClassificationResource.java
@@ -1,0 +1,52 @@
+package dk.trustworks.intranet.expenseservice.resources;
+
+import dk.trustworks.intranet.expenseservice.dto.ExpenseClassificationDTOs;
+import dk.trustworks.intranet.expenseservice.services.ExpenseClassificationService;
+import dk.trustworks.intranet.security.RequestHeaderHolder;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/expenses/classification")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ExpenseClassificationResource {
+
+    @Inject ExpenseClassificationService service;
+    @Inject RequestHeaderHolder header;
+
+    @GET
+    @Path("/tree")
+    @RolesAllowed({"expenses:read"})
+    public ExpenseClassificationDTOs.TreeResponse tree() {
+        return service.getActiveTree();
+    }
+
+    @POST
+    @Path("/analyze")
+    @RolesAllowed({"expenses:write"})
+    public ExpenseClassificationDTOs.AnalyzeResponse analyze(
+            @QueryParam("useruuid") String useruuid,
+            ExpenseClassificationDTOs.AnalyzeRequest request
+    ) {
+        return service.analyze(resolveUser(useruuid), request);
+    }
+
+    @POST
+    @Path("/resolve")
+    @RolesAllowed({"expenses:write"})
+    public ExpenseClassificationDTOs.ResolveResponse resolve(
+            @QueryParam("useruuid") String useruuid,
+            ExpenseClassificationDTOs.ResolveRequest request
+    ) {
+        return service.resolve(resolveUser(useruuid), request);
+    }
+
+    private String resolveUser(String fallback) {
+        String actor = header.getUserUuid();
+        if (actor != null && !actor.isBlank()) return actor;
+        if (fallback != null && !fallback.isBlank()) return fallback;
+        throw new BadRequestException("useruuid is required");
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/resources/ExpenseResource.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/resources/ExpenseResource.java
@@ -9,6 +9,7 @@ import dk.trustworks.intranet.expenseservice.dto.ExpenseJustificationDTO;
 import dk.trustworks.intranet.expenseservice.model.Expense;
 import dk.trustworks.intranet.expenseservice.model.ExpenseCategory;
 import dk.trustworks.intranet.expenseservice.services.EconomicsService;
+import dk.trustworks.intranet.expenseservice.services.ExpenseClassificationService;
 import dk.trustworks.intranet.expenseservice.services.ExpenseDecisionLogService;
 import dk.trustworks.intranet.expenseservice.services.ExpenseFileService;
 import dk.trustworks.intranet.expenseservice.services.ExpenseService;
@@ -58,6 +59,9 @@ public class ExpenseResource {
 
     @Inject
     ExpenseDecisionLogService logs;
+
+    @Inject
+    ExpenseClassificationService classificationService;
 
     @Inject
     dk.trustworks.intranet.security.RequestHeaderHolder header;
@@ -226,7 +230,8 @@ public class ExpenseResource {
     public Response saveExpense(@Valid Expense expense) throws IOException {
         log.info("ExpenseResource.saveExpense");
         log.info("expense = " + expense);
-        expenseService.processExpense(expense);
+        classificationService.applyResolvedAccount(expense);
+        expenseService.processExpense(expense, () -> classificationService.persistSubmittedClassification(expense));
         return Response.status(Response.Status.CREATED).entity(expense).build();
     }
 
@@ -263,6 +268,11 @@ public class ExpenseResource {
         Expense existing = Expense.findById(uuid);
         if (existing == null) {
             throw new WebApplicationException("Expense not found", 404);
+        }
+
+        if (expense.getClassification() != null) {
+            expense.setUseruuid(existing.getUseruuid());
+            classificationService.applyResolvedAccount(expense);
         }
 
         // Build dynamic update query based on what's being updated
@@ -313,6 +323,13 @@ public class ExpenseResource {
         if (expense.getExpensefile() != null && !expense.getExpensefile().isEmpty()) {
             ExpenseFile newFile = new ExpenseFile(uuid, expense.getExpensefile());
             expenseFileService.saveFile(newFile);
+        }
+
+        if (expense.getClassification() != null) {
+            existing.setClassification(expense.getClassification());
+            existing.setAccount(expense.getAccount());
+            existing.setAccountname(expense.getAccountname());
+            classificationService.persistSubmittedClassification(existing);
         }
 
         // If the row is sitting in a review state waiting on the employee, this edit

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseClassificationService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseClassificationService.java
@@ -1,0 +1,474 @@
+package dk.trustworks.intranet.expenseservice.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dk.trustworks.intranet.aggregates.users.services.UserService;
+import dk.trustworks.intranet.apis.openai.OpenAIService;
+import dk.trustworks.intranet.domain.user.entity.User;
+import dk.trustworks.intranet.expenseservice.dto.ExpenseClassificationDTOs;
+import dk.trustworks.intranet.expenseservice.model.*;
+import dk.trustworks.intranet.model.Company;
+import io.quarkus.panache.common.Sort;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
+import lombok.extern.jbosslog.JBossLog;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@JBossLog
+@ApplicationScoped
+public class ExpenseClassificationService {
+
+    private static final double AI_ACCEPT_THRESHOLD = 0.70;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, String>> STRING_MAP = new TypeReference<>() {};
+
+    @Inject OpenAIService openAIService;
+    @Inject UserService userService;
+
+    public String activeTreeVersion() {
+        ExpenseClassificationTree tree = ExpenseClassificationTree.find("active = ?1", true).firstResult();
+        if (tree == null) throw new NotFoundException("No active expense classification tree");
+        return tree.treeVersion;
+    }
+
+    public ExpenseClassificationDTOs.TreeResponse getActiveTree() {
+        String version = activeTreeVersion();
+        return new ExpenseClassificationDTOs.TreeResponse(version, treeNodes(version, null));
+    }
+
+    @Transactional
+    public ExpenseClassificationDTOs.AnalyzeResponse analyze(String useruuid, ExpenseClassificationDTOs.AnalyzeRequest request) {
+        if (request == null || request.receiptBase64() == null || request.receiptBase64().isBlank()) {
+            throw new BadRequestException("receiptBase64 is required");
+        }
+        String mime = request.mimeType() == null || request.mimeType().isBlank() ? "image/jpeg" : request.mimeType();
+        if ("application/pdf".equalsIgnoreCase(mime)) {
+            String version = activeTreeVersion();
+            ExpenseClassificationDTOs.AnalyzeResponse response = new ExpenseClassificationDTOs.AnalyzeResponse(
+                    UUID.randomUUID().toString(),
+                    version,
+                    emptyFacts("pdf"),
+                    List.of(),
+                    List.of("PDF receipts start from manual classification in v1."),
+                    "PDF receipt was not analyzed before submission."
+            );
+            persistAnalysis(useruuid, response);
+            return response;
+        }
+
+        String version = activeTreeVersion();
+        String fallback = fallbackAnalysisJson();
+        String raw = openAIService.askWithSchemaAndImage(
+                analysisSystemPrompt(),
+                "Read this employee receipt. Return only facts visible on the receipt and proposed question-tree answers. Do not choose final account numbers.",
+                request.receiptBase64(),
+                mime,
+                analysisSchema(),
+                "expense_receipt_analysis",
+                fallback
+        );
+
+        ExpenseClassificationDTOs.AnalyzeResponse parsed = parseAnalysis(version, raw);
+        persistAnalysis(useruuid, parsed);
+        return parsed;
+    }
+
+    public ExpenseClassificationDTOs.ResolveResponse resolve(String useruuid, ExpenseClassificationDTOs.ResolveRequest request) {
+        String version = request != null && request.treeVersion() != null && !request.treeVersion().isBlank()
+                ? request.treeVersion()
+                : activeTreeVersion();
+        List<ExpenseClassificationDTOs.Answer> accepted = sanitizeAnswers(version, request != null ? request.answers() : List.of());
+        Map<String, String> answerMap = accepted.stream()
+                .collect(Collectors.toMap(
+                        ExpenseClassificationDTOs.Answer::nodeKey,
+                        ExpenseClassificationDTOs.Answer::answerKey,
+                        (previous, next) -> next,
+                        LinkedHashMap::new
+                ));
+
+        List<ExpenseClassificationDTOs.NodeDTO> visibleNodes = visibleTreeNodes(version, answerMap);
+        List<ExpenseClassificationDTOs.NodeDTO> unanswered = visibleNodes.stream()
+                .filter(ExpenseClassificationDTOs.NodeDTO::required)
+                .filter(node -> !answerMap.containsKey(node.nodeKey()))
+                .toList();
+        if (!unanswered.isEmpty()) {
+            return new ExpenseClassificationDTOs.ResolveResponse(
+                    "NEEDS_ANSWERS",
+                    version,
+                    unanswered,
+                    null,
+                    accepted
+            );
+        }
+
+        ExpenseClassificationResult result = findMatchingResult(version, answerMap);
+        if (result == null) {
+            throw new BadRequestException("No classification result matches the provided answers");
+        }
+
+        ExpenseAccountMapping mapping = resolveMapping(result.accountKey, currentCompanyUuid(useruuid));
+        boolean mappingFallback = mapping == null;
+        if (mapping == null) mapping = fallbackMapping();
+
+        ExpenseClassificationDTOs.ResolvedResult resolved = new ExpenseClassificationDTOs.ResolvedResult(
+                result.resultKey,
+                result.employeeLabel,
+                result.employeeSummary,
+                mapping.accountKey,
+                mapping.accountNumber,
+                mapping.accountName,
+                result.taxTreatment,
+                result.requiresFinanceReview || mappingFallback || "finance_review_fallback".equals(mapping.accountKey)
+        );
+
+        return new ExpenseClassificationDTOs.ResolveResponse(
+                "RESOLVED",
+                version,
+                List.of(),
+                resolved,
+                accepted
+        );
+    }
+
+    public ExpenseClassificationDTOs.ResolveResponse resolveSubmission(String useruuid, ExpenseClassificationDTOs.Submission submission) {
+        if (submission == null) throw new BadRequestException("classification is required");
+        ExpenseClassificationDTOs.ResolveRequest request = new ExpenseClassificationDTOs.ResolveRequest(
+                submission.treeVersion(),
+                submission.analysisId(),
+                submission.aiUsed(),
+                submission.aiIgnored(),
+                submission.answers(),
+                submission.ignoredAiAnswers()
+        );
+        ExpenseClassificationDTOs.ResolveResponse response = resolve(useruuid, request);
+        if (response.result() == null) throw new BadRequestException("classification is incomplete");
+        return response;
+    }
+
+    public void applyResolvedAccount(Expense expense) {
+        if (expense.getClassification() == null) return;
+        ExpenseClassificationDTOs.ResolveResponse resolved = resolveSubmission(expense.getUseruuid(), expense.getClassification());
+        expense.setAccount(resolved.result().accountNumber());
+        expense.setAccountname(resolved.result().accountName());
+    }
+
+    @Transactional
+    public void persistSubmittedClassification(Expense expense) {
+        ExpenseClassificationDTOs.Submission submission = expense.getClassification();
+        if (submission == null) return;
+        ExpenseClassificationDTOs.ResolveResponse resolved = resolveSubmission(expense.getUseruuid(), submission);
+
+        ExpenseClassification row = ExpenseClassification.find("expenseUuid", expense.getUuid()).firstResult();
+        if (row == null) {
+            row = new ExpenseClassification();
+            row.uuid = UUID.randomUUID().toString();
+            row.expenseUuid = expense.getUuid();
+            row.createdAt = LocalDateTime.now();
+        }
+        row.useruuid = expense.getUseruuid();
+        row.analysisId = submission.analysisId();
+        row.treeVersion = resolved.treeVersion();
+        row.aiUsed = Boolean.TRUE.equals(submission.aiUsed());
+        row.aiIgnored = Boolean.TRUE.equals(submission.aiIgnored());
+        row.decisionResultKey = resolved.result().resultKey();
+        row.accountKey = resolved.result().accountKey();
+        row.accountNumber = resolved.result().accountNumber();
+        row.accountName = resolved.result().accountName();
+        row.requiresFinanceReview = resolved.result().requiresFinanceReview();
+        row.answersJson = toJson(resolved.acceptedAnswers(), "[]");
+        row.ignoredAiAnswersJson = toJson(submission.ignoredAiAnswers() == null ? List.of() : submission.ignoredAiAnswers(), "[]");
+        row.persist();
+    }
+
+    public boolean requiresFinanceReview(String expenseUuid) {
+        ExpenseClassification row = ExpenseClassification.find("expenseUuid", expenseUuid).firstResult();
+        return row != null && row.requiresFinanceReview;
+    }
+
+    List<ExpenseClassificationDTOs.Answer> sanitizeAnswers(String version, List<ExpenseClassificationDTOs.Answer> answers) {
+        if (answers == null || answers.isEmpty()) return List.of();
+        Map<String, ExpenseClassificationNode> nodes = ExpenseClassificationNode.<ExpenseClassificationNode>list("treeVersion = ?1", version)
+                .stream()
+                .collect(Collectors.toMap(node -> node.nodeKey, Function.identity()));
+        Set<String> validOptionKeys = ExpenseClassificationOption.<ExpenseClassificationOption>list("treeVersion = ?1", version)
+                .stream()
+                .map(option -> option.nodeKey + "\u0000" + option.answerKey)
+                .collect(Collectors.toSet());
+
+        LinkedHashMap<String, ExpenseClassificationDTOs.Answer> deduped = new LinkedHashMap<>();
+        for (ExpenseClassificationDTOs.Answer answer : answers) {
+            if (answer == null || answer.nodeKey() == null || answer.answerKey() == null) continue;
+            if (!nodes.containsKey(answer.nodeKey())) continue;
+            if (!validOptionKeys.contains(answer.nodeKey() + "\u0000" + answer.answerKey())) continue;
+            deduped.put(answer.nodeKey(), answer);
+        }
+        return new ArrayList<>(deduped.values());
+    }
+
+    private List<ExpenseClassificationDTOs.NodeDTO> visibleTreeNodes(String version, Map<String, String> answers) {
+        return treeNodes(version, answers);
+    }
+
+    private List<ExpenseClassificationDTOs.NodeDTO> treeNodes(String version, Map<String, String> answersOrNull) {
+        List<ExpenseClassificationNode> nodes = ExpenseClassificationNode.list(
+                "treeVersion = ?1",
+                Sort.by("sortOrder"),
+                version
+        );
+        Map<String, List<ExpenseClassificationOption>> options = ExpenseClassificationOption.<ExpenseClassificationOption>list(
+                        "treeVersion = ?1",
+                        Sort.by("sortOrder"),
+                        version
+                )
+                .stream()
+                .collect(Collectors.groupingBy(option -> option.nodeKey, LinkedHashMap::new, Collectors.toList()));
+
+        return nodes.stream()
+                .filter(node -> answersOrNull == null || visible(node.visibleWhenJson, answersOrNull))
+                .map(node -> new ExpenseClassificationDTOs.NodeDTO(
+                        node.nodeKey,
+                        node.prompt,
+                        node.answerSourcePolicy,
+                        node.required,
+                        options.getOrDefault(node.nodeKey, List.of()).stream()
+                                .map(option -> new ExpenseClassificationDTOs.OptionDTO(option.answerKey, option.label))
+                                .toList()
+                ))
+                .toList();
+    }
+
+    private boolean visible(String visibleWhenJson, Map<String, String> answers) {
+        Map<String, String> conditions = parseStringMap(visibleWhenJson);
+        for (Map.Entry<String, String> entry : conditions.entrySet()) {
+            if (!entry.getValue().equals(answers.get(entry.getKey()))) return false;
+        }
+        return true;
+    }
+
+    private ExpenseClassificationResult findMatchingResult(String version, Map<String, String> answers) {
+        return ExpenseClassificationResult.<ExpenseClassificationResult>list(
+                        "treeVersion = ?1",
+                        Sort.by("sortOrder"),
+                        version
+                )
+                .stream()
+                .filter(result -> visible(result.conditionsJson, answers))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private ExpenseAccountMapping resolveMapping(String accountKey, String companyuuid) {
+        if (companyuuid != null && !companyuuid.isBlank()) {
+            ExpenseAccountMapping exact = ExpenseAccountMapping.find(
+                    "accountKey = ?1 and companyuuid = ?2 and active = true",
+                    accountKey,
+                    companyuuid
+            ).firstResult();
+            if (exact != null) return exact;
+        }
+        return ExpenseAccountMapping.find(
+                "accountKey = ?1 and companyuuid is null and active = true",
+                accountKey
+        ).firstResult();
+    }
+
+    private ExpenseAccountMapping fallbackMapping() {
+        ExpenseAccountMapping fallback = resolveMapping("finance_review_fallback", null);
+        if (fallback != null) return fallback;
+        ExpenseAccountMapping synthetic = new ExpenseAccountMapping();
+        synthetic.accountKey = "finance_review_fallback";
+        synthetic.accountNumber = "9998";
+        synthetic.accountName = "Finance review";
+        synthetic.active = true;
+        return synthetic;
+    }
+
+    private String currentCompanyUuid(String useruuid) {
+        try {
+            User user = userService.findById(useruuid, false);
+            if (user == null) return null;
+            Company company = userService.getUserStatus(user, LocalDate.now()).getCompany();
+            return company != null ? company.getUuid() : null;
+        } catch (Exception ex) {
+            log.warnf(ex, "Could not resolve company for expense classification useruuid=%s", useruuid);
+            return null;
+        }
+    }
+
+    private void persistAnalysis(String useruuid, ExpenseClassificationDTOs.AnalyzeResponse response) {
+        ExpenseReceiptAnalysis row = new ExpenseReceiptAnalysis();
+        row.analysisId = response.analysisId();
+        row.useruuid = useruuid;
+        row.treeVersion = response.treeVersion();
+        row.createdAt = LocalDateTime.now();
+        row.receiptFactsJson = toJson(response.receiptFacts(), "{}");
+        row.proposedAnswersJson = toJson(response.proposedAnswers(), "[]");
+        row.warningsJson = toJson(response.warnings(), "[]");
+        row.rawModelSummary = response.rawModelSummary();
+        row.persist();
+    }
+
+    private ExpenseClassificationDTOs.AnalyzeResponse parseAnalysis(String version, String raw) {
+        try {
+            JsonNode node = MAPPER.readTree(raw == null || raw.isBlank() ? fallbackAnalysisJson() : raw);
+            String analysisId = UUID.randomUUID().toString();
+            ExpenseClassificationDTOs.ReceiptFacts facts = MAPPER.treeToValue(node.path("receiptFacts"), ExpenseClassificationDTOs.ReceiptFacts.class);
+            List<ExpenseClassificationDTOs.Answer> proposed = new ArrayList<>();
+            JsonNode proposedNode = node.path("proposedAnswers");
+            if (proposedNode.isArray()) {
+                for (JsonNode answerNode : proposedNode) {
+                    ExpenseClassificationDTOs.Answer answer = MAPPER.treeToValue(answerNode, ExpenseClassificationDTOs.Answer.class);
+                    if (answer.confidence() != null && answer.confidence() >= AI_ACCEPT_THRESHOLD) {
+                        proposed.add(answer);
+                    }
+                }
+            }
+            List<String> warnings = new ArrayList<>();
+            JsonNode warningsNode = node.path("warnings");
+            if (warningsNode.isArray()) {
+                warningsNode.forEach(w -> warnings.add(w.asText()));
+            }
+            return new ExpenseClassificationDTOs.AnalyzeResponse(
+                    analysisId,
+                    version,
+                    facts == null ? emptyFacts("receipt") : facts,
+                    sanitizeAnswers(version, proposed),
+                    warnings,
+                    node.path("rawModelSummary").asText("")
+            );
+        } catch (Exception ex) {
+            log.warnf(ex, "Failed to parse expense receipt classification response");
+            return new ExpenseClassificationDTOs.AnalyzeResponse(
+                    UUID.randomUUID().toString(),
+                    version,
+                    emptyFacts("receipt"),
+                    List.of(),
+                    List.of("Receipt analysis was unavailable. Please choose the classification manually."),
+                    ""
+            );
+        }
+    }
+
+    private ExpenseClassificationDTOs.ReceiptFacts emptyFacts(String documentType) {
+        return new ExpenseClassificationDTOs.ReceiptFacts(null, null, null, "DKK", null, null, List.of(), documentType);
+    }
+
+    private Map<String, String> parseStringMap(String json) {
+        if (json == null || json.isBlank()) return Map.of();
+        try {
+            return MAPPER.readValue(json, STRING_MAP);
+        } catch (JsonProcessingException ex) {
+            return Map.of();
+        }
+    }
+
+    private String toJson(Object value, String fallback) {
+        try {
+            return MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            return fallback;
+        }
+    }
+
+    private String analysisSystemPrompt() {
+        return """
+                You classify employee receipts for Trustworks before expense submission.
+                Return only facts visible on the receipt and possible answers to the question tree.
+                You may propose root categories and supplier-country answers when visible evidence supports them.
+                Do not output account numbers, tax codes, or final accounting decisions.
+                Valid root answer keys are: food_catering, transport_travel, gift, software, hardware, office_supplies, internet, course_training, other_unsure.
+                """;
+    }
+
+    private ObjectNode analysisSchema() {
+        ObjectNode schema = MAPPER.createObjectNode();
+        schema.put("type", "object");
+        schema.putArray("required").add("receiptFacts").add("proposedAnswers").add("warnings").add("rawModelSummary");
+        schema.put("additionalProperties", false);
+
+        ObjectNode properties = schema.putObject("properties");
+        ObjectNode facts = properties.putObject("receiptFacts");
+        facts.put("type", "object");
+        facts.put("additionalProperties", false);
+        facts.putArray("required")
+                .add("merchantName").add("date").add("amount").add("currency")
+                .add("supplierCountry").add("visibleVatText").add("lineItems").add("documentType");
+        ObjectNode factProps = facts.putObject("properties");
+        nullableString(factProps, "merchantName");
+        nullableString(factProps, "date");
+        nullableNumber(factProps, "amount");
+        nullableString(factProps, "currency");
+        nullableString(factProps, "supplierCountry");
+        nullableString(factProps, "visibleVatText");
+        ObjectNode lineItems = factProps.putObject("lineItems");
+        lineItems.put("type", "array");
+        lineItems.putObject("items").put("type", "string");
+        nullableString(factProps, "documentType");
+
+        ObjectNode proposed = properties.putObject("proposedAnswers");
+        proposed.put("type", "array");
+        ObjectNode answerItem = proposed.putObject("items");
+        answerItem.put("type", "object");
+        answerItem.put("additionalProperties", false);
+        answerItem.putArray("required").add("nodeKey").add("answerKey").add("source").add("confidence").add("evidence").add("accepted");
+        ObjectNode answerProps = answerItem.putObject("properties");
+        answerProps.putObject("nodeKey").put("type", "string");
+        answerProps.putObject("answerKey").put("type", "string");
+        answerProps.putObject("source").put("type", "string");
+        nullableNumber(answerProps, "confidence");
+        nullableString(answerProps, "evidence");
+        ObjectNode accepted = answerProps.putObject("accepted");
+        ArrayNode acceptedTypes = accepted.putArray("type");
+        acceptedTypes.add("boolean").add("null");
+
+        ObjectNode warnings = properties.putObject("warnings");
+        warnings.put("type", "array");
+        warnings.putObject("items").put("type", "string");
+        properties.putObject("rawModelSummary").put("type", "string");
+        return schema;
+    }
+
+    private void nullableString(ObjectNode props, String name) {
+        ObjectNode field = props.putObject(name);
+        ArrayNode types = field.putArray("type");
+        types.add("string").add("null");
+    }
+
+    private void nullableNumber(ObjectNode props, String name) {
+        ObjectNode field = props.putObject(name);
+        ArrayNode types = field.putArray("type");
+        types.add("number").add("null");
+    }
+
+    private String fallbackAnalysisJson() {
+        return """
+                {
+                  "receiptFacts": {
+                    "merchantName": null,
+                    "date": null,
+                    "amount": null,
+                    "currency": "DKK",
+                    "supplierCountry": null,
+                    "visibleVatText": null,
+                    "lineItems": [],
+                    "documentType": "receipt"
+                  },
+                  "proposedAnswers": [],
+                  "warnings": ["Receipt analysis was unavailable. Please choose the classification manually."],
+                  "rawModelSummary": ""
+                }
+                """;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseDecisionLogService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseDecisionLogService.java
@@ -17,6 +17,12 @@ public class ExpenseDecisionLogService {
     }
 
     @Transactional
+    public void recordAIApprovalPendingFinanceReview(Expense e, String reason) {
+        append(e, "AI", null, "AI_VALIDATED_APPROVED",
+               e.getStatus(), e.getStatus(), e.getReviewState(), "PENDING_HR", null, reason);
+    }
+
+    @Transactional
     public void recordAIRejection(Expense e, String toReviewState, String primaryRuleId, String reason) {
         append(e, "AI", null, "AI_VALIDATED_REJECTED",
                e.getStatus(), e.getStatus(), e.getReviewState(), toReviewState, primaryRuleId, reason);

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseService.java
@@ -84,12 +84,20 @@ public class ExpenseService {
 
     @Transactional
     public void processExpense(Expense expense) throws IOException {
+        processExpense(expense, null);
+    }
+
+    @Transactional
+    public void processExpense(Expense expense, Runnable afterPersistBeforeValidation) throws IOException {
         log.info("Processing new expense " + expense.getUuid());
         try {
             //save expense to db
             expense.setStatus(STATUS_CREATED);
             expense.persist();
             log.info("Expense persisted with status CREATED: " + expense.getUuid());
+            if (afterPersistBeforeValidation != null) {
+                afterPersistBeforeValidation.run();
+            }
 
             //save expense file to AWS
             ExpenseFile expenseFile = new ExpenseFile(expense.getUuid(), expense.getExpensefile());
@@ -471,4 +479,3 @@ public class ExpenseService {
         eventBus.publish("expense.validate", uuid);
     }
 }
-

--- a/src/main/resources/db/migration/V353__Create_expense_classification_tree.sql
+++ b/src/main/resources/db/migration/V353__Create_expense_classification_tree.sql
@@ -1,0 +1,220 @@
+-- Expense AI question tree v1. Account numbers are implementation metadata;
+-- employee-facing clients consume labels/results and keep account details hidden.
+
+CREATE TABLE expense_classification_tree (
+  tree_version VARCHAR(32) NOT NULL PRIMARY KEY,
+  active       BOOLEAN     NOT NULL DEFAULT FALSE,
+  created_at   DATETIME(3) NOT NULL,
+  created_by   VARCHAR(36) NOT NULL
+);
+
+CREATE TABLE expense_classification_node (
+  uuid                 VARCHAR(36)  NOT NULL PRIMARY KEY,
+  tree_version         VARCHAR(32)  NOT NULL,
+  node_key             VARCHAR(64)  NOT NULL,
+  prompt               VARCHAR(255) NOT NULL,
+  answer_source_policy VARCHAR(40)  NOT NULL,
+  required             BOOLEAN      NOT NULL DEFAULT TRUE,
+  sort_order           INT          NOT NULL,
+  visible_when_json    JSON         NULL,
+  UNIQUE KEY uq_ecn_tree_node (tree_version, node_key),
+  INDEX idx_ecn_tree_order (tree_version, sort_order),
+  CONSTRAINT fk_ecn_tree FOREIGN KEY (tree_version) REFERENCES expense_classification_tree(tree_version)
+);
+
+CREATE TABLE expense_classification_option (
+  uuid          VARCHAR(36)  NOT NULL PRIMARY KEY,
+  tree_version  VARCHAR(32)  NOT NULL,
+  node_key      VARCHAR(64)  NOT NULL,
+  answer_key    VARCHAR(64)  NOT NULL,
+  label         VARCHAR(160) NOT NULL,
+  sort_order    INT          NOT NULL,
+  UNIQUE KEY uq_eco_tree_node_answer (tree_version, node_key, answer_key),
+  INDEX idx_eco_tree_node_order (tree_version, node_key, sort_order),
+  CONSTRAINT fk_eco_tree FOREIGN KEY (tree_version) REFERENCES expense_classification_tree(tree_version)
+);
+
+CREATE TABLE expense_classification_result (
+  uuid                    VARCHAR(36)  NOT NULL PRIMARY KEY,
+  tree_version            VARCHAR(32)  NOT NULL,
+  result_key              VARCHAR(80)  NOT NULL,
+  employee_label          VARCHAR(180) NOT NULL,
+  employee_summary        VARCHAR(255) NOT NULL,
+  account_key             VARCHAR(80)  NOT NULL,
+  tax_treatment           VARCHAR(32)  NULL,
+  requires_finance_review BOOLEAN      NOT NULL DEFAULT FALSE,
+  conditions_json         JSON         NOT NULL,
+  sort_order              INT          NOT NULL,
+  UNIQUE KEY uq_ecr_tree_result (tree_version, result_key),
+  INDEX idx_ecr_tree_order (tree_version, sort_order),
+  CONSTRAINT fk_ecr_tree FOREIGN KEY (tree_version) REFERENCES expense_classification_tree(tree_version)
+);
+
+CREATE TABLE expense_account_mapping (
+  uuid           VARCHAR(36)  NOT NULL PRIMARY KEY,
+  account_key    VARCHAR(80)  NOT NULL,
+  companyuuid    VARCHAR(36)  NULL,
+  account_number VARCHAR(16)  NOT NULL,
+  account_name   VARCHAR(160) NOT NULL,
+  active         BOOLEAN      NOT NULL DEFAULT TRUE,
+  UNIQUE KEY uq_eam_key_company (account_key, companyuuid),
+  INDEX idx_eam_key_active (account_key, active)
+);
+
+CREATE TABLE expense_receipt_analysis (
+  analysis_id            VARCHAR(36) NOT NULL PRIMARY KEY,
+  useruuid               VARCHAR(36) NOT NULL,
+  tree_version           VARCHAR(32) NOT NULL,
+  created_at             DATETIME(3) NOT NULL,
+  receipt_facts_json     JSON        NOT NULL,
+  proposed_answers_json  JSON        NOT NULL,
+  warnings_json          JSON        NOT NULL,
+  raw_model_summary      TEXT        NULL,
+  INDEX idx_era_user_created (useruuid, created_at),
+  CONSTRAINT fk_era_tree FOREIGN KEY (tree_version) REFERENCES expense_classification_tree(tree_version)
+);
+
+CREATE TABLE expense_classification (
+  uuid                    VARCHAR(36) NOT NULL PRIMARY KEY,
+  expense_uuid            VARCHAR(36) NOT NULL,
+  useruuid                VARCHAR(36) NOT NULL,
+  analysis_id             VARCHAR(36) NULL,
+  tree_version            VARCHAR(32) NOT NULL,
+  ai_used                 BOOLEAN     NOT NULL DEFAULT FALSE,
+  ai_ignored              BOOLEAN     NOT NULL DEFAULT FALSE,
+  decision_result_key     VARCHAR(80) NOT NULL,
+  account_key             VARCHAR(80) NOT NULL,
+  account_number          VARCHAR(16) NOT NULL,
+  account_name            VARCHAR(160) NOT NULL,
+  requires_finance_review BOOLEAN     NOT NULL DEFAULT FALSE,
+  answers_json            JSON        NOT NULL,
+  ignored_ai_answers_json JSON        NOT NULL,
+  created_at              DATETIME(3) NOT NULL,
+  UNIQUE KEY uq_ec_expense (expense_uuid),
+  INDEX idx_ec_user_created (useruuid, created_at),
+  CONSTRAINT fk_ec_expense FOREIGN KEY (expense_uuid) REFERENCES expenses(uuid) ON DELETE CASCADE,
+  CONSTRAINT fk_ec_tree FOREIGN KEY (tree_version) REFERENCES expense_classification_tree(tree_version)
+);
+
+INSERT INTO expense_classification_tree (tree_version, active, created_at, created_by)
+VALUES ('2026-05-19.v1', TRUE, NOW(3), 'SYSTEM_SEED');
+
+INSERT INTO expense_classification_node (uuid, tree_version, node_key, prompt, answer_source_policy, required, sort_order, visible_when_json) VALUES
+  (UUID(), '2026-05-19.v1', 'root', 'What kind of expense is this?', 'AI_ALLOWED_USER_CAN_OVERRIDE', TRUE, 10, NULL),
+  (UUID(), '2026-05-19.v1', 'food_situation', 'What was the food or catering situation?', 'USER_REQUIRED', TRUE, 20, '{"root":"food_catering"}'),
+  (UUID(), '2026-05-19.v1', 'meal_purpose', 'Was it customer care or a normal lunch break?', 'USER_REQUIRED', TRUE, 30, '{"food_situation":"with_customer"}'),
+  (UUID(), '2026-05-19.v1', 'tw_event_type', 'Was it a professional or social arrangement?', 'USER_REQUIRED', TRUE, 40, '{"food_situation":"trustworks_event"}'),
+  (UUID(), '2026-05-19.v1', 'tw_event_location', 'Where did it take place?', 'USER_REQUIRED', TRUE, 50, '{"food_situation":"trustworks_event"}'),
+  (UUID(), '2026-05-19.v1', 'overtime_location', 'Where was the overtime meal bought or eaten?', 'USER_REQUIRED', TRUE, 60, '{"food_situation":"overtime_meal"}'),
+  (UUID(), '2026-05-19.v1', 'travel_cost', 'What travel cost is it?', 'USER_REQUIRED', TRUE, 70, '{"root":"transport_travel"}'),
+  (UUID(), '2026-05-19.v1', 'hotel_country', 'Was the hotel stay in Denmark or abroad?', 'AI_ALLOWED_USER_CAN_OVERRIDE', TRUE, 80, '{"travel_cost":"hotel"}'),
+  (UUID(), '2026-05-19.v1', 'bridge_kind', 'Which bridge or toll was it?', 'AI_ALLOWED_USER_CAN_OVERRIDE', TRUE, 90, '{"travel_cost":"bridge_toll"}'),
+  (UUID(), '2026-05-19.v1', 'gift_recipient', 'Who was the gift for?', 'USER_REQUIRED', TRUE, 100, '{"root":"gift"}'),
+  (UUID(), '2026-05-19.v1', 'software_supplier_country', 'Where is the software supplier invoicing from?', 'AI_ALLOWED_USER_CAN_OVERRIDE', TRUE, 110, '{"root":"software"}'),
+  (UUID(), '2026-05-19.v1', 'hardware_under_threshold', 'Is the hardware under 36,000 kr?', 'AI_ALLOWED_USER_CAN_OVERRIDE', TRUE, 120, '{"root":"hardware"}'),
+  (UUID(), '2026-05-19.v1', 'hardware_private_use', 'Can it also be used privately?', 'USER_REQUIRED', TRUE, 130, '{"hardware_under_threshold":"yes"}'),
+  (UUID(), '2026-05-19.v1', 'course_supplier_country', 'Where is the course supplier invoicing from?', 'AI_ALLOWED_USER_CAN_OVERRIDE', TRUE, 140, '{"root":"course_training"}');
+
+INSERT INTO expense_classification_option (uuid, tree_version, node_key, answer_key, label, sort_order) VALUES
+  (UUID(), '2026-05-19.v1', 'root', 'food_catering', 'Food / catering', 10),
+  (UUID(), '2026-05-19.v1', 'root', 'transport_travel', 'Transport / travel', 20),
+  (UUID(), '2026-05-19.v1', 'root', 'gift', 'Gift', 30),
+  (UUID(), '2026-05-19.v1', 'root', 'software', 'Software', 40),
+  (UUID(), '2026-05-19.v1', 'root', 'hardware', 'Hardware', 50),
+  (UUID(), '2026-05-19.v1', 'root', 'office_supplies', 'Office supplies', 60),
+  (UUID(), '2026-05-19.v1', 'root', 'internet', 'Internet', 70),
+  (UUID(), '2026-05-19.v1', 'root', 'course_training', 'Course / training', 80),
+  (UUID(), '2026-05-19.v1', 'root', 'other_unsure', 'Other / not sure', 90),
+  (UUID(), '2026-05-19.v1', 'food_situation', 'no_customer', 'No customer purpose', 10),
+  (UUID(), '2026-05-19.v1', 'food_situation', 'customer_site_lunch', 'Lunch while working at customer', 20),
+  (UUID(), '2026-05-19.v1', 'food_situation', 'with_customer', 'With customer', 30),
+  (UUID(), '2026-05-19.v1', 'food_situation', 'trustworks_event', 'Trustworks event', 40),
+  (UUID(), '2026-05-19.v1', 'food_situation', 'overtime_meal', 'Overtime meal', 50),
+  (UUID(), '2026-05-19.v1', 'meal_purpose', 'customer_care', 'Customer care', 10),
+  (UUID(), '2026-05-19.v1', 'meal_purpose', 'normal_lunch_break', 'Normal lunch break', 20),
+  (UUID(), '2026-05-19.v1', 'tw_event_type', 'professional', 'Professional arrangement', 10),
+  (UUID(), '2026-05-19.v1', 'tw_event_type', 'social', 'Social arrangement', 20),
+  (UUID(), '2026-05-19.v1', 'tw_event_location', 'trustworks_premises', 'Trustworks premises', 10),
+  (UUID(), '2026-05-19.v1', 'tw_event_location', 'external_location', 'External restaurant or location', 20),
+  (UUID(), '2026-05-19.v1', 'overtime_location', 'office', 'At the office', 10),
+  (UUID(), '2026-05-19.v1', 'overtime_location', 'city', 'Out in the city', 20),
+  (UUID(), '2026-05-19.v1', 'travel_cost', 'general_transport', 'Taxi, train, bus, flight or ferry', 10),
+  (UUID(), '2026-05-19.v1', 'travel_cost', 'hotel', 'Hotel', 20),
+  (UUID(), '2026-05-19.v1', 'travel_cost', 'bridge_toll', 'Bridge toll', 30),
+  (UUID(), '2026-05-19.v1', 'travel_cost', 'parking', 'Parking', 40),
+  (UUID(), '2026-05-19.v1', 'travel_cost', 'car_rental_short', 'Car rental under 6 months', 50),
+  (UUID(), '2026-05-19.v1', 'hotel_country', 'dk', 'Denmark', 10),
+  (UUID(), '2026-05-19.v1', 'hotel_country', 'abroad', 'Abroad', 20),
+  (UUID(), '2026-05-19.v1', 'bridge_kind', 'sweden_oresund', 'Sweden / Oresund', 10),
+  (UUID(), '2026-05-19.v1', 'bridge_kind', 'dk_storebaelt', 'Denmark / Storebaelt', 20),
+  (UUID(), '2026-05-19.v1', 'gift_recipient', 'client', 'Client', 10),
+  (UUID(), '2026-05-19.v1', 'gift_recipient', 'colleague', 'Colleague', 20),
+  (UUID(), '2026-05-19.v1', 'software_supplier_country', 'dk', 'Denmark', 10),
+  (UUID(), '2026-05-19.v1', 'software_supplier_country', 'eu', 'EU', 20),
+  (UUID(), '2026-05-19.v1', 'software_supplier_country', 'outside_eu', 'Outside EU', 30),
+  (UUID(), '2026-05-19.v1', 'hardware_under_threshold', 'yes', 'Yes', 10),
+  (UUID(), '2026-05-19.v1', 'hardware_under_threshold', 'no', 'No / not sure', 20),
+  (UUID(), '2026-05-19.v1', 'hardware_private_use', 'possible', 'Yes, private use is possible', 10),
+  (UUID(), '2026-05-19.v1', 'hardware_private_use', 'work_only', 'No, only work use', 20),
+  (UUID(), '2026-05-19.v1', 'course_supplier_country', 'dk', 'Denmark', 10),
+  (UUID(), '2026-05-19.v1', 'course_supplier_country', 'eu', 'EU', 20),
+  (UUID(), '2026-05-19.v1', 'course_supplier_country', 'outside_eu', 'Outside EU', 30);
+
+INSERT INTO expense_account_mapping (uuid, account_key, companyuuid, account_number, account_name, active) VALUES
+  (UUID(), 'internal_food', NULL, '3585', 'Internal food', TRUE),
+  (UUID(), 'customer_meal_care', NULL, '4006', 'Customer care meal', TRUE),
+  (UUID(), 'tw_professional_event_internal', NULL, '4009', 'Professional event internal', TRUE),
+  (UUID(), 'tw_social_event', NULL, '3589', 'Social event', TRUE),
+  (UUID(), 'overtime_meal_external', NULL, '3591', 'Overtime meal external', TRUE),
+  (UUID(), 'general_travel_transport', NULL, '4050', 'Travel transport', TRUE),
+  (UUID(), 'hotel_dk', NULL, '4031', 'Hotel Denmark', TRUE),
+  (UUID(), 'hotel_abroad', NULL, '4030', 'Hotel abroad', TRUE),
+  (UUID(), 'bridge_sweden_oresund', NULL, '4061', 'Oresund bridge', TRUE),
+  (UUID(), 'bridge_dk_storebaelt', NULL, '4066', 'Storebaelt bridge', TRUE),
+  (UUID(), 'parking', NULL, '4055', 'Parking', TRUE),
+  (UUID(), 'client_gift', NULL, '4008', 'Client gift', TRUE),
+  (UUID(), 'colleague_gift', NULL, '3585', 'Colleague gift', TRUE),
+  (UUID(), 'software_dk', NULL, '5214', 'Software Denmark', TRUE),
+  (UUID(), 'software_eu', NULL, '5216', 'Software EU', TRUE),
+  (UUID(), 'software_outside_eu', NULL, '5217', 'Software outside EU', TRUE),
+  (UUID(), 'hardware_private_use', NULL, '5219', 'Hardware private use', TRUE),
+  (UUID(), 'hardware_work_only', NULL, '5218', 'Hardware work only', TRUE),
+  (UUID(), 'office_supplies', NULL, '5233', 'Office supplies', TRUE),
+  (UUID(), 'internet', NULL, '5242', 'Internet', TRUE),
+  (UUID(), 'course_dk', NULL, '3560', 'Course Denmark', TRUE),
+  (UUID(), 'course_eu', NULL, '3561', 'Course EU', TRUE),
+  (UUID(), 'course_outside_eu', NULL, '3562', 'Course outside EU', TRUE),
+  (UUID(), 'finance_review_fallback', NULL, '9998', 'Finance review', TRUE);
+
+INSERT INTO expense_classification_result (uuid, tree_version, result_key, employee_label, employee_summary, account_key, tax_treatment, requires_finance_review, conditions_json, sort_order) VALUES
+  (UUID(), '2026-05-19.v1', 'INTERNAL_FOOD_NO_CUSTOMER', 'Food without customer purpose', 'This will be handled as internal food.', 'internal_food', 'U', FALSE, '{"root":"food_catering","food_situation":"no_customer"}', 10),
+  (UUID(), '2026-05-19.v1', 'CUSTOMER_SITE_LUNCH', 'Lunch while working at customer', 'This will be handled as customer-site lunch.', 'internal_food', 'U', FALSE, '{"root":"food_catering","food_situation":"customer_site_lunch"}', 20),
+  (UUID(), '2026-05-19.v1', 'CUSTOMER_MEAL_CARE', 'Customer care meal', 'This will be handled as customer care.', 'customer_meal_care', '25M', FALSE, '{"root":"food_catering","food_situation":"with_customer","meal_purpose":"customer_care"}', 30),
+  (UUID(), '2026-05-19.v1', 'NORMAL_CUSTOMER_LUNCH_BREAK', 'Normal lunch break at customer', 'This will be handled as an ordinary lunch break.', 'internal_food', 'U', FALSE, '{"root":"food_catering","food_situation":"with_customer","meal_purpose":"normal_lunch_break"}', 40),
+  (UUID(), '2026-05-19.v1', 'TW_PROFESSIONAL_EVENT_INTERNAL', 'Professional Trustworks event at Trustworks', 'This will be handled as a professional internal event.', 'tw_professional_event_internal', 'FM', FALSE, '{"root":"food_catering","food_situation":"trustworks_event","tw_event_type":"professional","tw_event_location":"trustworks_premises"}', 50),
+  (UUID(), '2026-05-19.v1', 'TW_SOCIAL_EVENT_INTERNAL', 'Social Trustworks event at Trustworks', 'This will be handled as a social internal event.', 'tw_social_event', 'U', FALSE, '{"root":"food_catering","food_situation":"trustworks_event","tw_event_type":"social","tw_event_location":"trustworks_premises"}', 60),
+  (UUID(), '2026-05-19.v1', 'TW_PROFESSIONAL_EVENT_EXTERNAL', 'Professional Trustworks event at external location', 'Finance will review this route before upload.', 'finance_review_fallback', 'TBD', TRUE, '{"root":"food_catering","food_situation":"trustworks_event","tw_event_type":"professional","tw_event_location":"external_location"}', 70),
+  (UUID(), '2026-05-19.v1', 'TW_SOCIAL_EVENT_EXTERNAL', 'Social Trustworks event at external location', 'This will be handled as a social event.', 'tw_social_event', 'U', FALSE, '{"root":"food_catering","food_situation":"trustworks_event","tw_event_type":"social","tw_event_location":"external_location"}', 80),
+  (UUID(), '2026-05-19.v1', 'OVERTIME_MEAL_OFFICE', 'Overtime meal at the office', 'Finance will review this route before upload.', 'finance_review_fallback', 'FM', TRUE, '{"root":"food_catering","food_situation":"overtime_meal","overtime_location":"office"}', 90),
+  (UUID(), '2026-05-19.v1', 'OVERTIME_MEAL_EXTERNAL', 'Overtime meal out in the city', 'This will be handled as an external overtime meal.', 'overtime_meal_external', '25% moms', FALSE, '{"root":"food_catering","food_situation":"overtime_meal","overtime_location":"city"}', 100),
+  (UUID(), '2026-05-19.v1', 'GENERAL_TRAVEL_TRANSPORT', 'Travel transport', 'This will be handled as travel transport.', 'general_travel_transport', 'U', FALSE, '{"root":"transport_travel","travel_cost":"general_transport"}', 110),
+  (UUID(), '2026-05-19.v1', 'HOTEL_DK', 'Hotel stay in Denmark', 'This will be handled as hotel in Denmark.', 'hotel_dk', 'FM', FALSE, '{"root":"transport_travel","travel_cost":"hotel","hotel_country":"dk"}', 120),
+  (UUID(), '2026-05-19.v1', 'HOTEL_ABROAD', 'Hotel stay abroad', 'This will be handled as hotel abroad.', 'hotel_abroad', 'U', FALSE, '{"root":"transport_travel","travel_cost":"hotel","hotel_country":"abroad"}', 130),
+  (UUID(), '2026-05-19.v1', 'BRIDGE_SWEDEN_ORESUND', 'Oresund bridge toll', 'This will be handled as an Oresund bridge toll.', 'bridge_sweden_oresund', 'FM', FALSE, '{"root":"transport_travel","travel_cost":"bridge_toll","bridge_kind":"sweden_oresund"}', 140),
+  (UUID(), '2026-05-19.v1', 'BRIDGE_DK_STOREBAELT', 'Storebaelt bridge toll', 'This will be handled as a Storebaelt bridge toll.', 'bridge_dk_storebaelt', 'U', FALSE, '{"root":"transport_travel","travel_cost":"bridge_toll","bridge_kind":"dk_storebaelt"}', 150),
+  (UUID(), '2026-05-19.v1', 'PARKING', 'Parking', 'This will be handled as parking.', 'parking', NULL, FALSE, '{"root":"transport_travel","travel_cost":"parking"}', 160),
+  (UUID(), '2026-05-19.v1', 'CAR_RENTAL_SHORT_TERM', 'Car rental under 6 months', 'This will be handled as travel transport.', 'general_travel_transport', 'U', FALSE, '{"root":"transport_travel","travel_cost":"car_rental_short"}', 170),
+  (UUID(), '2026-05-19.v1', 'CLIENT_GIFT', 'Gift for a client', 'Your answers are saved for Finance. The Finance route is selected in the background.', 'client_gift', 'U', FALSE, '{"root":"gift","gift_recipient":"client"}', 180),
+  (UUID(), '2026-05-19.v1', 'COLLEAGUE_GIFT', 'Gift for a colleague', 'This will be handled as a colleague gift.', 'colleague_gift', 'U', FALSE, '{"root":"gift","gift_recipient":"colleague"}', 190),
+  (UUID(), '2026-05-19.v1', 'SOFTWARE_DK', 'Software from Denmark', 'This will be handled as Danish software.', 'software_dk', 'FM', FALSE, '{"root":"software","software_supplier_country":"dk"}', 200),
+  (UUID(), '2026-05-19.v1', 'SOFTWARE_EU', 'Software from the EU', 'This will be handled as EU software.', 'software_eu', 'U(EU)', FALSE, '{"root":"software","software_supplier_country":"eu"}', 210),
+  (UUID(), '2026-05-19.v1', 'SOFTWARE_OUTSIDE_EU', 'Software from outside the EU', 'This will be handled as software from outside the EU.', 'software_outside_eu', 'U(EU)', FALSE, '{"root":"software","software_supplier_country":"outside_eu"}', 220),
+  (UUID(), '2026-05-19.v1', 'HARDWARE_PRIVATE_USE', 'Hardware that can also be used privately', 'This will be handled as hardware with possible private use.', 'hardware_private_use', 'HM', FALSE, '{"root":"hardware","hardware_under_threshold":"yes","hardware_private_use":"possible"}', 230),
+  (UUID(), '2026-05-19.v1', 'HARDWARE_WORK_ONLY', 'Hardware for work only', 'This will be handled as work-only hardware.', 'hardware_work_only', 'FM', FALSE, '{"root":"hardware","hardware_under_threshold":"yes","hardware_private_use":"work_only"}', 240),
+  (UUID(), '2026-05-19.v1', 'HARDWARE_FINANCE_REVIEW', 'Hardware requiring Finance review', 'Finance will review this route before upload.', 'finance_review_fallback', 'TBD', TRUE, '{"root":"hardware","hardware_under_threshold":"no"}', 250),
+  (UUID(), '2026-05-19.v1', 'OFFICE_SUPPLIES', 'Office supplies', 'This will be handled as office supplies.', 'office_supplies', 'FM', FALSE, '{"root":"office_supplies"}', 260),
+  (UUID(), '2026-05-19.v1', 'INTERNET', 'Internet', 'This will be handled as internet.', 'internet', 'HM', FALSE, '{"root":"internet"}', 270),
+  (UUID(), '2026-05-19.v1', 'COURSE_DK', 'Course from Denmark', 'This will be handled as a Danish course supplier.', 'course_dk', 'FM', FALSE, '{"root":"course_training","course_supplier_country":"dk"}', 280),
+  (UUID(), '2026-05-19.v1', 'COURSE_EU', 'Course from the EU', 'This will be handled as an EU course supplier.', 'course_eu', 'U(EU)', FALSE, '{"root":"course_training","course_supplier_country":"eu"}', 290),
+  (UUID(), '2026-05-19.v1', 'COURSE_OUTSIDE_EU', 'Course from outside the EU', 'This will be handled as a course supplier outside the EU.', 'course_outside_eu', 'U(EU)', FALSE, '{"root":"course_training","course_supplier_country":"outside_eu"}', 300),
+  (UUID(), '2026-05-19.v1', 'OTHER_OR_UNCLEAR', 'Other / not sure', 'Finance will review this route before upload.', 'finance_review_fallback', NULL, TRUE, '{"root":"other_unsure"}', 310);

--- a/src/test/java/dk/trustworks/intranet/expenseservice/events/ExpenseCreatedConsumerRoutingTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/events/ExpenseCreatedConsumerRoutingTest.java
@@ -1,6 +1,7 @@
 package dk.trustworks.intranet.expenseservice.events;
 
 import dk.trustworks.intranet.expenseservice.model.Expense;
+import dk.trustworks.intranet.expenseservice.model.ExpenseClassification;
 import dk.trustworks.intranet.expenseservice.model.ExpenseDecisionLog;
 import dk.trustworks.intranet.expenseservice.services.ExpenseAIValidationService;
 import dk.trustworks.intranet.expenseservice.services.ExpenseFileService;
@@ -65,5 +66,50 @@ class ExpenseCreatedConsumerRoutingTest {
         long logCount = QuarkusTransaction.requiringNew().call(() ->
                 ExpenseDecisionLog.count("expenseUuid", e.getUuid()));
         assertEquals(1, logCount);
+    }
+
+    @Test
+    void aiApprovalWithFinanceFallbackClassification_setsPendingHr() {
+        Expense e = new Expense();
+        e.setUuid(java.util.UUID.randomUUID().toString());
+        e.setUseruuid("u");
+        e.setAmount(1200.0);
+        e.setAccount("9998");
+        e.setAccountname("Finance review");
+        e.setExpensedate(java.time.LocalDate.now());
+        e.setDatecreated(java.time.LocalDate.now());
+        e.setStatus("CREATED");
+        QuarkusTransaction.requiringNew().run(() -> {
+            e.persist();
+            ExpenseClassification classification = new ExpenseClassification();
+            classification.uuid = java.util.UUID.randomUUID().toString();
+            classification.expenseUuid = e.getUuid();
+            classification.useruuid = "u";
+            classification.treeVersion = "2026-05-19.v1";
+            classification.aiUsed = false;
+            classification.aiIgnored = false;
+            classification.decisionResultKey = "HARDWARE_FINANCE_REVIEW";
+            classification.accountKey = "finance_review_fallback";
+            classification.accountNumber = "9998";
+            classification.accountName = "Finance review";
+            classification.requiresFinanceReview = true;
+            classification.answersJson = "[]";
+            classification.ignoredAiAnswersJson = "[]";
+            classification.createdAt = java.time.LocalDateTime.now();
+            classification.persist();
+        });
+
+        when(fileSvc.getFileById(any())).thenReturn(null);
+        when(aiSvc.extractExpenseData(any())).thenReturn("placeholder text");
+        when(aiSvc.validateWithExtractedText(any(), any(), any(), any(), any(), any()))
+                .thenReturn(new ExpenseAIValidationService.AIResult(true, "ok", java.util.List.of()));
+
+        consumer.onExpenseCreated(e.getUuid());
+
+        Expense refreshed = QuarkusTransaction.requiringNew()
+                .call(() -> Expense.findById(e.getUuid()));
+        assertEquals("CREATED", refreshed.getStatus());
+        assertEquals("PENDING_HR", refreshed.getReviewState());
+        assertEquals(Boolean.TRUE, refreshed.getAiValidationApproved());
     }
 }

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/ExpenseClassificationServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/ExpenseClassificationServiceTest.java
@@ -1,0 +1,129 @@
+package dk.trustworks.intranet.expenseservice.services;
+
+import dk.trustworks.intranet.expenseservice.dto.ExpenseClassificationDTOs;
+import dk.trustworks.intranet.expenseservice.model.Expense;
+import dk.trustworks.intranet.expenseservice.model.ExpenseClassification;
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class ExpenseClassificationServiceTest {
+
+    @Inject ExpenseClassificationService service;
+
+    @Test
+    void resolvesGiftForClientToHiddenAccountMapping() {
+        ExpenseClassificationDTOs.ResolveResponse response = service.resolve(
+                "missing-user",
+                new ExpenseClassificationDTOs.ResolveRequest(
+                        "2026-05-19.v1",
+                        null,
+                        true,
+                        false,
+                        List.of(
+                                new ExpenseClassificationDTOs.Answer("root", "gift", "AI", 0.91, "flower shop", true),
+                                new ExpenseClassificationDTOs.Answer("gift_recipient", "client", "USER", null, null, true)
+                        ),
+                        List.of()
+                )
+        );
+
+        assertEquals("RESOLVED", response.state());
+        assertNotNull(response.result());
+        assertEquals("CLIENT_GIFT", response.result().resultKey());
+        assertEquals("client_gift", response.result().accountKey());
+        assertEquals("4008", response.result().accountNumber());
+        assertFalse(response.result().requiresFinanceReview());
+    }
+
+    @Test
+    void routesTbdHardwareBranchToFinanceFallback() {
+        ExpenseClassificationDTOs.ResolveResponse response = service.resolve(
+                "missing-user",
+                new ExpenseClassificationDTOs.ResolveRequest(
+                        "2026-05-19.v1",
+                        null,
+                        false,
+                        false,
+                        List.of(
+                                new ExpenseClassificationDTOs.Answer("root", "hardware", "USER", null, null, true),
+                                new ExpenseClassificationDTOs.Answer("hardware_under_threshold", "no", "USER", null, null, true)
+                        ),
+                        List.of()
+                )
+        );
+
+        assertEquals("RESOLVED", response.state());
+        assertEquals("HARDWARE_FINANCE_REVIEW", response.result().resultKey());
+        assertEquals("finance_review_fallback", response.result().accountKey());
+        assertEquals("9998", response.result().accountNumber());
+        assertTrue(response.result().requiresFinanceReview());
+    }
+
+    @Test
+    void discardsInvalidAnswersBeforeResolving() {
+        ExpenseClassificationDTOs.ResolveResponse response = service.resolve(
+                "missing-user",
+                new ExpenseClassificationDTOs.ResolveRequest(
+                        "2026-05-19.v1",
+                        null,
+                        true,
+                        false,
+                        List.of(new ExpenseClassificationDTOs.Answer("root", "made_up", "AI", 0.99, "bad", true)),
+                        List.of()
+                )
+        );
+
+        assertEquals("NEEDS_ANSWERS", response.state());
+        assertTrue(response.acceptedAnswers().isEmpty());
+        assertEquals("root", response.unansweredNodes().getFirst().nodeKey());
+    }
+
+    @Test
+    @TestTransaction
+    void persistsAuditMetadataForSubmittedClassification() {
+        Expense expense = new Expense();
+        expense.setUuid(UUID.randomUUID().toString());
+        expense.setUseruuid("missing-user");
+        expense.setAmount(450.0);
+        expense.setAccount("placeholder");
+        expense.setAccountname("placeholder");
+        expense.setDescription("Gift");
+        expense.setExpensedate(LocalDate.now());
+        expense.setDatecreated(LocalDate.now());
+        expense.setStatus("CREATED");
+        expense.setClassification(new ExpenseClassificationDTOs.Submission(
+                "2026-05-19.v1",
+                "CLIENT_GIFT",
+                "client_gift",
+                "analysis-1",
+                true,
+                false,
+                false,
+                List.of(
+                        new ExpenseClassificationDTOs.Answer("root", "gift", "AI", 0.91, "flower shop", true),
+                        new ExpenseClassificationDTOs.Answer("gift_recipient", "client", "USER", null, null, true)
+                ),
+                List.of()
+        ));
+
+        service.applyResolvedAccount(expense);
+        expense.persist();
+        service.persistSubmittedClassification(expense);
+
+        ExpenseClassification row = ExpenseClassification.find("expenseUuid", expense.getUuid()).firstResult();
+        assertNotNull(row);
+        assertEquals("CLIENT_GIFT", row.decisionResultKey);
+        assertEquals("4008", row.accountNumber);
+        assertTrue(row.aiUsed);
+        assertFalse(row.requiresFinanceReview);
+    }
+}


### PR DESCRIPTION
## Summary

Implements backend support for the receipt-first expense classification flow.

- Adds migration `V353` with the versioned `2026-05-19.v1` decision tree, nodes/options/results, account mappings, receipt analyses, and persisted classifications.
- Adds classification DTOs, model entities, resolver/analyzer service, and `/expenses/classification/*` endpoints.
- Extends expense create/update handling to accept classification metadata while preserving legacy account payloads.
- Persists audit metadata for AI-filled answers, employee answers, ignored AI answers, final decision result, resolved account mapping, and Finance-review fallback state.
- Routes AI-approved Finance-review fallback expenses to `PENDING_HR`; existing AI rejection routing remains authoritative.

## Impact

Employees can submit expenses without seeing account numbers while the backend deterministically resolves account/accountname for the existing expense pipeline. Unknown/TBD paths resolve through fallback account `9998` with `requiresFinanceReview=true`.

## Validation

- `cd intranetservices && ./mvnw -DskipTests compile`
- Attempted `cd intranetservices && ./mvnw -Dtest='*ExpenseClassification*,ExpenseCreatedConsumerRoutingTest' test`; local test boot is blocked because MariaDB on `127.0.0.1` is not running, so Flyway cannot connect.

## Companion

Frontend companion PR will be opened separately in `trustworksdk/trustworks-intranet-v3`.