### PR TITLE
Promote phantom internal-invoicing (Phases 1–7) to production

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/EconomicRevenueImportBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/jobs/EconomicRevenueImportBatchlet.java
@@ -60,6 +60,9 @@ public class EconomicRevenueImportBatchlet {
     EconomicRevenueImportService refreshService;
 
     @Inject
+    dk.trustworks.intranet.aggregates.invoice.services.PhantomAttributionService phantomAttributionService;
+
+    @Inject
     SlackService slackService;
 
     @Inject
@@ -88,6 +91,16 @@ public class EconomicRevenueImportBatchlet {
                     outcome.perAccountDkk(),
                     outcome.skippedByLayer(),
                     from, to);
+
+            // Derive per-consultant attribution for in-scope phantoms (decision #3).
+            // Isolated from the import: a derivation failure must not fail/alert the import.
+            try {
+                var attribution = phantomAttributionService.deriveAllInScope();
+                log.infof("phantom attribution derivation complete: %s", attribution);
+            } catch (Exception de) {
+                log.errorf(de, "phantom attribution derivation failed (import itself succeeded)");
+            }
+
             lastAlertSent.set(null);
         } catch (Exception e) {
             log.errorf(e, "e-conomic revenue import failed");

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/PhantomClientMap.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/PhantomClientMap.java
@@ -1,0 +1,67 @@
+package dk.trustworks.intranet.aggregates.invoice.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * Maps a recurring phantom clientname (an e-conomic account label) to a real
+ * client, or marks it excluded. One row per distinct label. Maintained via the
+ * admin review queue; read by PhantomAttributionService during derivation.
+ *
+ * <p>Active-record Panache entity; mirrors {@link InvoiceItemAttribution}
+ * (public fields, Lombok accessors, timestamps set in the constructor).
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "phantom_client_map")
+public class PhantomClientMap extends PanacheEntityBase {
+
+    @Id
+    public String clientname;
+
+    @Column(name = "client_uuid")
+    public String clientUuid;
+
+    public boolean excluded;
+
+    public String note;
+
+    @Column(name = "confirmed_by")
+    public String confirmedBy;
+
+    @Column(name = "confirmed_at")
+    public LocalDateTime confirmedAt;
+
+    @Column(name = "created_at", updatable = false)
+    public LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    public LocalDateTime updatedAt;
+
+    public PhantomClientMap() {
+    }
+
+    public PhantomClientMap(String clientname,
+                            String clientUuid,
+                            boolean excluded,
+                            String note,
+                            String confirmedBy) {
+        LocalDateTime now = LocalDateTime.now();
+        this.clientname = clientname;
+        this.clientUuid = clientUuid;
+        this.excluded = excluded;
+        this.note = note;
+        this.confirmedBy = confirmedBy;
+        this.confirmedAt = now;
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/dto/PhantomAttributionReviewDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/dto/PhantomAttributionReviewDTO.java
@@ -1,0 +1,21 @@
+package dk.trustworks.intranet.aggregates.invoice.model.dto;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.math.BigDecimal;
+
+/**
+ * One row of the phantom attribution review queue, grouped by clientname label:
+ * the unattributed in-scope phantoms for that label, their current mapping
+ * state, and (when unmapped) an auto-suggestion to confirm.
+ */
+@RegisterForReflection
+public record PhantomAttributionReviewDTO(
+        String clientname,
+        long phantomCount,
+        BigDecimal totalAmount,
+        String mappedClientUuid,
+        String mappedClientName,
+        boolean excluded,
+        PhantomClientSuggestion suggestion
+) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/dto/PhantomClientSuggestion.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/dto/PhantomClientSuggestion.java
@@ -1,0 +1,21 @@
+package dk.trustworks.intranet.aggregates.invoice.model.dto;
+
+import dk.trustworks.intranet.aggregates.invoice.model.enums.SuggestionMethod;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * A non-binding client suggestion for a phantom label, shown in the review
+ * queue. {@code method == NONE} means no candidate (suggestedClientUuid null).
+ */
+@RegisterForReflection
+public record PhantomClientSuggestion(
+        String suggestedClientUuid,
+        String suggestedClientName,
+        double confidence,
+        SuggestionMethod method
+) {
+    /** Convenience: the "no candidate" suggestion. */
+    public static PhantomClientSuggestion none() {
+        return new PhantomClientSuggestion(null, null, 0.0, SuggestionMethod.NONE);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/enums/PhantomDerivationStatus.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/enums/PhantomDerivationStatus.java
@@ -1,0 +1,11 @@
+package dk.trustworks.intranet.aggregates.invoice.model.enums;
+
+/** Outcome of attempting to derive attribution for a single phantom. */
+public enum PhantomDerivationStatus {
+    ATTRIBUTED,        // AUTO rows written, sum to the phantom total
+    UNRESOLVED_CLIENT, // no confirmed client mapping -> review queue
+    EXCLUDED,          // label mapped excluded=1 (e.g. canteen) -> skipped, not in queue
+    NO_WORK,           // resolved, but no registered work for client+month -> review queue
+    SKIPPED_MANUAL,    // MANUAL override present -> left untouched (amount recalculated only)
+    OUT_OF_SCOPE       // not a CREATED PHANTOM in the current FY, or skip-flagged
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/enums/SuggestionMethod.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/model/enums/SuggestionMethod.java
@@ -1,0 +1,9 @@
+package dk.trustworks.intranet.aggregates.invoice.model.enums;
+
+/** How a phantom-label client suggestion was produced. */
+public enum SuggestionMethod {
+    EXACT,    // case-insensitive exact match on the prefix-stripped label
+    FUZZY,    // Jaro-Winkler match (>= ClientService threshold)
+    CONTAINS, // last-resort substring/contains match
+    NONE      // no candidate found
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/resources/InvoiceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/resources/InvoiceResource.java
@@ -1087,8 +1087,9 @@ public class InvoiceResource {
      * the modal's per-row BASE deselection. The attribution table is not modified
      * — exclusion is in-request only.
      *
-     * @return 200 with the projected groupings, 400 for PHANTOM sources or invalid
-     *         exclusion UUIDs, 404 when the source invoice does not exist.
+     * @return 200 with the projected groupings (empty for an unmapped / no-work /
+     *         excluded PHANTOM source — never a 400), 400 for invalid exclusion UUIDs,
+     *         404 when the source invoice does not exist.
      */
     @GET
     @Path("/{invoiceuuid}/internal-preview")
@@ -1110,8 +1111,9 @@ public class InvoiceResource {
      * <p>Idempotent per-issuer: issuers that already have a linked internal invoice
      * (any status) are skipped.
      *
-     * @return 200 with the list of created invoice UUIDs. 400 for PHANTOM sources
-     *         or invalid exclusion UUIDs. 404 when the source invoice does not exist.
+     * @return 200 with the list of created invoice UUIDs (empty for an unmapped /
+     *         no-work / excluded PHANTOM source — never a 400). 400 for invalid
+     *         exclusion UUIDs. 404 when the source invoice does not exist.
      */
     @POST
     @Path("/{invoiceuuid}/create-all-internal")

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/resources/InvoiceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/resources/InvoiceResource.java
@@ -96,6 +96,9 @@ public class InvoiceResource {
     InvoiceAttributionService invoiceAttributionService;
 
     @Inject
+    dk.trustworks.intranet.aggregates.invoice.services.PhantomAttributionService phantomAttributionService;
+
+    @Inject
     dk.trustworks.intranet.aggregates.invoice.services.InternalInvoiceOrchestrator internalInvoiceOrchestrator;
 
     @GET
@@ -1132,6 +1135,74 @@ public class InvoiceResource {
         List<String> created = invoiceService.createAllInternalFromAttribution(
                 invoiceuuid, issuerFilter, queue, excluded);
         return new dk.trustworks.intranet.aggregates.invoice.dto.CreateAllInternalResponse(created);
+    }
+
+    // ── Phantom attribution: review queue, mapping, derive ─────────────────
+
+    @GET
+    @Path("/phantoms/attribution-review")
+    @RolesAllowed({"invoices:read"})
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<dk.trustworks.intranet.aggregates.invoice.model.dto.PhantomAttributionReviewDTO> phantomAttributionReview() {
+        return phantomAttributionService.buildReviewQueue();
+    }
+
+    @PUT
+    @Path("/phantoms/client-map")
+    @RolesAllowed({"invoices:write"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response upsertPhantomClientMap(
+            @HeaderParam("X-Requested-By") String userUuid,
+            dk.trustworks.intranet.aggregates.invoice.resources.dto.PhantomClientMapRequest request) {
+
+        if (userUuid == null || userUuid.isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "X-Requested-By header is required")).build();
+        }
+        if (request == null || request.clientname() == null || request.clientname().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "clientname is required")).build();
+        }
+        boolean excluded = request.excluded() != null && request.excluded();
+        if (!excluded && (request.clientUuid() == null || request.clientUuid().isBlank())) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "clientUuid is required unless excluded=true")).build();
+        }
+        Map<dk.trustworks.intranet.aggregates.invoice.model.enums.PhantomDerivationStatus, Integer> result =
+                phantomAttributionService.upsertClientMapAndRederive(request, userUuid);
+        return Response.ok(result).build();
+    }
+
+    @POST
+    @Path("/{invoiceuuid}/phantom-attribution/derive")
+    @RolesAllowed({"invoices:write"})
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response derivePhantomAttribution(
+            @PathParam("invoiceuuid") String invoiceuuid,
+            @HeaderParam("X-Requested-By") String userUuid) {
+
+        if (userUuid == null || userUuid.isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "X-Requested-By header is required")).build();
+        }
+        dk.trustworks.intranet.aggregates.invoice.model.enums.PhantomDerivationStatus status =
+                phantomAttributionService.deriveForPhantom(invoiceuuid);
+        return Response.ok(Map.of("status", status.name())).build();
+    }
+
+    @POST
+    @Path("/phantoms/attribution/derive-all")
+    @RolesAllowed({"invoices:write"})
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response derivePhantomAttributionAll(@HeaderParam("X-Requested-By") String userUuid) {
+        if (userUuid == null || userUuid.isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", "X-Requested-By header is required")).build();
+        }
+        Map<dk.trustworks.intranet.aggregates.invoice.model.enums.PhantomDerivationStatus, Integer> result =
+                phantomAttributionService.deriveAllInScope();
+        return Response.ok(result).build();
     }
 
     /**

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/resources/dto/PhantomClientMapRequest.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/resources/dto/PhantomClientMapRequest.java
@@ -1,0 +1,16 @@
+package dk.trustworks.intranet.aggregates.invoice.resources.dto;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Upsert for one phantom label -> client mapping. {@code excluded=true} marks
+ * the label a known non-client (e.g. canteen); {@code clientUuid} resolves it.
+ * {@code confirmed_by} is taken from the X-Requested-By header, never the body.
+ */
+@RegisterForReflection
+public record PhantomClientMapRequest(
+        String clientname,
+        String clientUuid,
+        Boolean excluded,
+        String note
+) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceAttributionService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceAttributionService.java
@@ -156,6 +156,23 @@ public class InvoiceAttributionService {
         return rows.stream().map(this::mapRowToAttribution).toList();
     }
 
+    /**
+     * Re-read attributions in a fresh transaction so the read gets a new
+     * REPEATABLE READ snapshot. Required when the rows were just persisted by a
+     * {@code REQUIRES_NEW} sibling — e.g. {@link PhantomAttributionService#deriveForPhantom} —
+     * whose commit lands on a different connection and is therefore invisible to the
+     * caller's already-fixed snapshot. Calling this through the CDI proxy suspends the
+     * caller's transaction and runs the SELECT under a snapshot taken after that commit,
+     * so the freshly-derived rows are seen on the first invocation rather than only on a
+     * second call. (The non-phantom path uses the plain {@link #getInvoiceAttributions}
+     * because {@code computeAttributions} joins the caller's transaction — its writes are
+     * already visible to the same snapshot.)
+     */
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    public List<InvoiceItemAttribution> getInvoiceAttributionsInNewTx(String invoiceUuid) {
+        return getInvoiceAttributions(invoiceUuid);
+    }
+
     private InvoiceItemAttribution mapRowToAttribution(Object[] row) {
         var attr = new InvoiceItemAttribution();
         attr.uuid            = (String) row[0];

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceService.java
@@ -661,6 +661,17 @@ public class InvoiceService {
         // single issuer company (companyuuid) so we filter to just that issuer and do NOT
         // queue — matches the legacy contract ("create DRAFT only").
         if (attributionDrivenInternalInvoices) {
+            // PHANTOM sources are settled through the dedicated internal-invoice preview /
+            // create-all flow (which derives attribution from registered work) — not through
+            // this legacy single-issuer entry point. Phase 5 lifted the PHANTOM guard from
+            // createAllInternalFromAttribution to enable that dedicated flow; re-assert it
+            // here so this endpoint keeps rejecting phantoms as it did before.
+            if (invoice.getType() == InvoiceType.PHANTOM) {
+                throw new WebApplicationException(
+                        "PHANTOM source invoices are not supported by this endpoint; "
+                                + "use the internal-invoice preview / create-all flow.",
+                        Response.Status.BAD_REQUEST);
+            }
             createAllInternalFromAttribution(invoice.getUuid(), Set.of(companyuuid), false);
             return;
         }
@@ -738,6 +749,18 @@ public class InvoiceService {
         // requested issuer, with queue=true. Returns the single created internal invoice
         // (or throws if no cross-company work is detected for the requested issuer).
         if (attributionDrivenInternalInvoices) {
+            // PHANTOM sources are settled through the dedicated internal-invoice preview /
+            // create-all flow — not auto-created/queued here. Phase 5 lifted the PHANTOM
+            // guard from createAllInternalFromAttribution; re-assert it here so this legacy
+            // entry point keeps rejecting phantoms (as it did in attribution-driven mode
+            // before). The findById is L1-cached and reused by the delegate below.
+            Invoice phantomCheck = Invoice.findById(clientInvoiceUuid);
+            if (phantomCheck != null && phantomCheck.getType() == InvoiceType.PHANTOM) {
+                throw new WebApplicationException(
+                        "PHANTOM source invoices are not supported by this endpoint; "
+                                + "use the internal-invoice preview / create-all flow.",
+                        Response.Status.BAD_REQUEST);
+            }
             List<String> created = createAllInternalFromAttribution(
                     clientInvoiceUuid,
                     Set.of(issuerCompanyUuid),

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceService.java
@@ -79,6 +79,9 @@ public class InvoiceService {
     @Inject
     InvoiceAttributionService invoiceAttributionService;
 
+    @Inject
+    PhantomAttributionService phantomAttributionService;
+
     /**
      * Post-commit signal that an invoice's line items changed and its attributions
      * must be recomputed. Observed by {@code InvoiceAttributionDirtyObserver},
@@ -900,10 +903,11 @@ public class InvoiceService {
      *
      * <p>If the source invoice has no attribution rows yet (common for newly-created
      * invoices that haven't been through the finalization wizard), attributions are
-     * computed lazily inside the same transaction.
+     * computed lazily. For a {@code PHANTOM} source they are instead derived from
+     * registered work; an unmapped / no-work / excluded phantom simply yields an empty
+     * preview (no error).
      *
-     * @throws WebApplicationException 404 if the source invoice does not exist,
-     *                                 400 if the source is of type PHANTOM.
+     * @throws WebApplicationException 404 if the source invoice does not exist.
      */
     @Transactional
     public dk.trustworks.intranet.aggregates.invoice.dto.InternalInvoicePreview previewInternal(String sourceInvoiceUuid) {
@@ -930,19 +934,26 @@ public class InvoiceService {
         if (source == null) {
             throw new WebApplicationException("Invoice not found: " + sourceInvoiceUuid, Response.Status.NOT_FOUND);
         }
-        if (source.getType() == InvoiceType.PHANTOM) {
-            throw new WebApplicationException(
-                    "Internal invoices cannot be created from PHANTOM source invoices.",
-                    Response.Status.BAD_REQUEST);
-        }
-
         // Lazy-compute: if the source has no attributions, compute them now so the
         // preview reflects up-to-date distribution. Cheap when already computed.
         List<InvoiceItemAttribution> attributions =
                 invoiceAttributionService.getInvoiceAttributions(sourceInvoiceUuid);
         if (attributions.isEmpty()) {
-            invoiceAttributionService.computeAttributions(sourceInvoiceUuid);
-            attributions = invoiceAttributionService.getInvoiceAttributions(sourceInvoiceUuid);
+            if (source.getType() == InvoiceType.PHANTOM) {
+                // Phantom attribution is derived from registered work (per-consultant
+                // shares of the imported e-conomic revenue), not from the source's own
+                // line items. An unmapped / no-work / excluded phantom leaves the table
+                // empty here -> empty preview, never a 400.
+                phantomAttributionService.deriveForPhantom(sourceInvoiceUuid);
+                // deriveForPhantom commits in its own (REQUIRES_NEW) transaction, so its
+                // rows are invisible to this transaction's already-fixed REPEATABLE READ
+                // snapshot — re-read in a fresh transaction so the just-derived rows are
+                // seen on the first call (not only on a subsequent request).
+                attributions = invoiceAttributionService.getInvoiceAttributionsInNewTx(sourceInvoiceUuid);
+            } else {
+                invoiceAttributionService.computeAttributions(sourceInvoiceUuid);
+                attributions = invoiceAttributionService.getInvoiceAttributions(sourceInvoiceUuid);
+            }
         }
 
         // Resolve all attribution consultants' companies as-of the source's invoicedate.
@@ -1042,7 +1053,9 @@ public class InvoiceService {
      * are skipped — only missing issuers are created. This matches the "create all
      * drafts" UX where re-clicking should fill gaps, not duplicate rows.
      *
-     * @param sourceInvoiceUuid the source invoice UUID. 404 if missing. 400 if PHANTOM.
+     * @param sourceInvoiceUuid the source invoice UUID (404 if missing). A {@code PHANTOM}
+     *                          source derives attribution from registered work; if it is
+     *                          unmapped / has no work / is excluded, nothing is created.
      * @param issuerFilter      optional set restricting which issuers to materialize.
      *                          {@code null} or empty means "all detected issuers".
      * @param queue             when {@code true}, newly-created drafts are transitioned
@@ -1075,18 +1088,23 @@ public class InvoiceService {
         if (source == null) {
             throw new WebApplicationException("Invoice not found: " + sourceInvoiceUuid, Response.Status.NOT_FOUND);
         }
-        if (source.getType() == InvoiceType.PHANTOM) {
-            throw new WebApplicationException(
-                    "Internal invoices cannot be created from PHANTOM source invoices.",
-                    Response.Status.BAD_REQUEST);
-        }
-
-        // Lazy-compute attribution if missing.
+        // Lazy-compute attribution if missing. PHANTOM sources derive their attribution
+        // rows from registered work (see previewInternal); an unmapped / no-work /
+        // excluded phantom leaves the table empty -> empty create result, never a 400.
         List<InvoiceItemAttribution> attributions =
                 invoiceAttributionService.getInvoiceAttributions(sourceInvoiceUuid);
         if (attributions.isEmpty()) {
-            invoiceAttributionService.computeAttributions(sourceInvoiceUuid);
-            attributions = invoiceAttributionService.getInvoiceAttributions(sourceInvoiceUuid);
+            if (source.getType() == InvoiceType.PHANTOM) {
+                phantomAttributionService.deriveForPhantom(sourceInvoiceUuid);
+                // deriveForPhantom commits in its own (REQUIRES_NEW) transaction; re-read
+                // in a fresh transaction so the just-derived rows are visible to this call
+                // rather than being masked by this transaction's REPEATABLE READ snapshot
+                // (see previewInternal for the full rationale).
+                attributions = invoiceAttributionService.getInvoiceAttributionsInNewTx(sourceInvoiceUuid);
+            } else {
+                invoiceAttributionService.computeAttributions(sourceInvoiceUuid);
+                attributions = invoiceAttributionService.getInvoiceAttributions(sourceInvoiceUuid);
+            }
         }
 
         Set<String> consultantUuids = new HashSet<>();

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionService.java
@@ -362,7 +362,10 @@ public class PhantomAttributionService {
     /**
      * Confirm/exclude a label, then re-derive every in-scope phantom with that
      * label. The mapping is committed first (via the self proxy) so the
-     * REQUIRES_NEW derives see it. Returns the re-derive status histogram.
+     * REQUIRES_NEW derives see it. A freshly-confirmed mapping always wins: the
+     * re-derive clears any stale AUTO state first (see {@link #rederiveLabel}),
+     * so correcting a label to a different client actually re-points it. Returns
+     * the re-derive status histogram.
      */
     public Map<PhantomDerivationStatus, Integer> upsertClientMapAndRederive(
             PhantomClientMapRequest req, String userUuid) {
@@ -373,8 +376,19 @@ public class PhantomAttributionService {
         return rederiveLabel(req.clientname());
     }
 
-    /** Re-derive all in-scope phantoms carrying {@code clientname}. */
+    /**
+     * Re-derive all in-scope phantoms carrying {@code clientname}. Clears any
+     * stale AUTO state (a previously-stamped billing_client_uuid + AUTO rows)
+     * for the label's non-MANUAL phantoms FIRST, in its own committed
+     * transaction (via the self proxy), so the REQUIRES_NEW derives fall through
+     * to the just-confirmed mapping instead of short-circuiting on the old
+     * stamp. This makes a confirmed mapping authoritative on re-derive (an admin
+     * can correct a mis-mapped label). MANUAL-overridden phantoms are untouched
+     * (they return SKIPPED_MANUAL). Single-derive + nightly derive-all keep their
+     * stamp-preserving idempotency — only this label re-derive path resets.
+     */
     public Map<PhantomDerivationStatus, Integer> rederiveLabel(String clientname) {
+        self.resetAutoStateForLabel(clientname); // committed before the REQUIRES_NEW derives read
         List<String> uuids = self.listInScopeUuidsForLabel(clientname);
         Map<PhantomDerivationStatus, Integer> counts = new EnumMap<>(PhantomDerivationStatus.class);
         for (String uuid : uuids) {
@@ -386,6 +400,35 @@ public class PhantomAttributionService {
         }
         log.infof("rederiveLabel '%s': %s", clientname, counts);
         return counts;
+    }
+
+    /**
+     * Clear stale AUTO derivation state for a label's in-scope phantoms so a
+     * re-derive honors a freshly-confirmed mapping: for each in-scope phantom
+     * without a MANUAL attribution, delete its AUTO attribution rows and null
+     * its billing_client_uuid stamp. Phantoms carrying a MANUAL override are
+     * left untouched (deriveForPhantom returns SKIPPED_MANUAL for them, so their
+     * stamp must be preserved). Committed in its own transaction (called via the
+     * self proxy) so the subsequent REQUIRES_NEW derives read the cleared state.
+     */
+    @Transactional
+    public void resetAutoStateForLabel(String clientname) {
+        LocalDate fyStart = DateUtils.getCurrentFiscalStartDate();
+        LocalDate fyEnd = fyStart.plusYears(1);
+        List<Invoice> phantoms = Invoice.list("type = ?1 and status = ?2 and clientname = ?3",
+                InvoiceType.PHANTOM, InvoiceStatus.CREATED, clientname);
+        for (Invoice phantom : phantoms) {
+            if (!isInScope(phantom, fyStart, fyEnd)) continue;
+            List<InvoiceItem> items = phantom.getInvoiceitems();
+            InvoiceItem item = (items == null) ? null : items.stream().findFirst().orElse(null);
+            if (item == null) continue;
+            long manual = InvoiceItemAttribution.count("invoiceitemUuid = ?1 and source = ?2",
+                    item.uuid, AttributionSource.MANUAL);
+            if (manual > 0) continue; // preserve MANUAL overrides
+            InvoiceItemAttribution.delete("invoiceitemUuid = ?1 and source = ?2",
+                    item.uuid, AttributionSource.AUTO);
+            phantom.setBillingClientUuid(null); // managed entity -> flushed on commit
+        }
     }
 
     /** In-scope phantom uuids for one label (read via self proxy for a session). */

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionService.java
@@ -1,0 +1,115 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceStatus;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceType;
+import jakarta.enterprise.context.ApplicationScoped;
+import lombok.extern.jbosslog.JBossLog;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Derives per-consultant attribution for e-conomic-imported PHANTOM invoices
+ * from registered work, persisting invoice_item_attributions (source=AUTO,
+ * preserving MANUAL). The share math and scope predicate are pure static
+ * methods (unit-tested with no DB); persistence mirrors
+ * {@link InvoiceAttributionService#computeBaseItemAttribution}.
+ */
+@JBossLog
+@ApplicationScoped
+public class PhantomAttributionService {
+
+    private static final int PCT_SCALE = 4;   // matches InvoiceAttributionService
+    private static final int AMT_SCALE = 2;
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
+
+    /** Per-consultant work aggregate for a client+month. */
+    public record WorkAgg(BigDecimal hours, BigDecimal revenue) {}
+
+    /** A computed attribution row (pre-persist). */
+    public record ShareRow(String consultantUuid, BigDecimal sharePct,
+                           BigDecimal attributedAmount, BigDecimal originalHours) {}
+
+    /** In-scope = a CREATED PHANTOM, not skip-flagged, whose month is in [fyStart, fyEnd). */
+    static boolean isInScope(Invoice inv, LocalDate fyStart, LocalDate fyEnd) {
+        if (inv == null) return false;
+        if (inv.getType() != InvoiceType.PHANTOM) return false;
+        if (inv.getStatus() != InvoiceStatus.CREATED) return false;
+        if (inv.internalInvoiceSkip) return false;
+        LocalDate period = LocalDate.of(inv.getYear(), inv.getMonth(), 1);
+        return !period.isBefore(fyStart) && period.isBefore(fyEnd);
+    }
+
+    /**
+     * Compute attribution shares for one phantom. Basis = registered revenue
+     * (Σ hours×rate); falls back to hours when total revenue is 0. Shares are
+     * rounded to PCT_SCALE; amounts to AMT_SCALE; the rounding residual is
+     * absorbed into the largest-share consultant (ties → smallest consultant
+     * uuid) so amounts sum EXACTLY to {@code phantomTotal}. Pure.
+     */
+    public static List<ShareRow> computeShares(Map<String, WorkAgg> byConsultant, BigDecimal phantomTotal) {
+        if (byConsultant == null || byConsultant.isEmpty() || phantomTotal == null) {
+            return List.of();
+        }
+        List<String> consultants = new ArrayList<>(byConsultant.keySet());
+        consultants.sort(Comparator.naturalOrder()); // deterministic; smallest uuid first
+
+        BigDecimal totalRevenue = BigDecimal.ZERO;
+        BigDecimal totalHours = BigDecimal.ZERO;
+        for (String c : consultants) {
+            WorkAgg w = byConsultant.get(c);
+            totalRevenue = totalRevenue.add(nz(w.revenue()));
+            totalHours = totalHours.add(nz(w.hours()));
+        }
+
+        boolean revenueBasis = totalRevenue.signum() > 0;
+        BigDecimal totalWeight = revenueBasis ? totalRevenue : totalHours;
+        if (totalWeight.signum() <= 0) {
+            return List.of();
+        }
+
+        BigDecimal total = phantomTotal.setScale(AMT_SCALE, RoundingMode.HALF_UP);
+        List<ShareRow> rows = new ArrayList<>(consultants.size());
+        BigDecimal sumAmount = BigDecimal.ZERO;
+        for (String c : consultants) {
+            WorkAgg w = byConsultant.get(c);
+            BigDecimal weight = revenueBasis ? nz(w.revenue()) : nz(w.hours());
+            BigDecimal sharePct = weight.multiply(HUNDRED).divide(totalWeight, PCT_SCALE, RoundingMode.HALF_UP);
+            BigDecimal amount = sharePct.divide(HUNDRED, 10, RoundingMode.HALF_UP)
+                    .multiply(total).setScale(AMT_SCALE, RoundingMode.HALF_UP);
+            BigDecimal hours = nz(w.hours()).setScale(AMT_SCALE, RoundingMode.HALF_UP);
+            rows.add(new ShareRow(c, sharePct, amount, hours));
+            sumAmount = sumAmount.add(amount);
+        }
+
+        BigDecimal residual = total.subtract(sumAmount);
+        if (residual.signum() != 0) {
+            int idx = pickAbsorbingIndex(rows);
+            ShareRow r = rows.get(idx);
+            rows.set(idx, new ShareRow(r.consultantUuid(), r.sharePct(),
+                    r.attributedAmount().add(residual), r.originalHours()));
+        }
+        return rows;
+    }
+
+    /** Largest sharePct; ties resolved to the smallest consultant uuid (rows are uuid-sorted). */
+    private static int pickAbsorbingIndex(List<ShareRow> rows) {
+        int best = 0;
+        for (int i = 1; i < rows.size(); i++) {
+            if (rows.get(i).sharePct().compareTo(rows.get(best).sharePct()) > 0) {
+                best = i;
+            }
+        }
+        return best;
+    }
+
+    private static BigDecimal nz(BigDecimal v) {
+        return v == null ? BigDecimal.ZERO : v;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionService.java
@@ -1,16 +1,29 @@
 package dk.trustworks.intranet.aggregates.invoice.services;
 
 import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
+import dk.trustworks.intranet.aggregates.invoice.model.InvoiceItem;
+import dk.trustworks.intranet.aggregates.invoice.model.InvoiceItemAttribution;
+import dk.trustworks.intranet.aggregates.invoice.model.PhantomClientMap;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.AttributionSource;
 import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceStatus;
 import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceType;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.PhantomDerivationStatus;
+import dk.trustworks.intranet.dao.workservice.services.WorkService;
+import dk.trustworks.intranet.dto.work.ConsultantWorkRevenue;
+import dk.trustworks.intranet.utils.DateUtils;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import lombok.extern.jbosslog.JBossLog;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +41,18 @@ public class PhantomAttributionService {
     private static final int PCT_SCALE = 4;   // matches InvoiceAttributionService
     private static final int AMT_SCALE = 2;
     private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
+
+    @Inject
+    WorkService workService;
+
+    /**
+     * Self-injection so deriveAllInScope() invokes deriveForPhantom() / the
+     * read through the CDI client proxy — required for @Transactional(REQUIRES_NEW)
+     * and @Transactional to engage (a plain this.method() self-call bypasses the
+     * interceptor). Mirrors the per-voucher isolation in EconomicRevenueImportService.
+     */
+    @Inject
+    PhantomAttributionService self;
 
     /** Per-consultant work aggregate for a client+month. */
     public record WorkAgg(BigDecimal hours, BigDecimal revenue) {}
@@ -111,5 +136,131 @@ public class PhantomAttributionService {
 
     private static BigDecimal nz(BigDecimal v) {
         return v == null ? BigDecimal.ZERO : v;
+    }
+
+    /**
+     * Derive (or re-derive) attribution for a single phantom in its own
+     * transaction. Preserves MANUAL rows; replaces AUTO rows idempotently.
+     * Stamps invoices.billing_client_uuid with the resolved client.
+     */
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    public PhantomDerivationStatus deriveForPhantom(String invoiceUuid) {
+        Invoice phantom = Invoice.findById(invoiceUuid);
+        if (phantom == null) {
+            log.warnf("deriveForPhantom: invoice not found uuid=%s", invoiceUuid);
+            return PhantomDerivationStatus.OUT_OF_SCOPE;
+        }
+        LocalDate fyStart = DateUtils.getCurrentFiscalStartDate();
+        LocalDate fyEnd = fyStart.plusYears(1);
+        if (!isInScope(phantom, fyStart, fyEnd)) {
+            return PhantomDerivationStatus.OUT_OF_SCOPE;
+        }
+
+        InvoiceItem item = phantom.getInvoiceitems() == null
+                ? null
+                : phantom.getInvoiceitems().stream().findFirst().orElse(null);
+        if (item == null) {
+            log.warnf("deriveForPhantom: phantom has no invoiceitem uuid=%s", invoiceUuid);
+            return PhantomDerivationStatus.NO_WORK;
+        }
+
+        // Preserve MANUAL overrides (decision #7): recalc amount only, never replace.
+        List<InvoiceItemAttribution> existing = InvoiceItemAttribution.list("invoiceitemUuid", item.uuid);
+        boolean hasManual = existing.stream().anyMatch(a -> a.source == AttributionSource.MANUAL);
+        if (hasManual) {
+            double itemTotal = Math.abs(item.hours * item.rate);
+            for (InvoiceItemAttribution attr : existing) {
+                attr.recalculateAmount(itemTotal);
+                attr.updatedAt = LocalDateTime.now();
+            }
+            return PhantomDerivationStatus.SKIPPED_MANUAL;
+        }
+
+        // Resolve client: prefer an already-set billing_client_uuid, else the confirmed map.
+        String resolvedClientUuid = trimToNull(phantom.getBillingClientUuid());
+        if (resolvedClientUuid == null) {
+            PhantomClientMap map = PhantomClientMap.findById(phantom.getClientname());
+            if (map != null && map.excluded) {
+                return PhantomDerivationStatus.EXCLUDED;
+            }
+            if (map != null) {
+                resolvedClientUuid = trimToNull(map.clientUuid);
+            }
+        }
+        if (resolvedClientUuid == null) {
+            return PhantomDerivationStatus.UNRESOLVED_CLIENT;
+        }
+        phantom.setBillingClientUuid(resolvedClientUuid);
+
+        // Registered work for the resolved client + the phantom's month.
+        List<ConsultantWorkRevenue> work =
+                workService.findRevenueByClientAndMonth(resolvedClientUuid, phantom.getYear(), phantom.getMonth());
+        if (work.isEmpty()) {
+            return PhantomDerivationStatus.NO_WORK;
+        }
+        Map<String, WorkAgg> byConsultant = new LinkedHashMap<>();
+        for (ConsultantWorkRevenue r : work) {
+            byConsultant.put(r.useruuid(), new WorkAgg(r.hours(), r.revenue()));
+        }
+
+        BigDecimal phantomTotal = BigDecimal.valueOf(Math.abs(item.hours * item.rate))
+                .setScale(AMT_SCALE, RoundingMode.HALF_UP);
+        List<ShareRow> rows = computeShares(byConsultant, phantomTotal);
+        if (rows.isEmpty()) {
+            return PhantomDerivationStatus.NO_WORK;
+        }
+
+        // Idempotent AUTO replace (mirror computeBaseItemAttribution — enum bound directly).
+        InvoiceItemAttribution.delete("invoiceitemUuid = ?1 AND source = ?2", item.uuid, AttributionSource.AUTO);
+        for (ShareRow row : rows) {
+            new InvoiceItemAttribution(item.uuid, row.consultantUuid(), row.sharePct(),
+                    row.attributedAmount(), row.originalHours(), AttributionSource.AUTO).persist();
+        }
+        log.infof("deriveForPhantom: attributed phantom=%s client=%s consultants=%d total=%s",
+                invoiceUuid, resolvedClientUuid, rows.size(), phantomTotal);
+        return PhantomDerivationStatus.ATTRIBUTED;
+    }
+
+    /** Read the in-scope phantom uuids in a short transaction (called via self proxy). */
+    @Transactional
+    public List<String> listInScopeUuids() {
+        LocalDate fyStart = DateUtils.getCurrentFiscalStartDate();
+        LocalDate fyEnd = fyStart.plusYears(1);
+        return Invoice.<Invoice>list("type = ?1 and status = ?2",
+                        InvoiceType.PHANTOM, InvoiceStatus.CREATED)
+                .stream()
+                .filter(p -> isInScope(p, fyStart, fyEnd))
+                .map(Invoice::getUuid)
+                .toList();
+    }
+
+    /**
+     * Derive attribution for every in-scope phantom. Per-phantom failures are
+     * logged and counted but never abort the run (each derive is REQUIRES_NEW).
+     * Returns a status histogram for logging.
+     */
+    public Map<PhantomDerivationStatus, Integer> deriveAllInScope() {
+        List<String> uuids = self.listInScopeUuids();
+        Map<PhantomDerivationStatus, Integer> counts = new EnumMap<>(PhantomDerivationStatus.class);
+        for (String uuid : uuids) {
+            try {
+                counts.merge(self.deriveForPhantom(uuid), 1, Integer::sum);
+            } catch (RuntimeException e) {
+                log.errorf(e, "deriveForPhantom failed for phantom=%s", uuid);
+            }
+        }
+        log.infof("deriveAllInScope: processed=%d result=%s", uuids.size(), counts);
+        return counts;
+    }
+
+    /** Test/diagnostic passthrough to the work query. */
+    List<ConsultantWorkRevenue> findWork(String clientUuid, int year, int month) {
+        return workService.findRevenueByClientAndMonth(clientUuid, year, month);
+    }
+
+    private static String trimToNull(String s) {
+        if (s == null) return null;
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionService.java
@@ -4,15 +4,21 @@ import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
 import dk.trustworks.intranet.aggregates.invoice.model.InvoiceItem;
 import dk.trustworks.intranet.aggregates.invoice.model.InvoiceItemAttribution;
 import dk.trustworks.intranet.aggregates.invoice.model.PhantomClientMap;
+import dk.trustworks.intranet.aggregates.invoice.model.dto.PhantomAttributionReviewDTO;
+import dk.trustworks.intranet.aggregates.invoice.model.dto.PhantomClientSuggestion;
 import dk.trustworks.intranet.aggregates.invoice.model.enums.AttributionSource;
 import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceStatus;
 import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceType;
 import dk.trustworks.intranet.aggregates.invoice.model.enums.PhantomDerivationStatus;
+import dk.trustworks.intranet.aggregates.invoice.resources.dto.PhantomClientMapRequest;
+import dk.trustworks.intranet.dao.crm.model.Client;
 import dk.trustworks.intranet.dao.workservice.services.WorkService;
 import dk.trustworks.intranet.dto.work.ConsultantWorkRevenue;
 import dk.trustworks.intranet.utils.DateUtils;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Tuple;
 import jakarta.transaction.Transactional;
 import lombok.extern.jbosslog.JBossLog;
 
@@ -54,6 +60,12 @@ public class PhantomAttributionService {
      */
     @Inject
     PhantomAttributionService self;
+
+    @Inject
+    EntityManager em;
+
+    @Inject
+    PhantomClientResolver phantomClientResolver;
 
     /** Per-consultant work aggregate for a client+month. */
     public record WorkAgg(BigDecimal hours, BigDecimal revenue) {}
@@ -268,6 +280,125 @@ public class PhantomAttributionService {
     /** Test/diagnostic passthrough to the work query. */
     List<ConsultantWorkRevenue> findWork(String clientUuid, int year, int month) {
         return workService.findRevenueByClientAndMonth(clientUuid, year, month);
+    }
+
+    /**
+     * Build the review queue: in-scope phantoms with ZERO attribution rows,
+     * grouped by clientname label, with the current mapping state and (when
+     * unmapped) an auto-suggestion. Labels marked excluded are omitted.
+     */
+    @Transactional
+    public List<PhantomAttributionReviewDTO> buildReviewQueue() {
+        LocalDate fyStart = DateUtils.getCurrentFiscalStartDate();
+        LocalDate fyEnd = fyStart.plusYears(1);
+
+        @SuppressWarnings("unchecked")
+        List<Tuple> rows = em.createNativeQuery("""
+                SELECT i.clientname AS clientname, COUNT(*) AS cnt, SUM(t.total) AS total
+                FROM invoices i
+                JOIN (SELECT ii.invoiceuuid AS invoiceuuid, SUM(ABS(ii.hours * ii.rate)) AS total
+                      FROM invoiceitems ii GROUP BY ii.invoiceuuid) t ON t.invoiceuuid = i.uuid
+                WHERE i.type = 'PHANTOM' AND i.status = 'CREATED' AND i.internal_invoice_skip = 0
+                  AND (MAKEDATE(i.year, 1) + INTERVAL (i.month - 1) MONTH) >= :fyStart
+                  AND (MAKEDATE(i.year, 1) + INTERVAL (i.month - 1) MONTH) <  :fyEnd
+                  AND NOT EXISTS (
+                      SELECT 1 FROM invoice_item_attributions a
+                      JOIN invoiceitems ii2 ON a.invoiceitem_uuid = ii2.uuid
+                      WHERE ii2.invoiceuuid = i.uuid)
+                GROUP BY i.clientname
+                ORDER BY total DESC
+                """, Tuple.class)
+                .setParameter("fyStart", fyStart)
+                .setParameter("fyEnd", fyEnd)
+                .getResultList();
+
+        List<PhantomAttributionReviewDTO> queue = new ArrayList<>();
+        for (Tuple r : rows) {
+            String clientname = r.get("clientname", String.class);
+            long cnt = ((Number) r.get("cnt")).longValue();
+            BigDecimal total = r.get("total") == null ? BigDecimal.ZERO : new BigDecimal(r.get("total").toString());
+
+            PhantomClientMap map = PhantomClientMap.findById(clientname);
+            if (map != null && map.excluded) {
+                continue; // excluded -> not in the queue
+            }
+            String mappedClientUuid = map != null ? trimToNull(map.clientUuid) : null;
+            String mappedClientName = null;
+            PhantomClientSuggestion suggestion;
+            if (mappedClientUuid != null) {
+                Client c = Client.findById(mappedClientUuid);
+                mappedClientName = c != null ? c.getName() : null;
+                suggestion = PhantomClientSuggestion.none(); // mapped already (likely NO_WORK)
+            } else {
+                suggestion = phantomClientResolver.suggest(clientname);
+            }
+            queue.add(new PhantomAttributionReviewDTO(
+                    clientname, cnt, total, mappedClientUuid, mappedClientName, false, suggestion));
+        }
+        return queue;
+    }
+
+    /** Upsert one label->client mapping in its own committed transaction. */
+    @Transactional
+    public void upsertClientMap(PhantomClientMapRequest req, String userUuid) {
+        boolean excluded = req.excluded() != null && req.excluded();
+        String clientUuid = excluded ? null : trimToNull(req.clientUuid());
+        LocalDateTime now = LocalDateTime.now();
+
+        PhantomClientMap map = PhantomClientMap.findById(req.clientname());
+        if (map == null) {
+            map = new PhantomClientMap(req.clientname(), clientUuid, excluded, req.note(), userUuid);
+            map.persist();
+        } else {
+            map.clientUuid = clientUuid;
+            map.excluded = excluded;
+            map.note = req.note();
+            map.confirmedBy = userUuid;
+            map.confirmedAt = now;
+            map.updatedAt = now;
+        }
+    }
+
+    /**
+     * Confirm/exclude a label, then re-derive every in-scope phantom with that
+     * label. The mapping is committed first (via the self proxy) so the
+     * REQUIRES_NEW derives see it. Returns the re-derive status histogram.
+     */
+    public Map<PhantomDerivationStatus, Integer> upsertClientMapAndRederive(
+            PhantomClientMapRequest req, String userUuid) {
+        self.upsertClientMap(req, userUuid); // committed
+        if (req.excluded() != null && req.excluded()) {
+            return new EnumMap<>(PhantomDerivationStatus.class); // excluded -> nothing to derive
+        }
+        return rederiveLabel(req.clientname());
+    }
+
+    /** Re-derive all in-scope phantoms carrying {@code clientname}. */
+    public Map<PhantomDerivationStatus, Integer> rederiveLabel(String clientname) {
+        List<String> uuids = self.listInScopeUuidsForLabel(clientname);
+        Map<PhantomDerivationStatus, Integer> counts = new EnumMap<>(PhantomDerivationStatus.class);
+        for (String uuid : uuids) {
+            try {
+                counts.merge(self.deriveForPhantom(uuid), 1, Integer::sum);
+            } catch (RuntimeException e) {
+                log.errorf(e, "rederiveLabel: derive failed for phantom=%s", uuid);
+            }
+        }
+        log.infof("rederiveLabel '%s': %s", clientname, counts);
+        return counts;
+    }
+
+    /** In-scope phantom uuids for one label (read via self proxy for a session). */
+    @Transactional
+    public List<String> listInScopeUuidsForLabel(String clientname) {
+        LocalDate fyStart = DateUtils.getCurrentFiscalStartDate();
+        LocalDate fyEnd = fyStart.plusYears(1);
+        return Invoice.<Invoice>list("type = ?1 and status = ?2 and clientname = ?3",
+                        InvoiceType.PHANTOM, InvoiceStatus.CREATED, clientname)
+                .stream()
+                .filter(p -> isInScope(p, fyStart, fyEnd))
+                .map(Invoice::getUuid)
+                .toList();
     }
 
     private static String trimToNull(String s) {

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionService.java
@@ -49,7 +49,8 @@ public class PhantomAttributionService {
      * Self-injection so deriveAllInScope() invokes deriveForPhantom() / the
      * read through the CDI client proxy — required for @Transactional(REQUIRES_NEW)
      * and @Transactional to engage (a plain this.method() self-call bypasses the
-     * interceptor). Mirrors the per-voucher isolation in EconomicRevenueImportService.
+     * Arc interceptor, leaving the nested transaction a no-op). This gives each
+     * phantom its own transaction so one failure cannot roll back the whole batch.
      */
     @Inject
     PhantomAttributionService self;
@@ -67,6 +68,11 @@ public class PhantomAttributionService {
         if (inv.getType() != InvoiceType.PHANTOM) return false;
         if (inv.getStatus() != InvoiceStatus.CREATED) return false;
         if (inv.internalInvoiceSkip) return false;
+        // Guard a malformed period (e.g. an unset month=0 on a manually-created
+        // phantom): an out-of-range month/year would make LocalDate.of throw, and
+        // because isInScope runs inside listInScopeUuids()'s stream filter — OUTSIDE
+        // deriveAllInScope()'s per-phantom try/catch — that would abort the whole batch.
+        if (inv.getYear() < 1 || inv.getMonth() < 1 || inv.getMonth() > 12) return false;
         LocalDate period = LocalDate.of(inv.getYear(), inv.getMonth(), 1);
         return !period.isBefore(fyStart) && period.isBefore(fyEnd);
     }
@@ -156,12 +162,18 @@ public class PhantomAttributionService {
             return PhantomDerivationStatus.OUT_OF_SCOPE;
         }
 
-        InvoiceItem item = phantom.getInvoiceitems() == null
-                ? null
-                : phantom.getInvoiceitems().stream().findFirst().orElse(null);
+        List<InvoiceItem> items = phantom.getInvoiceitems();
+        InvoiceItem item = (items == null) ? null : items.stream().findFirst().orElse(null);
         if (item == null) {
             log.warnf("deriveForPhantom: phantom has no invoiceitem uuid=%s", invoiceUuid);
             return PhantomDerivationStatus.NO_WORK;
+        }
+        if (items.size() > 1) {
+            // Auto-imported phantoms carry exactly one item; a multi-item phantom can
+            // only come from the manual createPhantomInvoice path. Surface the unexpected
+            // shape — attribution uses only the first item's total.
+            log.warnf("deriveForPhantom: phantom uuid=%s has %d invoiceitems; attributing only the first",
+                    invoiceUuid, items.size());
         }
 
         // Preserve MANUAL overrides (decision #7): recalc amount only, never replace.

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomClientResolver.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomClientResolver.java
@@ -1,0 +1,32 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.model.dto.PhantomClientSuggestion;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Proposes a real client for a phantom clientname label (an e-conomic account
+ * label). Used ONLY to populate the review queue; an admin confirms before any
+ * mapping is written. Never auto-applies.
+ */
+@ApplicationScoped
+public class PhantomClientResolver {
+
+    /** Known revenue-account prefixes stripped before matching (case-insensitive). */
+    static final List<String> KNOWN_PREFIXES = List.of("Konsulenthonorar ", "Salg ");
+
+    /** Strip a known revenue-account prefix and trim. Null/blank -> "". Pure. */
+    static String stripKnownPrefixes(String raw) {
+        if (raw == null) return "";
+        String s = raw.trim();
+        if (s.isEmpty()) return "";
+        for (String prefix : KNOWN_PREFIXES) {
+            if (s.regionMatches(true, 0, prefix, 0, prefix.length())) {
+                return s.substring(prefix.length()).trim();
+            }
+        }
+        return s;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomClientResolver.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomClientResolver.java
@@ -54,10 +54,13 @@ public class PhantomClientResolver {
         }
 
         // 3. Last-resort substring/contains over all clients (low confidence).
+        //    Returns the first active client (DB order) whose name contains the
+        //    label. A "found" suggestion must carry a real uuid, so a name match
+        //    with a null uuid is skipped rather than returned as a candidate.
         String needle = stripped.toLowerCase(Locale.ROOT);
         for (Client c : clientService.findByActiveTrue()) {
             String name = c.getName();
-            if (name != null && name.toLowerCase(Locale.ROOT).contains(needle)) {
+            if (name != null && c.getUuid() != null && name.toLowerCase(Locale.ROOT).contains(needle)) {
                 return new PhantomClientSuggestion(c.getUuid(), c.getName(), 0.5, SuggestionMethod.CONTAINS);
             }
         }

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomClientResolver.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomClientResolver.java
@@ -1,10 +1,15 @@
 package dk.trustworks.intranet.aggregates.invoice.services;
 
 import dk.trustworks.intranet.aggregates.invoice.model.dto.PhantomClientSuggestion;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.SuggestionMethod;
+import dk.trustworks.intranet.dao.crm.model.Client;
+import dk.trustworks.intranet.dao.crm.services.ClientService;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * Proposes a real client for a phantom clientname label (an e-conomic account
@@ -16,6 +21,49 @@ public class PhantomClientResolver {
 
     /** Known revenue-account prefixes stripped before matching (case-insensitive). */
     static final List<String> KNOWN_PREFIXES = List.of("Konsulenthonorar ", "Salg ");
+
+    private final ClientService clientService;
+
+    @Inject
+    public PhantomClientResolver(ClientService clientService) {
+        this.clientService = clientService;
+    }
+
+    /**
+     * Suggest a client for a phantom label. Order: prefix-strip, then
+     * exact (case-insensitive), then Jaro-Winkler fuzzy, then substring/contains.
+     */
+    public PhantomClientSuggestion suggest(String clientname) {
+        String stripped = stripKnownPrefixes(clientname);
+        if (stripped.isEmpty()) {
+            return PhantomClientSuggestion.none();
+        }
+
+        // 1. Exact (case-insensitive) on the stripped remainder.
+        Client exact = clientService.findByExactNameIgnoreCase(stripped);
+        if (exact != null) {
+            return new PhantomClientSuggestion(exact.getUuid(), exact.getName(), 1.0, SuggestionMethod.EXACT);
+        }
+
+        // 2. Fuzzy (Jaro-Winkler) via ClientService (>= 0.90 threshold).
+        Optional<Client> fuzzy = clientService.findFuzzyMatch(stripped);
+        if (fuzzy.isPresent()) {
+            Client c = fuzzy.get();
+            // ClientService already enforces the 0.90 threshold; report a representative confidence.
+            return new PhantomClientSuggestion(c.getUuid(), c.getName(), 0.90, SuggestionMethod.FUZZY);
+        }
+
+        // 3. Last-resort substring/contains over all clients (low confidence).
+        String needle = stripped.toLowerCase(Locale.ROOT);
+        for (Client c : clientService.findByActiveTrue()) {
+            String name = c.getName();
+            if (name != null && name.toLowerCase(Locale.ROOT).contains(needle)) {
+                return new PhantomClientSuggestion(c.getUuid(), c.getName(), 0.5, SuggestionMethod.CONTAINS);
+            }
+        }
+
+        return PhantomClientSuggestion.none();
+    }
 
     /** Strip a known revenue-account prefix and trim. Null/blank -> "". Pure. */
     static String stripKnownPrefixes(String raw) {

--- a/src/main/java/dk/trustworks/intranet/dao/workservice/services/WorkService.java
+++ b/src/main/java/dk/trustworks/intranet/dao/workservice/services/WorkService.java
@@ -5,6 +5,7 @@ import dk.trustworks.intranet.dao.crm.services.ProjectService;
 import dk.trustworks.intranet.dao.workservice.model.Work;
 import dk.trustworks.intranet.dao.workservice.model.WorkFull;
 import dk.trustworks.intranet.dto.DateValueDTO;
+import dk.trustworks.intranet.dto.work.ConsultantWorkRevenue;
 import dk.trustworks.intranet.utils.DateUtils;
 import io.quarkus.cache.CacheInvalidateAll;
 import io.quarkus.panache.common.Page;
@@ -271,6 +272,50 @@ public class WorkService {
                         tuple.get("date", LocalDate.class).withDayOfMonth(1),
                         (Double) tuple.get("value")
                 )).toList();
+    }
+
+    /**
+     * Per-consultant registered work for a client in a single calendar month,
+     * read off the work_full view (clientuuid + contract rate pre-resolved).
+     * Returns hours (Σ workduration) and revenue (Σ workduration × rate),
+     * one row per useruuid. Filters workduration > 0 (rate = 0 rows still
+     * contribute hours, for the hours-fallback basis upstream).
+     *
+     * @param clientUuid resolved client uuid
+     * @param year       calendar year of the period
+     * @param month      calendar month (1–12)
+     */
+    @SuppressWarnings("unchecked")
+    public List<ConsultantWorkRevenue> findRevenueByClientAndMonth(String clientUuid, int year, int month) {
+        LocalDate periodStart = LocalDate.of(year, month, 1);
+        LocalDate periodEnd = periodStart.plusMonths(1);
+
+        String sql = "SELECT wf.useruuid AS useruuid, " +
+                "       SUM(wf.workduration)               AS hours, " +
+                "       SUM(wf.workduration * wf.rate)     AS revenue " +
+                "FROM work_full wf " +
+                "WHERE wf.clientuuid = :clientUuid " +
+                "  AND wf.registered >= :periodStart " +
+                "  AND wf.registered <  :periodEnd " +
+                "  AND wf.workduration > 0 " +
+                "GROUP BY wf.useruuid";
+
+        return ((List<Tuple>) em.createNativeQuery(sql, Tuple.class)
+                .setParameter("clientUuid", clientUuid)
+                .setParameter("periodStart", periodStart)
+                .setParameter("periodEnd", periodEnd)
+                .getResultList()).stream()
+                .map(t -> new ConsultantWorkRevenue(
+                        t.get("useruuid", String.class),
+                        toBigDecimal(t.get("hours")),
+                        toBigDecimal(t.get("revenue"))))
+                .toList();
+    }
+
+    private static java.math.BigDecimal toBigDecimal(Object o) {
+        if (o == null) return java.math.BigDecimal.ZERO;
+        if (o instanceof java.math.BigDecimal bd) return bd;
+        return new java.math.BigDecimal(((Number) o).toString());
     }
 
     public DateValueDTO findWorkRevenueByUserAndDay(String useruuid, LocalDate day) {

--- a/src/main/java/dk/trustworks/intranet/dto/work/ConsultantWorkRevenue.java
+++ b/src/main/java/dk/trustworks/intranet/dto/work/ConsultantWorkRevenue.java
@@ -1,0 +1,17 @@
+package dk.trustworks.intranet.dto.work;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.math.BigDecimal;
+
+/**
+ * Per-consultant aggregate of registered work for a client in a month:
+ * {@code hours} = Σ workduration, {@code revenue} = Σ (workduration × rate).
+ * Produced by {@code WorkService.findRevenueByClientAndMonth}.
+ */
+@RegisterForReflection
+public record ConsultantWorkRevenue(
+        String useruuid,
+        BigDecimal hours,
+        BigDecimal revenue
+) {}

--- a/src/main/resources/db/migration/V362__Create_phantom_client_map.sql
+++ b/src/main/resources/db/migration/V362__Create_phantom_client_map.sql
@@ -1,0 +1,59 @@
+-- =============================================================================
+-- Migration V362: Create phantom_client_map
+--
+-- Purpose:
+--   Maps a recurring phantom clientname (an e-conomic account label such as
+--   'Konsulenthonorar Vattenfall') to a real client, or marks it excluded
+--   (e.g. canteen). One row per distinct label. Drives nightly phantom
+--   attribution (PhantomAttributionService).
+--
+-- New table:
+--   phantom_client_map (clientname PK, client_uuid, excluded, note,
+--                       confirmed_by, confirmed_at, created_at, updated_at)
+--
+-- Backwards compatibility:
+--   Additive only (new table). No existing table/column altered or dropped.
+--   Inert until PhantomAttributionService (later phase) reads it.
+--
+-- Soft FKs:
+--   client_uuid -> client.uuid and confirmed_by -> user.uuid are soft FKs
+--   (project convention: no cross-service FK constraints).
+--
+-- Affected Java:
+--   dk.trustworks.intranet.aggregates.invoice.model.PhantomClientMap
+--   dk.trustworks.intranet.aggregates.invoice.services.PhantomAttributionService (later phase)
+--
+-- Idempotency:
+--   CREATE TABLE is not re-runnable; Flyway versioning guarantees single apply.
+--
+-- Rollback strategy (manual — Flyway does not auto-rollback DDL):
+--   DROP TABLE phantom_client_map;
+-- =============================================================================
+
+CREATE TABLE phantom_client_map (
+    clientname    VARCHAR(255) NOT NULL,            -- the phantom label (PK)
+    client_uuid   VARCHAR(36)  DEFAULT NULL,        -- resolved client (soft FK -> client.uuid); NULL when excluded/unset
+    excluded      TINYINT(1)   NOT NULL DEFAULT 0,  -- 1 = known non-client label, never attribute (e.g. kantine)
+    note          VARCHAR(500) DEFAULT NULL,
+    confirmed_by  VARCHAR(36)  DEFAULT NULL,        -- user uuid who confirmed (soft FK -> user.uuid)
+    confirmed_at  DATETIME     DEFAULT NULL,
+    created_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (clientname),
+    INDEX idx_pcm_client (client_uuid)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -----------------------------------------------------------------------------
+-- Validation queries (run manually after deploy; not executed by Flyway):
+--
+-- 1. Table exists with the right columns:
+--    SELECT column_name, data_type, is_nullable, column_default
+--    FROM information_schema.columns
+--    WHERE table_name = 'phantom_client_map' ORDER BY ordinal_position;
+--
+-- 2. Empty on first deploy:
+--    SELECT COUNT(*) AS should_be_zero FROM phantom_client_map;
+--
+-- 3. PK + index present:
+--    SHOW INDEX FROM phantom_client_map;
+-- -----------------------------------------------------------------------------

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/model/PhantomClientMapTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/model/PhantomClientMapTest.java
@@ -1,0 +1,36 @@
+package dk.trustworks.intranet.aggregates.invoice.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Pure POJO test — no CDI, no DB. */
+class PhantomClientMapTest {
+
+    @Test
+    void resolvedMapping_setsClientAndTimestamps() {
+        PhantomClientMap m = new PhantomClientMap(
+                "Konsulenthonorar Vattenfall",
+                "2cbb7f5e-1111-2222-3333-444455556666",
+                false,
+                "confirmed by accounting",
+                "user-uuid-1");
+
+        assertEquals("Konsulenthonorar Vattenfall", m.clientname);
+        assertEquals("2cbb7f5e-1111-2222-3333-444455556666", m.clientUuid);
+        assertFalse(m.excluded);
+        assertEquals("user-uuid-1", m.confirmedBy);
+        assertNotNull(m.confirmedAt);
+        assertNotNull(m.createdAt);
+        assertNotNull(m.updatedAt);
+    }
+
+    @Test
+    void excludedMapping_hasNoClient() {
+        PhantomClientMap m = new PhantomClientMap(
+                "Salg kantineordning", null, true, "canteen, not a client", "user-uuid-1");
+
+        assertTrue(m.excluded);
+        assertNull(m.clientUuid);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceServiceLegacyPhantomGuardTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceServiceLegacyPhantomGuardTest.java
@@ -1,0 +1,44 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceType;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Pure (no-DB, no-CDI) unit test that the legacy {@code createInternalInvoiceDraft} entry
+ * point still rejects PHANTOM sources after Phase 5 lifted the PHANTOM guard from the shared
+ * {@code createAllInternalFromAttribution}. Phantom internal invoicing must go through the
+ * dedicated internal-invoice preview / create-all flow, not this legacy endpoint.
+ *
+ * <p>Constructs {@link InvoiceService} directly and sets the (package-private) feature flag to
+ * the production default so the attribution-driven branch — the one that previously 400'd on
+ * PHANTOM via the now-lifted guard — is taken. The re-asserted guard throws before any injected
+ * collaborator or DB access, so no Quarkus context / database is required: this is a deterministic
+ * gate that runs under {@code ./mvnw test} everywhere (unlike the DB-backed
+ * {@link InvoiceServicePhantomGuardTest}). A regression that drops the guard would fail here.
+ */
+class InvoiceServiceLegacyPhantomGuardTest {
+
+    private InvoiceService attributionDrivenService() {
+        InvoiceService service = new InvoiceService();
+        service.attributionDrivenInternalInvoices = true; // production default; selects the guarded branch
+        return service;
+    }
+
+    @Test
+    void createInternalInvoiceDraft_onPhantom_throws400() {
+        InvoiceService service = attributionDrivenService();
+        Invoice phantom = new Invoice();
+        phantom.type = InvoiceType.PHANTOM;
+
+        WebApplicationException ex = assertThrows(WebApplicationException.class,
+                () -> service.createInternalInvoiceDraft("any-company-uuid", phantom));
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ex.getResponse().getStatus(),
+                "legacy createInternalInvoiceDraft must reject a PHANTOM source with 400");
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceServicePhantomGuardTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceServicePhantomGuardTest.java
@@ -1,0 +1,97 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.dto.InternalInvoicePreview;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Integration smoke test for the Phase 5 guard lift: a {@code PHANTOM} source invoice must
+ * no longer return {@code 400} from the internal-preview / create-all-internal flow.
+ *
+ * <p>This is a {@link QuarkusTest}, so it boots against the configured MariaDB and only
+ * exercises real behavior when a {@code CREATED} phantom exists in that database. When none
+ * is present (e.g. no local DB) the tests are {@code assumeTrue}-skipped — never silently
+ * reported as a green PASS. The real end-to-end gate is the staging probe in the plan's
+ * Task 4 (call {@code internal-preview} on a real phantom and confirm {@code 200}, and for a
+ * mapped phantom that the FIRST call already returns non-empty issuers — proving the
+ * REQUIRES_NEW re-read fix).
+ */
+@QuarkusTest
+@TestProfile(InvoiceServicePhantomGuardTest.BootProfile.class)
+class InvoiceServicePhantomGuardTest {
+
+    /**
+     * Minimal overrides so the CDI context boots in tests (S3 dev services off, placeholder
+     * cvtool credentials). Note: the {@code internal-preview}/{@code create-all-internal}
+     * methods under test do NOT read {@code feature.invoicing.internal.attribution-driven}
+     * (only the legacy {@code createInternalInvoiceDraft}/{@code autoCreateAndQueueInternal}
+     * entry points do), so no flag override is needed here.
+     */
+    public static class BootProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.s3.devservices.enabled", "false",
+                    "cvtool.username", "test-placeholder",
+                    "cvtool.password", "test-placeholder"
+            );
+        }
+    }
+
+    @Inject InvoiceService invoiceService;
+    @Inject EntityManager em;
+
+    private String findCreatedPhantomUuid() {
+        @SuppressWarnings("unchecked")
+        List<String> uuids = em.createNativeQuery(
+                "SELECT uuid FROM invoices WHERE type = 'PHANTOM' AND status = 'CREATED' LIMIT 1")
+                .getResultList();
+        return uuids.isEmpty() ? null : uuids.get(0);
+    }
+
+    @Test
+    void previewInternal_onPhantom_doesNotThrow400() {
+        String uuid = findCreatedPhantomUuid();
+        assumeTrue(uuid != null, "no CREATED phantom in this DB — skipping (exercise via the staging probe)");
+
+        InternalInvoicePreview preview =
+                assertDoesNotThrow(() -> invoiceService.previewInternal(uuid, Set.of()));
+        assertNotNull(preview);
+        assertEquals(uuid, preview.sourceInvoiceUuid());
+        // issuers is present but may be empty (unmapped / no-work / excluded phantom). When it
+        // is non-empty, this single call also demonstrates that freshly-derived attribution is
+        // visible on the FIRST invocation (the REQUIRES_NEW re-read fix).
+        assertNotNull(preview.issuers(), "issuers list present (possibly empty)");
+    }
+
+    @Test
+    void createAll_onPhantomWithEmptyPreview_createsNothing_andDoesNotThrow() {
+        String uuid = findCreatedPhantomUuid();
+        assumeTrue(uuid != null, "no CREATED phantom in this DB — skipping (exercise via the staging probe)");
+
+        // NOTE: previewInternal may itself idempotently derive + commit AUTO attribution rows
+        // (and stamp billing_client_uuid) for a phantom that resolves to a client with work —
+        // this mirrors the non-phantom computeAttributions lazy-compute and is intended, not a
+        // leak. We only proceed to createAll when the preview yields NO issuers, so the create
+        // path materializes nothing in the shared DB.
+        InternalInvoicePreview preview = invoiceService.previewInternal(uuid, Set.of());
+        if (!preview.issuers().isEmpty()) {
+            // Phantom resolves to issuers — skip to avoid creating real internal invoices.
+            return;
+        }
+        List<String> created =
+                assertDoesNotThrow(() -> invoiceService.createAllInternalFromAttribution(uuid, null, false, Set.of()));
+        assertTrue(created.isEmpty(), "no issuers -> no internal invoices created");
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceServicePhantomGuardTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceServicePhantomGuardTest.java
@@ -6,6 +6,8 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -33,10 +35,11 @@ class InvoiceServicePhantomGuardTest {
 
     /**
      * Minimal overrides so the CDI context boots in tests (S3 dev services off, placeholder
-     * cvtool credentials). Note: the {@code internal-preview}/{@code create-all-internal}
-     * methods under test do NOT read {@code feature.invoicing.internal.attribution-driven}
-     * (only the legacy {@code createInternalInvoiceDraft}/{@code autoCreateAndQueueInternal}
-     * entry points do), so no flag override is needed here.
+     * cvtool credentials). {@code feature.invoicing.internal.attribution-driven=true} is set so
+     * {@code autoCreateAndQueueInternal} takes the attribution-driven branch — the one whose
+     * re-asserted PHANTOM guard this test exercises. The {@code internal-preview} /
+     * {@code create-all-internal} methods do not read that flag; it is only relevant to the
+     * legacy auto-create path.
      */
     public static class BootProfile implements QuarkusTestProfile {
         @Override
@@ -44,7 +47,8 @@ class InvoiceServicePhantomGuardTest {
             return Map.of(
                     "quarkus.s3.devservices.enabled", "false",
                     "cvtool.username", "test-placeholder",
-                    "cvtool.password", "test-placeholder"
+                    "cvtool.password", "test-placeholder",
+                    "feature.invoicing.internal.attribution-driven", "true"
             );
         }
     }
@@ -93,5 +97,20 @@ class InvoiceServicePhantomGuardTest {
         List<String> created =
                 assertDoesNotThrow(() -> invoiceService.createAllInternalFromAttribution(uuid, null, false, Set.of()));
         assertTrue(created.isEmpty(), "no issuers -> no internal invoices created");
+    }
+
+    @Test
+    void autoCreateAndQueueInternal_onPhantom_throws400() {
+        String uuid = findCreatedPhantomUuid();
+        assumeTrue(uuid != null, "no CREATED phantom in this DB — skipping (exercise via the staging probe)");
+
+        // The legacy auto-create endpoint must keep REJECTING PHANTOM (Phase 5 re-asserted the
+        // guard in its attribution-driven branch, since the shared createAllInternalFromAttribution
+        // no longer 400s on phantoms). The guard throws right after loading the phantom, before any
+        // derive/create — so this asserts the 400 with no side effects on the shared DB.
+        WebApplicationException ex = assertThrows(WebApplicationException.class,
+                () -> invoiceService.autoCreateAndQueueInternal(uuid, "any-issuer-company-uuid"));
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ex.getResponse().getStatus(),
+                "legacy autoCreateAndQueueInternal must reject a PHANTOM source with 400");
     }
 }

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionReviewTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionReviewTest.java
@@ -67,6 +67,19 @@ class PhantomAttributionReviewTest {
         }
     }
 
+    @Test
+    void rederiveLabel_onUnknownLabel_isEmptyNoOp() {
+        // Exercises the re-derive path wiring (resetAutoStateForLabel ->
+        // listInScopeUuidsForLabel -> derive loop) for a label with no phantoms:
+        // it must reset nothing, derive nothing, and return an empty histogram
+        // without throwing. The behavioral re-map correction (a label re-pointed
+        // from client A to B actually re-attributes to B) is verified by the
+        // staging API/SQL probe — it needs registered work for two clients.
+        Map<?, ?> result = service.rederiveLabel("ZZZ-phantom-test-label-" + System.identityHashCode(this));
+        assertNotNull(result);
+        assertTrue(result.isEmpty(), "no phantoms for an unknown label -> empty re-derive histogram");
+    }
+
     @Transactional
     void deleteMap(String clientname) {
         PhantomClientMap.deleteById(clientname);

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionReviewTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionReviewTest.java
@@ -1,0 +1,74 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.model.PhantomClientMap;
+import dk.trustworks.intranet.aggregates.invoice.model.dto.PhantomAttributionReviewDTO;
+import dk.trustworks.intranet.aggregates.invoice.resources.dto.PhantomClientMapRequest;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(PhantomAttributionReviewTest.NoDevServicesProfile.class)
+class PhantomAttributionReviewTest {
+
+    public static class NoDevServicesProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.s3.devservices.enabled", "false",
+                    "cvtool.username", "test-placeholder",
+                    "cvtool.password", "test-placeholder"
+            );
+        }
+    }
+
+    @Inject PhantomAttributionService service;
+
+    @Test
+    void reviewQueue_isWellFormed() {
+        List<PhantomAttributionReviewDTO> queue = service.buildReviewQueue();
+        assertNotNull(queue);
+        for (PhantomAttributionReviewDTO dto : queue) {
+            assertNotNull(dto.clientname());
+            assertTrue(dto.phantomCount() >= 1, "queue rows have at least one unattributed phantom");
+            assertNotNull(dto.totalAmount());
+            assertNotNull(dto.suggestion(), "suggestion is never null (NONE when unavailable)");
+            assertFalse(dto.excluded(), "excluded labels are omitted from the queue");
+        }
+    }
+
+    @Test
+    void excludingALabel_removesItFromTheQueue() {
+        String tempLabel = "ZZZ-phantom-test-label-" + System.identityHashCode(this);
+        try {
+            // exclude a (non-existent-phantom) label; re-derive returns empty.
+            Map<?, ?> result = service.upsertClientMapAndRederive(
+                    new PhantomClientMapRequest(tempLabel, null, true, "test exclude"), "test-user");
+            assertTrue(result.isEmpty(), "excluded label has nothing to derive");
+
+            PhantomClientMap map = PhantomClientMap.findById(tempLabel);
+            assertNotNull(map);
+            assertTrue(map.excluded);
+            assertNull(map.clientUuid);
+            assertEquals("test-user", map.confirmedBy);
+
+            // the excluded label must not appear in the queue
+            assertTrue(service.buildReviewQueue().stream().noneMatch(d -> d.clientname().equals(tempLabel)));
+        } finally {
+            deleteMap(tempLabel);
+        }
+    }
+
+    @Transactional
+    void deleteMap(String clientname) {
+        PhantomClientMap.deleteById(clientname);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionServiceMathTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionServiceMathTest.java
@@ -1,0 +1,111 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceStatus;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceType;
+import dk.trustworks.intranet.aggregates.invoice.services.PhantomAttributionService.ShareRow;
+import dk.trustworks.intranet.aggregates.invoice.services.PhantomAttributionService.WorkAgg;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Pure unit test — no CDI, no DB. Covers AC2, AC9-math, AC10, residual. */
+class PhantomAttributionServiceMathTest {
+
+    private static final LocalDate FY_START = LocalDate.of(2025, 7, 1);
+    private static final LocalDate FY_END = LocalDate.of(2026, 7, 1);
+
+    private static Map<String, WorkAgg> work(Object... triples) {
+        Map<String, WorkAgg> m = new LinkedHashMap<>();
+        for (int i = 0; i < triples.length; i += 3) {
+            m.put((String) triples[i],
+                    new WorkAgg(BigDecimal.valueOf(((Number) triples[i + 1]).doubleValue()),
+                                BigDecimal.valueOf(((Number) triples[i + 2]).doubleValue())));
+        }
+        return m;
+    }
+
+    @Test
+    void revenueBasis_proportionalToRevenue() {
+        // a: 30h @ revenue 3000 ; b: 10h @ revenue 1000 ; total 4000
+        Map<String, WorkAgg> w = work("a", 30, 3000, "b", 10, 1000);
+        List<ShareRow> rows = PhantomAttributionService.computeShares(w, new BigDecimal("4000.00"));
+
+        ShareRow a = rows.stream().filter(r -> r.consultantUuid().equals("a")).findFirst().orElseThrow();
+        ShareRow b = rows.stream().filter(r -> r.consultantUuid().equals("b")).findFirst().orElseThrow();
+        assertEquals(0, a.sharePct().compareTo(new BigDecimal("75.0000")));
+        assertEquals(0, b.sharePct().compareTo(new BigDecimal("25.0000")));
+        assertEquals(0, a.attributedAmount().compareTo(new BigDecimal("3000.00")));
+        assertEquals(0, b.attributedAmount().compareTo(new BigDecimal("1000.00")));
+        assertEquals(0, a.originalHours().compareTo(new BigDecimal("30.00")));
+    }
+
+    @Test
+    void hoursFallback_whenAllRevenueZero() {
+        // revenue all 0 -> fall back to hours (30 vs 10)
+        Map<String, WorkAgg> w = work("a", 30, 0, "b", 10, 0);
+        List<ShareRow> rows = PhantomAttributionService.computeShares(w, new BigDecimal("4000.00"));
+
+        ShareRow a = rows.stream().filter(r -> r.consultantUuid().equals("a")).findFirst().orElseThrow();
+        assertEquals(0, a.sharePct().compareTo(new BigDecimal("75.0000")));
+        assertEquals(0, a.attributedAmount().compareTo(new BigDecimal("3000.00")));
+    }
+
+    @Test
+    void residualAbsorbed_sumEqualsPhantomTotalExactly() {
+        // three equal consultants on 100.00 -> 33.33 each = 99.99 ; +0.01 residual to smallest uuid
+        Map<String, WorkAgg> w = work("a", 1, 1, "b", 1, 1, "c", 1, 1);
+        BigDecimal total = new BigDecimal("100.00");
+        List<ShareRow> rows = PhantomAttributionService.computeShares(w, total);
+
+        BigDecimal sum = rows.stream().map(ShareRow::attributedAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertEquals(0, sum.compareTo(total), "amounts must sum exactly to the phantom total");
+
+        ShareRow a = rows.stream().filter(r -> r.consultantUuid().equals("a")).findFirst().orElseThrow();
+        assertEquals(0, a.attributedAmount().compareTo(new BigDecimal("33.34")),
+                "residual goes to the smallest-uuid largest-share consultant");
+    }
+
+    @Test
+    void singleConsultant_getsFullTotal() {
+        List<ShareRow> rows = PhantomAttributionService.computeShares(
+                work("solo", 12, 500), new BigDecimal("12345.67"));
+        assertEquals(1, rows.size());
+        assertEquals(0, rows.get(0).sharePct().compareTo(new BigDecimal("100.0000")));
+        assertEquals(0, rows.get(0).attributedAmount().compareTo(new BigDecimal("12345.67")));
+    }
+
+    @Test
+    void noWork_emptyResult() {
+        assertTrue(PhantomAttributionService.computeShares(Map.of(), new BigDecimal("100.00")).isEmpty());
+        // all weights zero -> empty
+        assertTrue(PhantomAttributionService.computeShares(
+                work("a", 0, 0), new BigDecimal("100.00")).isEmpty());
+    }
+
+    @Test
+    void scope_currentFyCreatedPhantomOnly() {
+        assertTrue(PhantomAttributionService.isInScope(phantom(InvoiceType.PHANTOM, InvoiceStatus.CREATED, 2025, 9, false), FY_START, FY_END));
+        assertFalse(PhantomAttributionService.isInScope(phantom(InvoiceType.PHANTOM, InvoiceStatus.CREATED, 2025, 3, false), FY_START, FY_END), "prior FY out");
+        assertFalse(PhantomAttributionService.isInScope(phantom(InvoiceType.INVOICE, InvoiceStatus.CREATED, 2025, 9, false), FY_START, FY_END), "non-phantom out");
+        assertFalse(PhantomAttributionService.isInScope(phantom(InvoiceType.PHANTOM, InvoiceStatus.DRAFT, 2025, 9, false), FY_START, FY_END), "non-CREATED out");
+        assertFalse(PhantomAttributionService.isInScope(phantom(InvoiceType.PHANTOM, InvoiceStatus.CREATED, 2025, 9, true), FY_START, FY_END), "skip-flagged out");
+    }
+
+    private static Invoice phantom(InvoiceType type, InvoiceStatus status, int year, int month, boolean skip) {
+        Invoice i = new Invoice();
+        i.type = type;
+        i.status = status;
+        i.year = year;
+        i.month = month;
+        i.internalInvoiceSkip = skip;
+        return i;
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionServiceMathTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionServiceMathTest.java
@@ -74,6 +74,76 @@ class PhantomAttributionServiceMathTest {
     }
 
     @Test
+    void residual_goesToLargestShare_notSmallestUuid() {
+        // a,b small (16.67% each), z large (66.67%); per-row rounding overshoots the
+        // total by 0.01, so the residual is NEGATIVE and must land on the LARGEST-share
+        // consultant z — NOT row 0 (the smallest uuid 'a'). The original equal-share
+        // residual test could not tell these apart (a buggy "always index 0" passes it).
+        Map<String, WorkAgg> w = work("a", 1, 1, "b", 1, 1, "z", 1, 4);
+        BigDecimal total = new BigDecimal("100.00");
+        List<ShareRow> rows = PhantomAttributionService.computeShares(w, total);
+
+        BigDecimal sum = rows.stream().map(ShareRow::attributedAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertEquals(0, sum.compareTo(total), "amounts must sum exactly to the phantom total");
+
+        ShareRow a = rows.stream().filter(r -> r.consultantUuid().equals("a")).findFirst().orElseThrow();
+        ShareRow z = rows.stream().filter(r -> r.consultantUuid().equals("z")).findFirst().orElseThrow();
+        assertEquals(0, z.attributedAmount().compareTo(new BigDecimal("66.66")),
+                "negative residual absorbed by the LARGEST-share consultant z — proves sharePct drives selection");
+        assertEquals(0, a.attributedAmount().compareTo(new BigDecimal("16.67")),
+                "the smallest-uuid (small-share) consultant keeps its rounded amount");
+    }
+
+    @Test
+    void residual_tieForLargestShare_goesToSmallerUuidOfTheTie() {
+        // a small (9.09%), m & z tie for the largest share (45.45% each); rounding
+        // undershoots by 0.01, so the +0.01 residual goes to the smaller-uuid member
+        // of the LARGEST-share tie (m), not to the global smallest uuid 'a'.
+        Map<String, WorkAgg> w = work("a", 1, 1, "m", 1, 5, "z", 1, 5);
+        BigDecimal total = new BigDecimal("100.00");
+        List<ShareRow> rows = PhantomAttributionService.computeShares(w, total);
+
+        BigDecimal sum = rows.stream().map(ShareRow::attributedAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertEquals(0, sum.compareTo(total), "amounts must sum exactly to the phantom total");
+
+        ShareRow a = rows.stream().filter(r -> r.consultantUuid().equals("a")).findFirst().orElseThrow();
+        ShareRow m = rows.stream().filter(r -> r.consultantUuid().equals("m")).findFirst().orElseThrow();
+        assertEquals(0, m.attributedAmount().compareTo(new BigDecimal("45.46")),
+                "tie among the largest share resolves to the smaller uuid (m)");
+        assertEquals(0, a.attributedAmount().compareTo(new BigDecimal("9.09")),
+                "the global-smallest uuid 'a' does NOT absorb the residual (it is not in the largest-share tie)");
+    }
+
+    @Test
+    void mixedRevenue_zeroRevenueConsultantGetsZeroShare() {
+        // Any positive total revenue => revenue basis; a consultant with revenue=0 is
+        // zero-weighted (0%), NOT hours-weighted. Pins the basis-switch boundary between
+        // the two extreme cases above.
+        Map<String, WorkAgg> w = work("a", 10, 1000, "b", 10, 0);
+        List<ShareRow> rows = PhantomAttributionService.computeShares(w, new BigDecimal("1000.00"));
+
+        ShareRow a = rows.stream().filter(r -> r.consultantUuid().equals("a")).findFirst().orElseThrow();
+        ShareRow b = rows.stream().filter(r -> r.consultantUuid().equals("b")).findFirst().orElseThrow();
+        assertEquals(0, a.sharePct().compareTo(new BigDecimal("100.0000")));
+        assertEquals(0, a.attributedAmount().compareTo(new BigDecimal("1000.00")));
+        assertEquals(0, b.sharePct().compareTo(new BigDecimal("0.0000")),
+                "revenue=0 consultant is zero-weighted under revenue basis");
+        assertEquals(0, b.attributedAmount().compareTo(new BigDecimal("0.00")));
+    }
+
+    @Test
+    void scope_malformedPeriodIsOutOfScope() {
+        // An unset/garbage month (int default 0, or >12) or year<1 would make
+        // LocalDate.of throw; isInScope must treat these as out-of-scope so a single
+        // malformed phantom cannot abort the whole deriveAllInScope batch.
+        assertFalse(PhantomAttributionService.isInScope(phantom(InvoiceType.PHANTOM, InvoiceStatus.CREATED, 2025, 0, false), FY_START, FY_END), "month=0 out");
+        assertFalse(PhantomAttributionService.isInScope(phantom(InvoiceType.PHANTOM, InvoiceStatus.CREATED, 2025, 13, false), FY_START, FY_END), "month=13 out");
+        assertFalse(PhantomAttributionService.isInScope(phantom(InvoiceType.PHANTOM, InvoiceStatus.CREATED, 0, 9, false), FY_START, FY_END), "year=0 out");
+    }
+
+    @Test
     void singleConsultant_getsFullTotal() {
         List<ShareRow> rows = PhantomAttributionService.computeShares(
                 work("solo", 12, 500), new BigDecimal("12345.67"));

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomAttributionServiceTest.java
@@ -1,0 +1,139 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.model.InvoiceItemAttribution;
+import dk.trustworks.intranet.aggregates.invoice.model.PhantomClientMap;
+import dk.trustworks.intranet.aggregates.invoice.model.dto.PhantomClientSuggestion;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.AttributionSource;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.PhantomDerivationStatus;
+import dk.trustworks.intranet.dto.work.ConsultantWorkRevenue;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Tuple;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(PhantomAttributionServiceTest.NoDevServicesProfile.class)
+class PhantomAttributionServiceTest {
+
+    public static class NoDevServicesProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.s3.devservices.enabled", "false",
+                    "cvtool.username", "test-placeholder",
+                    "cvtool.password", "test-placeholder"
+            );
+        }
+    }
+
+    @Inject PhantomAttributionService service;
+    @Inject PhantomClientResolver resolver;
+    @Inject EntityManager em;
+
+    @Test
+    void deriveForPhantom_attributesAndSumsExactly_thenIdempotent() {
+        // Find a viable CREATED 'Konsulenthonorar%' phantom: resolver suggests a client
+        // AND that client has work in the phantom's month.
+        @SuppressWarnings("unchecked")
+        List<Tuple> phantoms = em.createNativeQuery("""
+                SELECT i.uuid AS uuid, i.clientname AS clientname, i.year AS yr, i.month AS mo,
+                       (SELECT ii.uuid FROM invoiceitems ii WHERE ii.invoiceuuid = i.uuid LIMIT 1) AS itemuuid,
+                       (SELECT ABS(ii.hours * ii.rate) FROM invoiceitems ii WHERE ii.invoiceuuid = i.uuid LIMIT 1) AS total
+                FROM invoices i
+                WHERE i.type = 'PHANTOM' AND i.status = 'CREATED'
+                  AND i.clientname LIKE 'Konsulenthonorar%'
+                ORDER BY i.year DESC, i.month DESC
+                LIMIT 25
+                """, Tuple.class).getResultList();
+
+        String pickUuid = null, pickItem = null, pickClient = null;
+        BigDecimal pickTotal = null;
+        for (Tuple t : phantoms) {
+            String clientname = t.get("clientname", String.class);
+            PhantomClientSuggestion s = resolver.suggest(clientname);
+            if (s.suggestedClientUuid() == null) continue;
+            int yr = ((Number) t.get("yr")).intValue();
+            int mo = ((Number) t.get("mo")).intValue();
+            List<ConsultantWorkRevenue> work =
+                    service.findWork(s.suggestedClientUuid(), yr, mo); // see helper below
+            if (work.isEmpty()) continue;
+            pickUuid = t.get("uuid", String.class);
+            pickItem = t.get("itemuuid", String.class);
+            pickClient = s.suggestedClientUuid();
+            pickTotal = t.get("total") == null ? null : new BigDecimal(t.get("total").toString());
+            break;
+        }
+        if (pickUuid == null) return; // no viable phantom locally — skip gracefully
+
+        // Capture + clean prior state, install a temp mapping.
+        String priorBilling = currentBillingClientUuid(pickUuid);
+        String clientname = clientnameOf(pickUuid);
+        cleanupAuto(pickItem);
+        upsertMap(clientname, pickClient);
+        try {
+            PhantomDerivationStatus st = service.deriveForPhantom(pickUuid);
+            assertEquals(PhantomDerivationStatus.ATTRIBUTED, st);
+
+            List<InvoiceItemAttribution> rows = InvoiceItemAttribution.list("invoiceitemUuid", pickItem);
+            assertFalse(rows.isEmpty());
+            assertTrue(rows.stream().allMatch(r -> r.source == AttributionSource.AUTO));
+            BigDecimal sum = rows.stream().map(r -> r.attributedAmount)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            assertEquals(0, sum.setScale(2).compareTo(pickTotal.setScale(2)),
+                    "attributed amounts must sum exactly to the phantom total");
+            assertEquals(pickClient, currentBillingClientUuid(pickUuid), "billing_client_uuid stamped");
+
+            int firstCount = rows.size();
+            assertEquals(PhantomDerivationStatus.ATTRIBUTED, service.deriveForPhantom(pickUuid));
+            assertEquals(firstCount, InvoiceItemAttribution.<InvoiceItemAttribution>list("invoiceitemUuid", pickItem).size(),
+                    "idempotent: same row count on re-derive");
+        } finally {
+            cleanupAuto(pickItem);
+            deleteMap(clientname);
+            restoreBilling(pickUuid, priorBilling);
+        }
+    }
+
+    @Transactional
+    void cleanupAuto(String itemUuid) {
+        InvoiceItemAttribution.delete("invoiceitemUuid = ?1 AND source = ?2", itemUuid, AttributionSource.AUTO);
+    }
+
+    @Transactional
+    void upsertMap(String clientname, String clientUuid) {
+        deleteMap(clientname);
+        new PhantomClientMap(clientname, clientUuid, false, "test", "test").persist();
+    }
+
+    @Transactional
+    void deleteMap(String clientname) {
+        PhantomClientMap.deleteById(clientname);
+    }
+
+    @Transactional
+    void restoreBilling(String invoiceUuid, String prior) {
+        em.createNativeQuery("UPDATE invoices SET billing_client_uuid = :v WHERE uuid = :u")
+                .setParameter("v", prior).setParameter("u", invoiceUuid).executeUpdate();
+    }
+
+    String currentBillingClientUuid(String invoiceUuid) {
+        Object v = em.createNativeQuery("SELECT billing_client_uuid FROM invoices WHERE uuid = :u")
+                .setParameter("u", invoiceUuid).getSingleResult();
+        return v == null ? null : v.toString();
+    }
+
+    String clientnameOf(String invoiceUuid) {
+        return (String) em.createNativeQuery("SELECT clientname FROM invoices WHERE uuid = :u")
+                .setParameter("u", invoiceUuid).getSingleResult();
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomClientResolverTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomClientResolverTest.java
@@ -1,8 +1,15 @@
 package dk.trustworks.intranet.aggregates.invoice.services;
 
+import dk.trustworks.intranet.aggregates.invoice.model.dto.PhantomClientSuggestion;
+import dk.trustworks.intranet.aggregates.invoice.model.enums.SuggestionMethod;
+import dk.trustworks.intranet.dao.crm.model.Client;
+import dk.trustworks.intranet.dao.crm.services.ClientService;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /** Pure unit test for the static prefix-strip helper — no CDI, no DB. */
 class PhantomClientResolverTest {
@@ -31,5 +38,62 @@ class PhantomClientResolverTest {
     void nullAndBlankAreSafe() {
         assertEquals("", PhantomClientResolver.stripKnownPrefixes(null));
         assertEquals("", PhantomClientResolver.stripKnownPrefixes("   "));
+    }
+
+    private static Client client(String uuid, String name) {
+        Client c = new Client();
+        c.setUuid(uuid);
+        c.setName(name);
+        return c;
+    }
+
+    @Test
+    void exactMatch_onStrippedLabel_givesConfidenceOne() {
+        ClientService cs = mock(ClientService.class);
+        when(cs.findByExactNameIgnoreCase("Energinet"))
+                .thenReturn(client("16e3ccad-aaaa", "Energinet"));
+
+        PhantomClientResolver resolver = new PhantomClientResolver(cs);
+        PhantomClientSuggestion s = resolver.suggest("Konsulenthonorar Energinet");
+
+        assertEquals(SuggestionMethod.EXACT, s.method());
+        assertEquals("16e3ccad-aaaa", s.suggestedClientUuid());
+        assertEquals(1.0, s.confidence(), 0.0001);
+    }
+
+    @Test
+    void fuzzyMatch_whenNoExact() {
+        ClientService cs = mock(ClientService.class);
+        when(cs.findByExactNameIgnoreCase("Vattenfall")).thenReturn(null);
+        when(cs.findFuzzyMatch("Vattenfall"))
+                .thenReturn(Optional.of(client("2cbb7f5e-bbbb", "VATTENFALL VINDKRAFT A/S")));
+
+        PhantomClientResolver resolver = new PhantomClientResolver(cs);
+        PhantomClientSuggestion s = resolver.suggest("Konsulenthonorar Vattenfall");
+
+        assertEquals(SuggestionMethod.FUZZY, s.method());
+        assertEquals("2cbb7f5e-bbbb", s.suggestedClientUuid());
+        assertTrue(s.confidence() >= 0.9 && s.confidence() <= 1.0);
+    }
+
+    @Test
+    void noCandidate_givesNone() {
+        ClientService cs = mock(ClientService.class);
+        when(cs.findByExactNameIgnoreCase(anyString())).thenReturn(null);
+        when(cs.findFuzzyMatch(anyString())).thenReturn(Optional.empty());
+
+        PhantomClientResolver resolver = new PhantomClientResolver(cs);
+        PhantomClientSuggestion s = resolver.suggest("Magnit Global");
+
+        assertEquals(SuggestionMethod.NONE, s.method());
+        assertNull(s.suggestedClientUuid());
+    }
+
+    @Test
+    void blankLabel_givesNone() {
+        ClientService cs = mock(ClientService.class);
+        PhantomClientResolver resolver = new PhantomClientResolver(cs);
+        assertEquals(SuggestionMethod.NONE, resolver.suggest("   ").method());
+        verifyNoInteractions(cs);
     }
 }

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomClientResolverTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomClientResolverTest.java
@@ -6,6 +6,7 @@ import dk.trustworks.intranet.dao.crm.model.Client;
 import dk.trustworks.intranet.dao.crm.services.ClientService;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -95,5 +96,72 @@ class PhantomClientResolverTest {
         PhantomClientResolver resolver = new PhantomClientResolver(cs);
         assertEquals(SuggestionMethod.NONE, resolver.suggest("   ").method());
         verifyNoInteractions(cs);
+    }
+
+    @Test
+    void containsMatch_whenNoExactOrFuzzy() {
+        ClientService cs = mock(ClientService.class);
+        when(cs.findByExactNameIgnoreCase(anyString())).thenReturn(null);
+        when(cs.findFuzzyMatch(anyString())).thenReturn(Optional.empty());
+        when(cs.findByActiveTrue())
+                .thenReturn(List.of(client("c-magnit", "Magnit Global Solutions A/S")));
+
+        PhantomClientResolver resolver = new PhantomClientResolver(cs);
+        PhantomClientSuggestion s = resolver.suggest("Magnit");
+
+        assertEquals(SuggestionMethod.CONTAINS, s.method());
+        assertEquals("c-magnit", s.suggestedClientUuid());
+        assertEquals("Magnit Global Solutions A/S", s.suggestedClientName());
+        assertEquals(0.5, s.confidence(), 0.0001);
+    }
+
+    @Test
+    void containsMatch_isCaseInsensitive_andSkipsNullName() {
+        ClientService cs = mock(ClientService.class);
+        when(cs.findByExactNameIgnoreCase(anyString())).thenReturn(null);
+        when(cs.findFuzzyMatch(anyString())).thenReturn(Optional.empty());
+        // First client has a null name (must be skipped, not NPE); second matches case-insensitively.
+        when(cs.findByActiveTrue()).thenReturn(List.of(
+                client("c-null-name", null),
+                client("c-acme", "ACME MAGNIT COMPANY")));
+
+        PhantomClientResolver resolver = new PhantomClientResolver(cs);
+        PhantomClientSuggestion s = resolver.suggest("magnit");
+
+        assertEquals(SuggestionMethod.CONTAINS, s.method());
+        assertEquals("c-acme", s.suggestedClientUuid());
+    }
+
+    @Test
+    void noContainsMatch_withPopulatedList_givesNone() {
+        ClientService cs = mock(ClientService.class);
+        when(cs.findByExactNameIgnoreCase(anyString())).thenReturn(null);
+        when(cs.findFuzzyMatch(anyString())).thenReturn(Optional.empty());
+        when(cs.findByActiveTrue()).thenReturn(List.of(
+                client("c-other", "Other Corp"),
+                client("c-another", "Another Inc")));
+
+        PhantomClientResolver resolver = new PhantomClientResolver(cs);
+        PhantomClientSuggestion s = resolver.suggest("Magnit");
+
+        assertEquals(SuggestionMethod.NONE, s.method());
+        assertNull(s.suggestedClientUuid());
+    }
+
+    @Test
+    void containsMatch_skipsClientWithNullUuid() {
+        ClientService cs = mock(ClientService.class);
+        when(cs.findByExactNameIgnoreCase(anyString())).thenReturn(null);
+        when(cs.findFuzzyMatch(anyString())).thenReturn(Optional.empty());
+        // A name match with a null uuid must NOT be returned as a "found" suggestion.
+        when(cs.findByActiveTrue()).thenReturn(List.of(
+                client(null, "Magnit Global"),
+                client("c-real", "Magnit Holdings")));
+
+        PhantomClientResolver resolver = new PhantomClientResolver(cs);
+        PhantomClientSuggestion s = resolver.suggest("Magnit");
+
+        assertEquals(SuggestionMethod.CONTAINS, s.method());
+        assertEquals("c-real", s.suggestedClientUuid());
     }
 }

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomClientResolverTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/PhantomClientResolverTest.java
@@ -1,0 +1,35 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Pure unit test for the static prefix-strip helper — no CDI, no DB. */
+class PhantomClientResolverTest {
+
+    @Test
+    void stripsKonsulenthonorarPrefix_caseInsensitive() {
+        assertEquals("Vattenfall",
+                PhantomClientResolver.stripKnownPrefixes("Konsulenthonorar Vattenfall"));
+        assertEquals("Energinet",
+                PhantomClientResolver.stripKnownPrefixes("konsulenthonorar Energinet"));
+    }
+
+    @Test
+    void stripsSalgPrefix() {
+        assertEquals("kantineordning",
+                PhantomClientResolver.stripKnownPrefixes("Salg kantineordning"));
+    }
+
+    @Test
+    void leavesUnprefixedLabelUntouched_andTrims() {
+        assertEquals("Magnit Global",
+                PhantomClientResolver.stripKnownPrefixes("  Magnit Global  "));
+    }
+
+    @Test
+    void nullAndBlankAreSafe() {
+        assertEquals("", PhantomClientResolver.stripKnownPrefixes(null));
+        assertEquals("", PhantomClientResolver.stripKnownPrefixes("   "));
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/dao/workservice/services/WorkServiceClientRevenueTest.java
+++ b/src/test/java/dk/trustworks/intranet/dao/workservice/services/WorkServiceClientRevenueTest.java
@@ -1,0 +1,81 @@
+package dk.trustworks.intranet.dao.workservice.services;
+
+import dk.trustworks.intranet.dto.work.ConsultantWorkRevenue;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Tuple;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(WorkServiceClientRevenueTest.NoDevServicesProfile.class)
+class WorkServiceClientRevenueTest {
+
+    public static class NoDevServicesProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.s3.devservices.enabled", "false",
+                    "cvtool.username", "test-placeholder",
+                    "cvtool.password", "test-placeholder"
+            );
+        }
+    }
+
+    @Inject
+    WorkService workService;
+
+    @Inject
+    EntityManager em;
+
+    @Test
+    void returnsPerConsultantHoursAndRevenue_forAClientWithWork() {
+        // Find a (clientuuid, year, month) that actually has billable work in work_full.
+        @SuppressWarnings("unchecked")
+        List<Tuple> seed = em.createNativeQuery("""
+                SELECT wf.clientuuid AS clientuuid,
+                       YEAR(wf.registered) AS yr,
+                       MONTH(wf.registered) AS mo
+                FROM work_full wf
+                WHERE wf.clientuuid IS NOT NULL AND wf.workduration > 0 AND wf.rate > 0
+                GROUP BY wf.clientuuid, YEAR(wf.registered), MONTH(wf.registered)
+                HAVING COUNT(DISTINCT wf.useruuid) >= 1
+                LIMIT 1
+                """, Tuple.class).getResultList();
+
+        if (seed.isEmpty()) return; // no data locally — skip gracefully
+
+        String clientUuid = seed.get(0).get("clientuuid", String.class);
+        int year = ((Number) seed.get(0).get("yr")).intValue();
+        int month = ((Number) seed.get(0).get("mo")).intValue();
+
+        List<ConsultantWorkRevenue> rows = workService.findRevenueByClientAndMonth(clientUuid, year, month);
+
+        assertFalse(rows.isEmpty(), "expected at least one consultant row");
+        for (ConsultantWorkRevenue r : rows) {
+            assertNotNull(r.useruuid());
+            assertNotNull(r.hours());
+            assertNotNull(r.revenue());
+            assertTrue(r.hours().compareTo(BigDecimal.ZERO) > 0, "hours must be > 0 (workduration > 0 filter)");
+            assertTrue(r.revenue().compareTo(BigDecimal.ZERO) >= 0, "revenue must be >= 0");
+        }
+        // useruuid must be distinct (GROUP BY useruuid)
+        long distinct = rows.stream().map(ConsultantWorkRevenue::useruuid).distinct().count();
+        assertEquals(rows.size(), distinct, "one row per consultant");
+    }
+
+    @Test
+    void emptyForNonexistentClient() {
+        List<ConsultantWorkRevenue> rows =
+                workService.findRevenueByClientAndMonth("00000000-0000-0000-0000-000000000000", 2025, 9);
+        assertTrue(rows.isEmpty());
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/dao/workservice/services/WorkServiceClientRevenueTest.java
+++ b/src/test/java/dk/trustworks/intranet/dao/workservice/services/WorkServiceClientRevenueTest.java
@@ -10,8 +10,10 @@ import jakarta.persistence.Tuple;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -70,6 +72,84 @@ class WorkServiceClientRevenueTest {
         // useruuid must be distinct (GROUP BY useruuid)
         long distinct = rows.stream().map(ConsultantWorkRevenue::useruuid).distinct().count();
         assertEquals(rows.size(), distinct, "one row per consultant");
+
+        // Correctness: independently re-derive the expected per-consultant aggregate using the METHOD's
+        // own predicate (workduration > 0 ONLY — NOT rate > 0). This pins two things the shape
+        // assertions above cannot:
+        //   (a) the consultant SET must match exactly — a stray `rate > 0` filter would silently drop
+        //       rate=0 (hours-fallback) consultants and shrink the result; and
+        //   (b) hours == Σ workduration and revenue == Σ (workduration × rate) — catching a wrong
+        //       aggregate (AVG, or dropping the × rate term).
+        LocalDate periodStart = LocalDate.of(year, month, 1);
+        LocalDate periodEnd = periodStart.plusMonths(1);
+        @SuppressWarnings("unchecked")
+        List<Tuple> expected = em.createNativeQuery("""
+                SELECT wf.useruuid AS useruuid,
+                       SUM(wf.workduration)            AS hours,
+                       SUM(wf.workduration * wf.rate)  AS revenue
+                FROM work_full wf
+                WHERE wf.clientuuid = :clientUuid
+                  AND wf.registered >= :periodStart
+                  AND wf.registered <  :periodEnd
+                  AND wf.workduration > 0
+                GROUP BY wf.useruuid
+                """, Tuple.class)
+                .setParameter("clientUuid", clientUuid)
+                .setParameter("periodStart", periodStart)
+                .setParameter("periodEnd", periodEnd)
+                .getResultList();
+
+        Map<String, ConsultantWorkRevenue> actualByUser =
+                rows.stream().collect(Collectors.toMap(ConsultantWorkRevenue::useruuid, r -> r));
+
+        assertEquals(expected.size(), rows.size(),
+                "method must return one row per workduration>0 consultant (no stray rate>0 filter)");
+        for (Tuple e : expected) {
+            String u = e.get("useruuid", String.class);
+            ConsultantWorkRevenue a = actualByUser.get(u);
+            assertNotNull(a, "method dropped consultant " + u + " — likely a stray rate>0 filter");
+            double expHours = ((Number) e.get("hours")).doubleValue();
+            double expRevenue = e.get("revenue") == null ? 0d : ((Number) e.get("revenue")).doubleValue();
+            assertEquals(expHours, a.hours().doubleValue(), 0.0001, "hours mismatch for " + u);
+            assertEquals(expRevenue, a.revenue().doubleValue(), 0.01, "revenue (Σ workduration×rate) mismatch for " + u);
+        }
+    }
+
+    @Test
+    void includesRateZeroConsultantWithZeroRevenue() {
+        // Directly pin the defining behavior: a consultant whose work for a client+month is entirely
+        // rate=0 (revenue 0) but has hours (workduration > 0) MUST still be returned — the method drops
+        // the `rate > 0` filter on purpose (hours-fallback basis). Find such a (client, period, useruuid).
+        @SuppressWarnings("unchecked")
+        List<Tuple> seed = em.createNativeQuery("""
+                SELECT wf.clientuuid AS clientuuid,
+                       YEAR(wf.registered) AS yr,
+                       MONTH(wf.registered) AS mo,
+                       wf.useruuid AS useruuid
+                FROM work_full wf
+                WHERE wf.clientuuid IS NOT NULL AND wf.workduration > 0
+                GROUP BY wf.clientuuid, YEAR(wf.registered), MONTH(wf.registered), wf.useruuid
+                HAVING SUM(wf.workduration) > 0 AND SUM(wf.workduration * wf.rate) = 0
+                LIMIT 1
+                """, Tuple.class).getResultList();
+
+        if (seed.isEmpty()) return; // no rate=0 consultant in the dataset — skip gracefully
+
+        String clientUuid = seed.get(0).get("clientuuid", String.class);
+        int year = ((Number) seed.get(0).get("yr")).intValue();
+        int month = ((Number) seed.get(0).get("mo")).intValue();
+        String rateZeroUser = seed.get(0).get("useruuid", String.class);
+
+        List<ConsultantWorkRevenue> rows = workService.findRevenueByClientAndMonth(clientUuid, year, month);
+
+        ConsultantWorkRevenue r = rows.stream()
+                .filter(x -> rateZeroUser.equals(x.useruuid()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(r, "rate=0 consultant " + rateZeroUser + " must NOT be dropped (no rate>0 filter)");
+        assertTrue(r.hours().compareTo(BigDecimal.ZERO) > 0, "rate=0 consultant still contributes hours");
+        assertEquals(0, r.revenue().compareTo(BigDecimal.ZERO), "rate=0 consultant contributes 0 revenue");
     }
 
     @Test


### PR DESCRIPTION
Promotes the complete **phantom consultant-attribution & internal-invoicing** backend (Phases 1–7) from `staging` to `master`. 26 commits; `master` is a direct ancestor of `staging` (no divergence).

## What's included
- **P1** `V362__Create_phantom_client_map.sql` (additive table) + `PhantomClientMap` entity — *the only new migration vs prod*
- **P2** `PhantomClientResolver.suggest()` (prefix-strip → exact → fuzzy → contains)
- **P3** `WorkService.findRevenueByClientAndMonth()` over `work_full`
- **P4** `PhantomAttributionService` (`computeShares`, `deriveForPhantom` REQUIRES_NEW, `deriveAllInScope`)
- **P5** Lift the two PHANTOM `400` guards on the dedicated internal flow + route phantom lazy-compute; re-guard the 2 legacy self-callers
- **P6** 4 REST endpoints (review queue / client-map upsert / derive / derive-all) + DTOs
- **P7** Nightly `deriveAllInScope()` hook after the e-conomic import (self-isolated try/catch)

## Activation boundary (safe by design)
With `phantom_client_map` empty, this is **read-only on prod** — `deriveForPhantom` returns `UNRESOLVED_CLIENT` before any write, and **no e-conomic write occurs on any path** (derivation only touches local `invoice_item_attributions` + `invoices.billing_client_uuid`). Production writes begin only on the first nightly run **after a human confirms** the Vattenfall/Energinet label mappings.

## Verification on staging (2026-06-04)
- Deployed: PRIMARY td:217 image == `56700fec` (no canary rollback), `/health` 200, clean boot, Flyway v362.
- Functional probe: `POST /invoices/phantoms/attribution/derive-all` → `200 {"UNRESOLVED_CLIENT":160}`; CloudWatch `deriveAllInScope: processed=160 result={UNRESOLVED_CLIENT=160}`, no errors, zero writes.
- Per-phase adversarial reviews: 0 BLOCKER/HIGH across all phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)