### PR TITLE
fix(invoicing): settle internal invoices on issuer's immediate payment term

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/PaymentTermsMappingRepository.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/PaymentTermsMappingRepository.java
@@ -25,4 +25,18 @@ public class PaymentTermsMappingRepository implements PanacheRepositoryBase<Paym
         return find("paymentTermsType = ?1 and paymentDays = ?2 and company.uuid = ?3",
                 type, days, companyUuid).firstResultOptional();
     }
+
+    /**
+     * Returns the company's most-immediate NET payment term — the NET mapping
+     * with the fewest days (0 = "Netto kontant" / "Til omgående betaling"),
+     * tie-broken by the lowest e-conomic number. Used for INTERNAL /
+     * INTERNAL_SERVICE invoices, which settle immediately and must use a term
+     * that exists in the ISSUER's own agreement.
+     */
+    public Optional<PaymentTermsMapping> findMostImmediateNet(String companyUuid) {
+        if (companyUuid == null) throw new IllegalArgumentException("companyUuid is required");
+        return find("company.uuid = ?1 and paymentTermsType = ?2 and paymentDays is not null "
+                        + "order by paymentDays asc, economicsPaymentTermsNumber asc",
+                companyUuid, PaymentTermsType.NET).firstResultOptional();
+    }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/EconomicsAgreementResolver.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/EconomicsAgreementResolver.java
@@ -133,6 +133,29 @@ public class EconomicsAgreementResolver {
     }
 
     /**
+     * Returns the e-conomic payment-term number for IMMEDIATE settlement in the
+     * issuer company's own agreement.
+     *
+     * <p>INTERNAL / INTERNAL_SERVICE invoices are finalized only after the external
+     * client has paid, so the intermediary settles right away. Crucially, the term
+     * must exist in the ISSUER's agreement — the debtor contract's term number often
+     * does not (issuers carry only the low numbers, e.g. 1–5, while the debtor uses
+     * 8 = "Netto 30 dage"). Sending a non-existent number makes e-conomic reject the
+     * draft with HTTP 400. This picks the issuer's NET term with the fewest days
+     * (0 = "Netto kontant" / "Til omgående betaling").
+     *
+     * @throws BadRequestException when the issuer has no NET payment term configured.
+     */
+    public int immediatePaymentTermFor(String issuerCompanyUuid) {
+        return paymentTermsRepo.findMostImmediateNet(issuerCompanyUuid)
+                .map(PaymentTermsMapping::getEconomicsPaymentTermsNumber)
+                .orElseThrow(() -> new BadRequestException(
+                        "No immediate (NET, e.g. 'Netto kontant') payment term is configured for company "
+                        + issuerCompanyUuid + ". Internal invoices settle immediately and require one — "
+                        + "add a NET payment-terms mapping for this company and try again."));
+    }
+
+    /**
      * Returns the internal journal number used for inter-company (supplier) voucher posting
      * to the debtor company's e-conomic agreement.
      *

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestrator.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestrator.java
@@ -149,12 +149,25 @@ public class InvoiceFinalizationOrchestrator {
         String companyUuid = inv.getCompany().getUuid();
         EconomicsAgreementResolver.Tokens tokens = agreements.tokens(companyUuid);
 
+        // INTERNAL / INTERNAL_SERVICE invoices are issued only after the external
+        // client has paid, so the intermediary settles immediately. Their payment
+        // term must also be valid in the ISSUER's own e-conomic agreement — the
+        // debtor contract's term number frequently is not (subsidiaries carry only
+        // the low numbers while the debtor uses e.g. 8 = "Netto 30 dage"), which
+        // otherwise makes e-conomic reject the draft with HTTP 400. Regular invoices
+        // keep the contract's payment term.
+        boolean internal = inv.getType() == InvoiceType.INTERNAL
+                || inv.getType() == InvoiceType.INTERNAL_SERVICE;
+        int termOfPaymentNumber = internal
+                ? agreements.immediatePaymentTermFor(companyUuid)
+                : agreements.paymentTermFor(bc.contract());
+
         DraftContext ctx = new DraftContext(
                 inv,
                 bc.contract(),
                 bc.billingClient(),
                 agreements.layoutNumber(companyUuid),
-                agreements.paymentTermFor(bc.contract()),
+                termOfPaymentNumber,
                 agreements.vatZoneFor(inv.getCurrency(), companyUuid),
                 agreements.productNumber(companyUuid)
         );

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/EconomicsAgreementResolverTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/EconomicsAgreementResolverTest.java
@@ -60,6 +60,27 @@ class EconomicsAgreementResolverTest {
     }
 
     @Test
+    void immediatePaymentTermFor_returnsIssuersMostImmediateNetTerm() {
+        dk.trustworks.intranet.aggregates.invoice.economics.PaymentTermsMapping kontant =
+                new dk.trustworks.intranet.aggregates.invoice.economics.PaymentTermsMapping();
+        kontant.setEconomicsPaymentTermsNumber(3);
+        when(paymentTermsRepo.findMostImmediateNet("issuer-co")).thenReturn(Optional.of(kontant));
+
+        assertEquals(3, resolver.immediatePaymentTermFor("issuer-co"),
+                "Internal invoices must use the issuer's own immediate NET term number");
+    }
+
+    @Test
+    void immediatePaymentTermFor_throwsWhenIssuerHasNoNetTerm() {
+        when(paymentTermsRepo.findMostImmediateNet("issuer-co")).thenReturn(Optional.empty());
+
+        BadRequestException ex = assertThrows(BadRequestException.class,
+                () -> resolver.immediatePaymentTermFor("issuer-co"));
+        assertTrue(ex.getMessage().toLowerCase().contains("payment term"));
+        assertTrue(ex.getMessage().contains("issuer-co"));
+    }
+
+    @Test
     void vatZoneDetailsForReturnsNumberAndRate() {
         VatZoneMapping m = new VatZoneMapping();
         m.setEconomicsVatZoneNumber(7);

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestratorInternalTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestratorInternalTest.java
@@ -70,7 +70,9 @@ class InvoiceFinalizationOrchestratorInternalTest {
         when(billingResolver.resolve(inv)).thenReturn(new BillingContext(inv, contract, intercompanyClient));
         when(agreements.tokens("issuer-co")).thenReturn(new EconomicsAgreementResolver.Tokens("APP", "GRANT"));
         when(agreements.layoutNumber("issuer-co")).thenReturn(22);
-        when(agreements.paymentTermFor(any())).thenReturn(5);
+        // INTERNAL invoices settle immediately on the ISSUER's own NET/0 term,
+        // not the debtor contract's term (which may not exist in the issuer agreement).
+        when(agreements.immediatePaymentTermFor("issuer-co")).thenReturn(3);
         when(agreements.vatZoneFor(any(), any())).thenReturn(1);
         when(agreements.productNumber("issuer-co")).thenReturn("1");
 
@@ -90,6 +92,9 @@ class InvoiceFinalizationOrchestratorInternalTest {
         verify(mapper).toDraft(ctxCap.capture());
         assertSame(intercompanyClient, ctxCap.getValue().billingClient(),
                 "Mapper must receive the intercompany Client (not the contract's external client)");
+        assertEquals(3, ctxCap.getValue().termOfPaymentNumber(),
+                "INTERNAL invoices must settle on the issuer's immediate (NET/0) term, "
+                + "not the debtor contract's payment term");
 
         // AC-9: the null-guard did NOT overwrite the pre-stamped billingClientUuid.
         assertEquals("intercompany-client-uuid", out.getBillingClientUuid(),


### PR DESCRIPTION
Fixes the systemic HTTP 400 on internal-invoice finalization (43/49 queued internal invoices stranded, e.g. 56a632a3 failing nightly). Internal/internal-service invoices now resolve the e-conomic payment term in the ISSUER's own agreement (immediate NET/0 'kontant' term) instead of inheriting the debtor contract's term number, which often doesn't exist in the issuer agreement. Matches policy: settle immediately once the client has paid. Regular invoices unchanged. Unit tests green (resolver + internal createDraft term); follows the prior diagnostic-logging change (#92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)