### PR TITLE
fix(invoicing): label internal-invoice lines by their attributed consultant

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InternalInvoiceLineGenerator.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InternalInvoiceLineGenerator.java
@@ -30,6 +30,11 @@ import java.util.Set;
  *   <li>CALCULATED items: {@code rate = HALF_UP(sharePct/100 × source.rate, 2)},
  *       {@code hours = 1.0}. {@code calculationRef}, {@code ruleId}, {@code label}
  *       are copied from source.</li>
+ *   <li>Each line's {@code itemname} is the ATTRIBUTED consultant's name
+ *       ({@code attribution.consultantName}), so split lines are labeled by their
+ *       own consultant rather than the source line's. Falls back to
+ *       {@code source.itemname} when the attributed consultant's name is unknown
+ *       (e.g. synthetic CALCULATED attributions that carry no name).</li>
  *   <li>Zero-rounding rows ({@code |rate × hours| < 0.01}) are skipped.</li>
  *   <li>Rounding residual absorbed into the largest-share line within the
  *       source item's per-issuer group; ties broken lexicographically by
@@ -167,7 +172,18 @@ public final class InternalInvoiceLineGenerator {
 
                 InvoiceItem line = new InvoiceItem();
                 line.consultantuuid = pl.attribution.consultantUuid;
-                line.itemname = src.itemname;
+                // Label the line with ITS attributed consultant — not the source line's
+                // consultant. When one source line is split across multiple consultants
+                // via attribution, each generated line must show its own consultant's name
+                // (the source name would mislabel every split line; bug: inv 56a632a3 showed
+                // both Tanja's and Alexander's lines as "Tanja Bøggild Kaufmann").
+                // Fall back to the source item name when the attributed consultant's name is
+                // unknown (e.g. synthetic CALCULATED rows carry no name) — preserves prior
+                // behavior and never NPEs.
+                line.itemname = (pl.attribution.consultantName != null
+                        && !pl.attribution.consultantName.isBlank())
+                        ? pl.attribution.consultantName
+                        : src.itemname;
                 line.description = src.description;
                 line.rate = pl.rate.doubleValue();
                 line.hours = pl.hours.doubleValue();

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InternalInvoiceLineGeneratorTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InternalInvoiceLineGeneratorTest.java
@@ -193,6 +193,59 @@ class InternalInvoiceLineGeneratorTest {
         assertTrue(out.isEmpty() || out.values().stream().allMatch(List::isEmpty));
     }
 
+    // ── itemname labeled by ATTRIBUTED consultant (split-line mislabel bug) ──
+
+    @Test
+    void splitAcrossTwoConsultants_eachLineLabeledByItsOwnConsultantName() {
+        // Repro of prod inv 56a632a3: one source line (consultant "Tanja", 162.5h) split
+        // by attribution into Tanja 144h (88.6154%) + Alexander 18.5h (11.3846%), both
+        // cross-company. Before the fix, BOTH generated lines carried the source line's
+        // name "Tanja Bøggild Kaufmann". Each line must now show ITS consultant's name.
+        InvoiceItem src = base("item-1", 1000.0, 162.5);
+        src.itemname = "Tanja Bøggild Kaufmann"; // source line's consultant name
+
+        InvoiceItemAttribution tanja = attr("attr-t", "item-1", "tanja", "88.6154");
+        tanja.consultantName = "Tanja Bøggild Kaufmann";
+        InvoiceItemAttribution alex = attr("attr-a", "item-1", "alex", "11.3846");
+        alex.consultantName = "Alexander Fetterlein Hansen";
+        Map<String, String> users = Map.of("tanja", ISSUER_A, "alex", ISSUER_A);
+
+        Map<String, List<InvoiceItem>> out = InternalInvoiceLineGenerator.generate(
+                SOURCE_COMPANY, List.of(src), List.of(tanja, alex), users);
+
+        List<InvoiceItem> lines = out.get(ISSUER_A);
+        assertEquals(2, lines.size());
+
+        InvoiceItem tanjaLine = lines.stream()
+                .filter(l -> "tanja".equals(l.consultantuuid))
+                .findFirst().orElseThrow();
+        InvoiceItem alexLine = lines.stream()
+                .filter(l -> "alex".equals(l.consultantuuid))
+                .findFirst().orElseThrow();
+
+        assertEquals("Tanja Bøggild Kaufmann", tanjaLine.itemname);
+        assertEquals("Alexander Fetterlein Hansen", alexLine.itemname,
+                "Split line must be labeled with its own consultant, not the source line's");
+    }
+
+    @Test
+    void blankConsultantName_fallsBackToSourceItemName() {
+        // A synthetic CALCULATED attribution carries no consultantName (null) — the line
+        // must fall back to the source item's name rather than emit null.
+        InvoiceItem src = calculated("i1", -200.0);
+        src.itemname = "Spring discount";
+        InvoiceItemAttribution noName = attr("a-null", "i1", "mary", "40.0000"); // consultantName left null
+        InvoiceItemAttribution blankName = attr("a-blank", "i1", "bob", "60.0000");
+        blankName.consultantName = "   "; // blank → also falls back
+        Map<String, String> users = Map.of("mary", ISSUER_A, "bob", ISSUER_B);
+
+        Map<String, List<InvoiceItem>> out = InternalInvoiceLineGenerator.generate(
+                SOURCE_COMPANY, List.of(src), List.of(noName, blankName), users);
+
+        assertEquals("Spring discount", out.get(ISSUER_A).get(0).itemname);
+        assertEquals("Spring discount", out.get(ISSUER_B).get(0).itemname);
+    }
+
     // ── exclusion (per-row deselection in CreateInternalInvoicesModal) ────────
 
     @Test


### PR DESCRIPTION
Internal-invoice line items now show the attributed consultant's name instead of the source line's consultant. Fixes mislabel where split lines (one source line attributed across multiple consultants) all showed the source consultant — e.g. invoice 56a632a3 labeled Alexander's split as 'Tanja Bøggild Kaufmann'. Falls back to source name for synthetic CALCULATED/discount lines. Unit-tested (33 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)