### PR TITLE
feat(cxo-finance): honor costSource param across cost endpoints

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CxoFinanceResource.java
@@ -1314,10 +1314,11 @@ public class CxoFinanceResource {
             @QueryParam("serviceLines") String serviceLines,
             @QueryParam("contractTypes") String contractTypes,
             @QueryParam("clientId") String clientId,
-            @QueryParam("companyIds") String companyIds) {
+            @QueryParam("companyIds") String companyIds,
+            @QueryParam("costSource") String costSourceParam) {
 
-        log.debugf("GET /finance/cxo/expected-accumulated-ebitda/source-data: asOfDate=%s, sectors=%s, serviceLines=%s, contractTypes=%s, clientId=%s, companyIds=%s",
-                asOfDateStr, sectors, serviceLines, contractTypes, clientId, companyIds);
+        log.debugf("GET /finance/cxo/expected-accumulated-ebitda/source-data: asOfDate=%s, sectors=%s, serviceLines=%s, contractTypes=%s, clientId=%s, companyIds=%s, costSource=%s",
+                asOfDateStr, sectors, serviceLines, contractTypes, clientId, companyIds, costSourceParam);
 
         LocalDate asOfDate = (asOfDateStr != null && !asOfDateStr.trim().isEmpty())
                 ? LocalDate.parse(asOfDateStr)
@@ -1329,7 +1330,8 @@ public class CxoFinanceResource {
         Set<String> companyIdSet    = parseCommaSeparated(companyIds);
 
         EbitdaSourceDataDTO result = cxoFinanceService.getEbitdaSourceData(
-                asOfDate, sectorSet, serviceLineSet, contractTypeSet, clientId, companyIdSet);
+                asOfDate, sectorSet, serviceLineSet, contractTypeSet, clientId, companyIdSet,
+                CostSource.fromQueryParam(costSourceParam));
 
         log.debugf("Returning EBITDA source data: %d invoices, %d creditNotes, %d directCosts, %d internalInvoices, %d opexEntries",
                 result.getInvoices().size(), result.getCreditNotes().size(),
@@ -1799,9 +1801,13 @@ public class CxoFinanceResource {
      */
     @GET
     @Path("/cost-to-revenue")
-    public List<CostToRevenueDataPointDTO> costToRevenue(@QueryParam("companyIds") String companyIds) {
-        log.debugf("GET /finance/cxo/cost-to-revenue: companyIds=%s", companyIds);
-        return cxoFinanceService.costToRevenue(parseCommaSeparated(companyIds));
+    public List<CostToRevenueDataPointDTO> costToRevenue(
+            @QueryParam("companyIds") String companyIds,
+            @QueryParam("costSource") String costSourceParam) {
+        log.debugf("GET /finance/cxo/cost-to-revenue: companyIds=%s, costSource=%s", companyIds, costSourceParam);
+        return cxoFinanceService.costToRevenue(
+                parseCommaSeparated(companyIds),
+                CostSource.fromQueryParam(costSourceParam));
     }
 
     /**

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/services/CxoFinanceService.java
@@ -4752,6 +4752,17 @@ public class CxoFinanceService {
             Set<String> contractTypes,
             String clientId,
             Set<String> companyIds) {
+        return getEbitdaSourceData(asOfDate, sectors, serviceLines, contractTypes, clientId, companyIds, CostSource.BOOKED);
+    }
+
+    public EbitdaSourceDataDTO getEbitdaSourceData(
+            LocalDate asOfDate,
+            Set<String> sectors,
+            Set<String> serviceLines,
+            Set<String> contractTypes,
+            String clientId,
+            Set<String> companyIds,
+            CostSource costSource) {
 
         LocalDate today = (asOfDate != null) ? asOfDate : LocalDate.now();
 
@@ -4780,10 +4791,10 @@ public class CxoFinanceService {
                 fyFromKey, fyToKey, sectors, serviceLines, contractTypes, clientId, companyIds);
 
         // 3) Internal invoices: QUEUED from invoices table + CREATED_GL from finance_details
-        List<InternalInvoiceRowDTO> internalInvoices = queryInternalInvoices(fyStart, fyEnd, fyFromKey, fyToKey, companyIds);
+        List<InternalInvoiceRowDTO> internalInvoices = queryInternalInvoices(fyStart, fyEnd, fyFromKey, fyToKey, companyIds, costSource);
 
         // 4) OPEX: raw finance_details GL entries, excluding non-OPEX categories
-        List<OpexRowExportDTO> opexEntries = queryOpexEntries(fyStart, fyEnd, companyIds);
+        List<OpexRowExportDTO> opexEntries = queryOpexEntries(fyStart, fyEnd, companyIds, costSource);
 
         log.debugf("getEbitdaSourceData: %d invoices, %d creditNotes, %d directCosts, %d internalInvoices, %d opexEntries",
                 invoices.size(), creditNotes.size(), directCosts.size(), internalInvoices.size(), opexEntries.size());
@@ -5000,7 +5011,8 @@ public class CxoFinanceService {
     private List<InternalInvoiceRowDTO> queryInternalInvoices(
             LocalDate fyStart, LocalDate fyEnd,
             String fyFromKey, String fyToKey,
-            Set<String> companyIds) {
+            Set<String> companyIds,
+            CostSource costSource) {
 
         List<InternalInvoiceRowDTO> result = new ArrayList<>();
 
@@ -5078,7 +5090,7 @@ public class CxoFinanceService {
                 "FROM finance_details fd " +
                 "WHERE fd.expensedate BETWEEN :fyStart AND :fyEnd " +
                 "  AND fd.amount != 0 " +
-                "  AND fd.postingstatus = 'BOOKED' " +
+                "  AND fd.postingstatus IN (:postingStatuses) " +
                 "  AND fd.accountnumber IN (3050, 3055, 3070, 3075, 1350) "
         );
         if (companyIds != null && !companyIds.isEmpty()) {
@@ -5089,6 +5101,7 @@ public class CxoFinanceService {
         Query glQuery = em.createNativeQuery(glSql.toString(), Tuple.class);
         glQuery.setParameter("fyStart", fyStart);
         glQuery.setParameter("fyEnd", fyEnd);
+        glQuery.setParameter("postingStatuses", (costSource == null ? CostSource.BOOKED : costSource).postingStatusNames());
         if (companyIds != null && !companyIds.isEmpty()) {
             glQuery.setParameter("companyIds", companyIds);
         }
@@ -5123,7 +5136,8 @@ public class CxoFinanceService {
      */
     private List<OpexRowExportDTO> queryOpexEntries(
             LocalDate fyStart, LocalDate fyEnd,
-            Set<String> companyIds) {
+            Set<String> companyIds,
+            CostSource costSource) {
 
         StringBuilder sql = new StringBuilder(
                 "SELECT " +
@@ -5146,7 +5160,7 @@ public class CxoFinanceService {
                 "    LEFT JOIN companies comp ON comp.uuid = fd.companyuuid " +
                 "WHERE fd.expensedate BETWEEN :fyStart AND :fyEnd " +
                 "  AND fd.amount != 0 " +
-                "  AND fd.postingstatus = 'BOOKED' " +
+                "  AND fd.postingstatus IN (:postingStatuses) " +
                 "  AND (aa.account_code >= '3000' AND aa.account_code < '6000') " +
                 "  AND ac.groupname NOT IN ('Varesalg', 'Direkte omkostninger', 'Igangvaerende arbejde') "
         );
@@ -5158,6 +5172,7 @@ public class CxoFinanceService {
         Query query = em.createNativeQuery(sql.toString(), Tuple.class);
         query.setParameter("fyStart", fyStart);
         query.setParameter("fyEnd", fyEnd);
+        query.setParameter("postingStatuses", (costSource == null ? CostSource.BOOKED : costSource).postingStatusNames());
         if (companyIds != null && !companyIds.isEmpty()) {
             query.setParameter("companyIds", companyIds);
         }
@@ -6237,6 +6252,10 @@ public class CxoFinanceService {
      * @return monthly data points ordered by month_key ascending (may be empty)
      */
     public List<CostToRevenueDataPointDTO> costToRevenue(Set<String> companyIds) {
+        return costToRevenue(companyIds, CostSource.BOOKED);
+    }
+
+    public List<CostToRevenueDataPointDTO> costToRevenue(Set<String> companyIds, CostSource costSource) {
         LocalDate today = LocalDate.now();
         LocalDate fromDate = today.withDayOfMonth(1).minusMonths(17);
         int fromYear = fromDate.getYear();
@@ -6279,7 +6298,7 @@ public class CxoFinanceService {
                 "  SELECT month_key, company_id, SUM(opex_amount_dkk) AS opex_cost " +
                 "  FROM fact_opex_mat " +
                 "  WHERE cost_type = 'OPEX' " +
-                "    AND posting_status = 'BOOKED' " +
+                "    AND posting_status IN (:postingStatuses) " +
                 "    AND month_key BETWEEN :fromMonthKey AND :toMonthKey" +
                 companyFilterOpex + " " +
                 "  GROUP BY month_key, company_id " +
@@ -6292,6 +6311,7 @@ public class CxoFinanceService {
         Query query = em.createNativeQuery(sql, Tuple.class);
         query.setParameter("fromMonthKey", fromMonthKey);
         query.setParameter("toMonthKey", toMonthKey);
+        query.setParameter("postingStatuses", (costSource == null ? CostSource.BOOKED : costSource).postingStatusNames());
         if (hasCompanyFilter) {
             query.setParameter("companyIds", companyIds);
         }


### PR DESCRIPTION
## Summary
- `/finance/cxo/cost-to-revenue` and `/finance/cxo/expected-accumulated-ebitda/source-data` now accept `?costSource=BOOKED|BOOKED_PLUS_DRAFT`
- 3 hardcoded `posting_status='BOOKED'` SQL filters replaced with parameter-bound `IN (:postingStatuses)`
- Existing service-layer signatures preserved as overloads defaulting to `CostSource.BOOKED` — every internal caller's behavior is unchanged

## Why
Both endpoints silently ignored the dashboard's global cost-source toggle. Charts on the same screen at the same toggle position could show inconsistent numbers. This closes that gap.

## Not in scope
`/gross-margin-trend` and `/revenue-margin-trend` read from `fact_project_financials_mat`, which has no `posting_status` column — a `costSource` parameter there would be meaningless until the materialization adds draft awareness. Deferred.

## Test plan
- [x] `./mvnw compile` succeeds
- [x] Production DB sanity check: rolling 18-month cost-to-revenue with BOOKED returns 47.68M OPEX (unchanged); with BOOKED_PLUS_DRAFT returns 51.38M (+3.7M from drafts)
- [ ] After deploy: hit the staging API with `?costSource=BOOKED_PLUS_DRAFT` and confirm numbers differ from BOOKED
- [ ] After deploy: hit the staging API without the parameter and confirm numbers match production (regression check)

## Rollback
Single-commit revert. No DB migrations.