### PR TITLE
Release: unstrand pre-Phase-4 AI-rejected expenses (V356 + approve/upload gates)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/expenseservice/batch/ExpenseItemReader.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/batch/ExpenseItemReader.java
@@ -18,8 +18,13 @@ import java.util.stream.Collectors;
 
 /**
  * ItemReader for expense upload batch job.
- * Loads all VALIDATED expenses and reads them one by one for processing.
+ * Loads all VALIDATED expenses without an open review state and reads them one
+ * by one for processing.
  * Applies filters:
+ * - Status = VALIDATED
+ * - reviewState IS NULL — an expense parked in a Phase-4 review queue (e.g.
+ *   PENDING_HR after the V356 backfill) must wait for Accounting approval
+ *   before it is uploaded
  * - Amount must be greater than 0
  * - Created more than 2 days ago (to avoid processing very recent submissions)
  */
@@ -42,7 +47,8 @@ public class ExpenseItemReader implements ItemReader {
         // Load all VALIDATED expenses with filters
         LocalDate cutoffDate = LocalDate.now().minusDays(2);
 
-        expenses = Expense.<Expense>stream("status", ExpenseService.STATUS_VALIDATED)
+        expenses = Expense.<Expense>stream("status = ?1 AND reviewState IS NULL",
+                        ExpenseService.STATUS_VALIDATED)
                 .filter(e -> e.getAmount() != null && e.getAmount() > 0)
                 .filter(e -> e.getDatecreated() != null && e.getDatecreated().isBefore(cutoffDate))
                 .collect(Collectors.toList());

--- a/src/main/java/dk/trustworks/intranet/expenseservice/resources/ExpenseReviewDecisionResource.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/resources/ExpenseReviewDecisionResource.java
@@ -35,7 +35,13 @@ public class ExpenseReviewDecisionResource {
         Expense e = Expense.findById(uuid);
         requireOverridable(e);
         logs.recordHRApprove(e, header.getUserUuid(), body.reason());
-        e.setStatus("VALIDATED");
+        // Only advance CREATED → VALIDATED. For stranded legacy rows whose status
+        // has already moved past CREATED (e.g. VERIFIED_UNBOOKED via a pre-Phase-4
+        // accountant override) the expense already lives in e-conomic; downgrading
+        // its status would re-queue it for upload and create a duplicate voucher.
+        if ("CREATED".equals(e.getStatus())) {
+            e.setStatus("VALIDATED");
+        }
         e.setReviewState(null);
         e.setHrDecision("APPROVED");
         e.setHrDecisionBy(header.getUserUuid());

--- a/src/main/resources/db/migration/V356__Backfill_review_state_for_stranded_ai_rejected.sql
+++ b/src/main/resources/db/migration/V356__Backfill_review_state_for_stranded_ai_rejected.sql
@@ -1,0 +1,26 @@
+-- V356__Backfill_review_state_for_stranded_ai_rejected.sql
+--
+-- Pre-Phase-4 (pre-V346, 2026-05-18) AI-rejected expenses that were overridden
+-- by an accountant via the legacy PUT /expenses/{uuid}/status endpoint kept
+-- ai_validation_approved = 0 but advanced beyond status=CREATED. Phase 4 added
+-- the review_state column NULLable with no backfill, leaving those rows invisible
+-- to the four new Accounting review queues (PENDING_HR, AWAITING_EMPLOYEE,
+-- HR_SENT_BACK, STUCK) — exactly the visibility gap reported by Marta Katborg.
+--
+-- This migration backfills review_state = 'PENDING_HR' for the stranded *unpaid*
+-- rows so they surface in "Pending review" and an accountant can either approve
+-- (clears review_state without downgrading status — see ExpenseReviewDecisionResource)
+-- or reject. Paid rows are intentionally skipped: they are already reimbursed and
+-- pulling them into a review queue would add noise without recourse.
+--
+-- Predicate breakdown (matches production count of 169 on 2026-05-28):
+--   ai_validation_approved = 0       — AI rejected at submission
+--   review_state IS NULL              — never routed by Phase 4
+--   status NOT IN ('CREATED','DELETED') — already past AI gate (or removed)
+--   paid_out IS NULL                  — still owed to employee
+UPDATE expenses
+SET review_state = 'PENDING_HR'
+WHERE ai_validation_approved = 0
+  AND review_state IS NULL
+  AND status NOT IN ('CREATED', 'DELETED')
+  AND paid_out IS NULL;

--- a/src/test/java/dk/trustworks/intranet/expenseservice/resources/ExpenseReviewResourceDecisionsTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/resources/ExpenseReviewResourceDecisionsTest.java
@@ -175,4 +175,48 @@ class ExpenseReviewResourceDecisionsTest {
         assertEquals("NEEDS_FIX", after.getReviewState());
         assertEquals("CREATED", after.getStatus());
     }
+
+    /**
+     * Stranded pre-Phase-4 AI-rejected rows (V356 backfill) have status already
+     * past CREATED — typically VERIFIED_UNBOOKED with a real voucher in e-conomic.
+     * Approving them must NOT downgrade the status back to VALIDATED, or the upload
+     * batch would re-process them and create a duplicate voucher.
+     */
+    @Test @TestSecurity(user = "hr", roles = {"expenses:review"})
+    void approveOnAdvancedStatusDoesNotDowngradeStatus() {
+        Expense e = new Expense();
+        e.setUuid(java.util.UUID.randomUUID().toString());
+        e.setUseruuid("u");
+        e.setAmount(138.6);
+        e.setAccount("3585");
+        e.setExpensedate(java.time.LocalDate.now().minusDays(20));
+        e.setDatecreated(java.time.LocalDate.now().minusDays(20));
+        e.setStatus("VERIFIED_UNBOOKED");
+        e.setVouchernumber(6037617);
+        e.setJournalnumber(16);
+        e.setAccountingyear("2025_6_2026a");
+        e.setReviewState("PENDING_HR");
+        e.setAiValidationApproved(false);
+        e.setAiValidationReason("R_OFFICE_FOOD_DRINK proximity");
+        io.quarkus.narayana.jta.QuarkusTransaction.requiringNew().run(e::persist);
+        String uuid = e.getUuid();
+
+        given()
+          .header("X-Requested-By", "hr")
+          .contentType(MediaType.APPLICATION_JSON)
+          .body("{\"reason\":\"Stranded legacy row — voucher already in e-conomic\"}")
+        .when()
+          .post("/expenses/" + uuid + "/review/approve")
+        .then()
+          .statusCode(204);
+
+        Expense after = io.quarkus.narayana.jta.QuarkusTransaction.requiringNew()
+            .call(() -> Expense.findById(uuid));
+        assertEquals("VERIFIED_UNBOOKED", after.getStatus(),
+            "Status must NOT be downgraded — the expense is already in e-conomic");
+        assertNull(after.getReviewState());
+        assertEquals("APPROVED", after.getHrDecision());
+        assertEquals("hr", after.getHrDecisionBy());
+        assertNotNull(after.getHrDecisionAt());
+    }
 }


### PR DESCRIPTION
## Release Summary

One commit: `0a5aaa61 fix(expense-review): unstrand pre-Phase-4 AI-rejected expenses`.

Pre-Phase-4 (pre-V346) AI-rejected expenses overridden via the legacy
`PUT /expenses/{uuid}/status` endpoint kept `ai_validation_approved=0`
but advanced beyond `status=CREATED`. V346 added `review_state` NULLable
without a backfill, so 169 unpaid stranded rows are invisible to the
four Phase-4 Accounting review queues. Reported via Marta Katborg's
138.6 kr VERIFIED_UNBOOKED row.

* V356 backfills `review_state='PENDING_HR'` for the 169 stranded rows.
* `ExpenseReviewDecisionResource.approve` no longer downgrades status
  past CREATED — would otherwise re-queue an existing e-conomic voucher.
* `ExpenseItemReader` gates upload on `reviewState IS NULL` so the
  post-backfill VALIDATED+PENDING_HR combination cannot bypass approval.
* New test covers approve on an already-advanced VERIFIED_UNBOOKED row.

## Pre-merge checklist
- [x] Staging deploy succeeded (run 26600697054, ~5min)
- [x] Staging /health returns UP
- [x] Staging /expenses/review returns 401 (route registered)
- [x] type-check + lint clean on touched files
- [x] Frontend test suite green (13/13 in ExpensesSection.test.tsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)