### PR TITLE
feat(timesheet): seed submission authority roles (V361)

### DIFF
--- a/src/main/resources/db/migration/V361__Seed_timesheet_submission_authority_roles.sql
+++ b/src/main/resources/db/migration/V361__Seed_timesheet_submission_authority_roles.sql
@@ -1,0 +1,27 @@
+-- ============================================================================
+-- V361: Seed configurable timesheet submission authority roles
+-- ============================================================================
+-- Purpose: Stores which user roles may CHANGE timesheet submission state —
+--          i.e. unlock a SUBMITTED month and submit a month on behalf of
+--          another user. Admins edit this in Settings → Access Management →
+--          Timesheet Submission.
+--
+--          The frontend reads this via app_settings (category 'timesheet') and
+--          falls back to 'ADMIN' when the row is absent/empty, so behaviour is
+--          identical to the previous hardcoded hasRole('ADMIN') gate until an
+--          admin changes it.
+--
+--          Value is a comma-separated list of UPPERCASE role names matching the
+--          frontend role vocabulary (see mapBackendRoles), e.g. 'ADMIN,HR'.
+--
+-- INSERT IGNORE: relies on the uq_app_settings_key UNIQUE constraint so a later
+--          admin edit is never reset to the default on redeploy.
+--
+-- Rollback: DELETE FROM app_settings WHERE setting_key = 'timesheet.submission.authorityRoles';
+--
+-- Author: Claude Code
+-- Date: 2026-06-02
+-- ============================================================================
+
+INSERT IGNORE INTO app_settings (setting_key, setting_value, category)
+VALUES ('timesheet.submission.authorityRoles', 'ADMIN', 'timesheet');


### PR DESCRIPTION
## Summary
- Flyway V361 seeds `app_settings` row `timesheet.submission.authorityRoles=ADMIN` (category `timesheet`). This is the admin-configurable role list for who may unlock a submitted month / submit on behalf of another user.
- `INSERT IGNORE` so admin edits are preserved across redeploys. The frontend defaults to `ADMIN` when the row is absent, so this is non-breaking and not order-coupled with the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)