### PR TITLE
fix(revenue-cost-forecast): add direct delivery cost so chart reconciles to EBITDA

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/analytics/RevenueCostForecastDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/dto/analytics/RevenueCostForecastDTO.java
@@ -4,16 +4,34 @@ package dk.trustworks.intranet.aggregates.finance.dto.analytics;
  * Revenue vs. cost data point for TTM actuals and forecast months.
  *
  * <p>For actual months (isForecast=false):
- * registeredRevenueDkk comes from fact_user_day,
- * invoiceRevenueDkk from fact_company_revenue_mat,
- * totalCostDkk from DistributionAwareOpexProvider (OPEX + SALARIES).
+ * <ul>
+ *   <li>{@code registeredRevenueDkk} from {@code fact_user_day}.</li>
+ *   <li>{@code invoiceRevenueDkk} from {@code fact_company_revenue_mat}.</li>
+ *   <li>{@code directDeliveryCostDkk} = signed GL DIRECT_COSTS from {@code finance_details}
+ *       (cost_type='DIRECT_COSTS' on {@code accounting_accounts}) + synthesized QUEUED
+ *       INTERNAL cost attributed to the debtor company. Same cost stack the EBITDA
+ *       chart's {@code monthlyDirectCostDkk} uses, so the two views reconcile.</li>
+ *   <li>{@code totalCostDkk} = OPEX + Salaries (from {@code DistributionAwareOpexProvider})
+ *       + {@code directDeliveryCostDkk}. Equals every cost component the EBITDA chart
+ *       subtracts; therefore {@code invoiceRevenueDkk − totalCostDkk ≈ accumulated EBITDA}.</li>
+ * </ul>
  *
  * <p>For forecast months (isForecast=true):
- * both revenue fields carry budget + weighted pipeline,
- * totalCostDkk is the TTM flat average monthly cost.
+ * <ul>
+ *   <li>Revenue fields carry forecast budget + weighted pipeline.</li>
+ *   <li>{@code directDeliveryCostDkk} = forecast revenue × (1 − TTM gross margin) — same
+ *       formula the EBITDA forecast uses, so accumulated trajectories align.</li>
+ *   <li>{@code totalCostDkk} = flat TTM monthly OPEX+Salaries average + forecast
+ *       {@code directDeliveryCostDkk}.</li>
+ * </ul>
  *
- * <p>avgCostDkk is the flat TTM average across all 12 completed months
- * (same value for every row — used as a reference line in charts).
+ * <p>{@code avgCostDkk} is the flat TTM average across the completed months — same value
+ * on every row, used only as a horizontal reference line in charts.
+ *
+ * @param directDeliveryCostDkk Component of {@code totalCostDkk}; populated on every row
+ *                              (zero is valid when no GL data exists for the month).
+ *                              The frontend tooltip splits Total Cost into OPEX+Salaries
+ *                              ({@code totalCostDkk − directDeliveryCostDkk}) and this field.
  */
 public record RevenueCostForecastDTO(
         String monthKey,
@@ -23,6 +41,7 @@ public record RevenueCostForecastDTO(
         double registeredRevenueDkk,
         double invoiceRevenueDkk,
         double totalCostDkk,
+        double directDeliveryCostDkk,
         Double avgCostDkk,
         boolean isForecast
 ) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CostAnalyticsResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CostAnalyticsResource.java
@@ -611,43 +611,93 @@ public class CostAnalyticsResource {
         @SuppressWarnings("unchecked") List<Tuple> regRows = regQuery.getResultList();
         @SuppressWarnings("unchecked") List<Tuple> invRows = invQuery.getResultList();
 
+        String ttmEndKey = toMonthKey(today.minusMonths(1));
+
         // Index by month_key
         Map<String, Tuple> regMap = indexByMonthKey(regRows);
         Map<String, Tuple> invMap = indexByMonthKey(invRows);
-        Map<String, Double> costMap = opexProvider
-                .getMonthlyOpex(ttmStartKey, toMonthKey(today.minusMonths(1)), companies, costSource);
+        Map<String, Double> opexSalaryMap = opexProvider
+                .getMonthlyOpex(ttmStartKey, ttmEndKey, companies, costSource);
+
+        // Q3a: GL DIRECT_COSTS by month (signed, costSource-aware)
+        String glDirectSql = buildMonthlyGlDirectCostSql(companies);
+        var glDirectQuery = em.createNativeQuery(glDirectSql, Tuple.class);
+        glDirectQuery.setParameter("fromKey", ttmStartKey);
+        glDirectQuery.setParameter("toKey", ttmEndKey);
+        glDirectQuery.setParameter("postingStatuses", costSource.postingStatusNames());
+        if (companies != null) glDirectQuery.setParameter("companyIds", companies);
+        @SuppressWarnings("unchecked") List<Tuple> glDirectRows = glDirectQuery.getResultList();
+        Map<String, Double> glDirectMap = new HashMap<>();
+        for (Tuple row : glDirectRows) {
+            glDirectMap.put((String) row.get("month_key"), numericValue(row, "gl_direct_cost"));
+        }
+
+        // Q3b: QUEUED INTERNAL synthesized cost by month (debtor-side, costSource-independent)
+        String queuedSql = buildMonthlyQueuedInternalCostSql(companies);
+        var queuedQuery = em.createNativeQuery(queuedSql, Tuple.class);
+        queuedQuery.setParameter("fromKey", ttmStartKey);
+        queuedQuery.setParameter("toKey", ttmEndKey);
+        if (companies != null) queuedQuery.setParameter("companyIds", companies);
+        @SuppressWarnings("unchecked") List<Tuple> queuedRows = queuedQuery.getResultList();
+        Map<String, Double> queuedMap = new HashMap<>();
+        for (Tuple row : queuedRows) {
+            queuedMap.put((String) row.get("month_key"), numericValue(row, "queued_cost"));
+        }
 
         // Collect all month keys
         Set<String> allKeys = new TreeSet<>();
         allKeys.addAll(regMap.keySet());
         allKeys.addAll(invMap.keySet());
-        allKeys.addAll(costMap.keySet());
+        allKeys.addAll(opexSalaryMap.keySet());
+        allKeys.addAll(glDirectMap.keySet());
+        allKeys.addAll(queuedMap.keySet());
 
         // Build actual months
         List<RevenueCostForecastDTO> result = new ArrayList<>();
         double totalCostSum = 0;
+        double totalOpexSalarySum = 0;
+        double totalInvoiceRevenueSum = 0;
+        double totalDirectCostSum = 0;
 
         for (String key : allKeys) {
             int year = resolveYear(key, regMap.get(key), invMap.get(key));
             int month = resolveMonth(key, regMap.get(key), invMap.get(key));
             double regRev = numericValue(regMap.get(key), "registered_revenue");
             double invRev = numericValue(invMap.get(key), "net_revenue");
-            double cost = costMap.getOrDefault(key, 0.0);
-            totalCostSum += Math.round(cost);
+            double opexSalary = opexSalaryMap.getOrDefault(key, 0.0);
+            double glDirect = glDirectMap.getOrDefault(key, 0.0);
+            double queued = queuedMap.getOrDefault(key, 0.0);
+            double directDelivery = glDirect + queued;
+            double totalCost = opexSalary + directDelivery;
+
+            totalCostSum += Math.round(totalCost);
+            totalOpexSalarySum += Math.round(opexSalary);
+            totalInvoiceRevenueSum += invRev;
+            totalDirectCostSum += directDelivery;
 
             result.add(new RevenueCostForecastDTO(
                     key, year, month,
                     SalaryAnalyticsProvider.formatMonthLabel(year, month),
-                    Math.round(regRev), Math.round(invRev), Math.round(cost),
+                    Math.round(regRev), Math.round(invRev),
+                    Math.round(totalCost), Math.round(directDelivery),
                     null, false));
         }
 
-        // Flat TTM average cost
+        // Flat TTM average total cost — kept on every row as horizontal reference line
         Double flatAvgCost = !result.isEmpty() ? Math.round(totalCostSum / result.size()) * 1.0 : null;
+        // TTM avg OPEX+Salary — used as the OPEX/Salary forecast component (the
+        // direct-delivery forecast component is derived from the gross-margin ratio).
+        double flatAvgOpexSalary = !result.isEmpty() ? totalOpexSalarySum / result.size() : 0;
+        // TTM gross margin = (revenue - direct cost) / revenue. Same formula the EBITDA
+        // chart uses for forecast direct delivery cost projection.
+        double ttmGrossMargin = totalInvoiceRevenueSum > 0
+                ? (totalInvoiceRevenueSum - totalDirectCostSum) / totalInvoiceRevenueSum
+                : 0;
+
         List<RevenueCostForecastDTO> withAvg = result.stream()
                 .map(r -> new RevenueCostForecastDTO(r.monthKey(), r.year(), r.monthNumber(),
                         r.monthLabel(), r.registeredRevenueDkk(), r.invoiceRevenueDkk(),
-                        r.totalCostDkk(), flatAvgCost, false))
+                        r.totalCostDkk(), r.directDeliveryCostDkk(), flatAvgCost, false))
                 .collect(Collectors.toCollection(ArrayList::new));
 
         // ── Forecast months (current through FY end) ─────────────────────
@@ -658,8 +708,6 @@ public class CostAnalyticsResource {
         String fyEndKey = toMonthKey(fyEndYear, 6);
 
         if (currentMonthKey.compareTo(fyEndKey) <= 0) {
-            double forecastMonthlyCost = flatAvgCost != null ? flatAvgCost : 0;
-
             // Q4: Budget revenue
             String budgetSql = buildBudgetRevenueSql(companies);
             var budgetQuery = em.createNativeQuery(budgetSql, Tuple.class);
@@ -695,10 +743,15 @@ public class CostAnalyticsResource {
                 double pipelineRev = pipelineMap.getOrDefault(fKey, 0.0);
                 double forecastRevenue = Math.round(budgetRev + pipelineRev);
 
+                // Forecast direct delivery cost via TTM gross margin (matches EBITDA chart).
+                double forecastDirectDelivery = Math.round(forecastRevenue * (1.0 - ttmGrossMargin));
+                double forecastTotalCost = Math.round(flatAvgOpexSalary + forecastDirectDelivery);
+
                 withAvg.add(new RevenueCostForecastDTO(
                         fKey, fYear, fMonth,
                         SalaryAnalyticsProvider.formatMonthLabel(fYear, fMonth),
-                        forecastRevenue, forecastRevenue, forecastMonthlyCost,
+                        forecastRevenue, forecastRevenue,
+                        forecastTotalCost, forecastDirectDelivery,
                         flatAvgCost, true));
 
                 fMonth++;
@@ -971,6 +1024,54 @@ public class CostAnalyticsResource {
                 "AND o.posting_status = 'BOOKED' " +
                 "AND o.month_key >= :ttmStart AND o.month_key < :currentMonth " +
                 filter;
+    }
+
+    /**
+     * Monthly GL DIRECT_COSTS from finance_details (signed sum), parameterized by costSource.
+     * Identical predicate to {@code CxoFinanceService.queryMonthlyDirectCostByMonth} so the
+     * Revenue/Cost chart and EBITDA chart subtract the same direct delivery cost.
+     */
+    private static String buildMonthlyGlDirectCostSql(Set<String> companies) {
+        String filter = companies != null ? "AND fd.companyuuid IN (:companyIds) " : "";
+        return "SELECT DATE_FORMAT(fd.expensedate, '%Y%m') AS month_key, " +
+                "       COALESCE(SUM(fd.amount), 0.0) AS gl_direct_cost " +
+                "FROM finance_details fd " +
+                "INNER JOIN accounting_accounts aa " +
+                "    ON fd.accountnumber = aa.account_code " +
+                "    AND fd.companyuuid  = aa.companyuuid " +
+                "WHERE aa.cost_type = 'DIRECT_COSTS' " +
+                "  AND DATE_FORMAT(fd.expensedate, '%Y%m') BETWEEN :fromKey AND :toKey " +
+                "  AND fd.amount != 0 " +
+                "  AND fd.postingstatus IN (:postingStatuses) " +
+                filter +
+                "GROUP BY DATE_FORMAT(fd.expensedate, '%Y%m') ORDER BY month_key";
+    }
+
+    /**
+     * Monthly QUEUED INTERNAL invoice cost, attributed to debtor company, in DKK.
+     * Mirrors {@code CxoFinanceService.queryMonthlyQueuedInternalCostByMonth}. QUEUED
+     * INTERNALs aren't yet in the GL, so they're synthesized here. Independent of
+     * costSource (QUEUED rows aren't subject to BOOKED/DRAFT classification).
+     */
+    private static String buildMonthlyQueuedInternalCostSql(Set<String> companies) {
+        String filter = companies != null ? "AND i.debtor_companyuuid IN (:companyIds) " : "";
+        return "SELECT DATE_FORMAT(i.invoicedate, '%Y%m') AS month_key, " +
+                "       COALESCE(SUM(ii.rate * ii.hours * " +
+                "           CASE WHEN i.currency = 'DKK' THEN 1.0 " +
+                "                ELSE COALESCE((SELECT c.conversion FROM currences c " +
+                "                              WHERE c.currency = i.currency " +
+                "                                AND c.month = DATE_FORMAT(i.invoicedate, '%Y%m') LIMIT 1), 1.0) " +
+                "           END), 0.0) AS queued_cost " +
+                "FROM invoices i " +
+                "JOIN invoiceitems ii ON ii.invoiceuuid = i.uuid " +
+                "WHERE i.type = 'INTERNAL' " +
+                "  AND i.status = 'QUEUED' " +
+                "  AND i.debtor_companyuuid IS NOT NULL " +
+                "  AND DATE_FORMAT(i.invoicedate, '%Y%m') BETWEEN :fromKey AND :toKey " +
+                "  AND ii.rate IS NOT NULL " +
+                "  AND ii.hours IS NOT NULL " +
+                filter +
+                "GROUP BY DATE_FORMAT(i.invoicedate, '%Y%m') ORDER BY month_key";
     }
 
     /** Budget revenue from fact_revenue_budget_mat (forecast window). */


### PR DESCRIPTION
## Summary
The Annual P&L Accumulated mode shows Implied EBITDA = **+26.4M** for Apr 2026; the EBITDA mode shows Accumulated EBITDA = **−1.9M** for the same period. Same chart container, **28M gap**. Plus the Accumulated tooltip renders literal `kr. NaN` for OPEX+Salaries and Direct delivery cost rows.

## Root cause
The May-22 "Add direct delivery cost" commit (`1955813d`) updated the **docstring** of `RevenueCostForecastDTO` but never added the record component. The resource never populated direct delivery cost. The frontend was updated against a contract the backend never delivered — `directDeliveryCostDkk` was `undefined` at runtime, the accumulator yielded `NaN`, and `totalCostDkk` was missing two major components.

## Fix
- Add `directDeliveryCostDkk` as a 10th component of `RevenueCostForecastDTO`.
- Add two SQL helpers (`buildMonthlyGlDirectCostSql`, `buildMonthlyQueuedInternalCostSql`) that mirror the predicates `CxoFinanceService` uses for the EBITDA chart — so both charts subtract the same cost stack.
- Rewrite `getRevenueCostForecast` to populate the new field, sum it into `totalCostDkk`, and switch forecast direct-cost methodology to `forecastRevenue × (1 − TTM gross margin)` (same as EBITDA).

## Production DB sanity (FY 2025-26 actuals through Apr 2026, BOOKED)
| Component | Mio kr |
|---|---|
| Invoice revenue | 136.28 |
| OPEX + Salaries (fact_opex_distribution_mat) | 96.34 |
| GL DIRECT_COSTS (signed) | 14.21 |
| QUEUED INTERNAL synthesized | 5.12 |
| **EBITDA cost stack** | 115.67 |

## Test plan
- [x] `mvn compile` clean
- [ ] After deploy: hit `/finance/analytics/revenue-cost-forecast?costSource=BOOKED_PLUS_DRAFT` and confirm `directDeliveryCostDkk` is non-zero on actual months
- [ ] After deploy: hit with `?costSource=BOOKED` and confirm `totalCostDkk` differs (drafts removed)
- [ ] After frontend deploy: Annual P&L Accumulated tooltip should show real DKK values (no NaN) and Implied EBITDA should reconcile to EBITDA chart's accumulated EBITDA within ±0.4M

## Rollback
Single-commit revert. The frontend has been updated separately to nullish-coalesce so the revert is safe.