### PR TITLE
Release: prod health-sweep fixes (OpenAI 403 / e-conomic contact 405 / Client jsr310 500)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/customer/EconomicsCustomerContactSyncService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/customer/EconomicsCustomerContactSyncService.java
@@ -130,7 +130,19 @@ public class EconomicsCustomerContactSyncService {
             // REQUIRES_NEW — see EconomicsCustomerSyncService for rationale.
             failureRecorder.clear(billingClient.getUuid(), companyUuid);
         } catch (WebApplicationException e) {
-            String status = e.getResponse() == null ? "?" : Integer.toString(e.getResponse().getStatus());
+            int status = e.getResponse() == null ? 0 : e.getResponse().getStatus();
+            // 405 Method Not Allowed is permanent: e-conomic rejects the contact-update (PUT) for
+            // this agreement. Retrying never helps, and recording it would churn the shared
+            // customer/contact failure row — which can stall customer-sync retries for the same
+            // (client, company). Skip with one concise WARN instead of recording + re-throwing on
+            // every contract save. The underlying 405 needs an e-conomic-side fix.
+            if (status == Response.Status.METHOD_NOT_ALLOWED.getStatusCode()) {
+                LOG.warnf("e-conomic returned 405 (Method Not Allowed) updating the contact for client %s / "
+                        + "company %s — contact updates appear unsupported for this agreement; skipping "
+                        + "(existing e-conomic contact left unchanged).",
+                        billingClient.getUuid(), companyUuid);
+                return;
+            }
             failureRecorder.record(billingClient.getUuid(), companyUuid,
                     "Contact sync HTTP " + status + ": " + safeMessage(e));
             throw new SyncFailedException("Contact sync failed for "

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceAttributionAIService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceAttributionAIService.java
@@ -3,6 +3,7 @@ package dk.trustworks.intranet.aggregates.invoice.services;
 import com.openai.client.OpenAIClient;
 import com.openai.client.okhttp.OpenAIOkHttpClient;
 import com.openai.models.ChatCompletionCreateParams;
+import com.openai.errors.PermissionDeniedException;
 import dk.trustworks.intranet.aggregates.invoice.model.dto.ResolvedAttribution;
 import dk.trustworks.intranet.aggregates.invoice.model.dto.ResolvedItem;
 import jakarta.annotation.PostConstruct;
@@ -20,7 +21,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * Wraps OpenAI GPT-4.1 for analyzing ambiguous invoice attributions.
+ * Wraps an OpenAI chat model (default {@code gpt-4o}, configurable via
+ * {@code openai.attribution-model}) for analyzing ambiguous invoice attributions.
  * When users edit invoice line items (consolidate, split, restructure),
  * this service proposes how to re-attribute revenue to consultants.
  * <p>
@@ -32,7 +34,6 @@ import java.util.stream.Collectors;
 public class InvoiceAttributionAIService {
 
     private static final Logger LOG = Logger.getLogger(InvoiceAttributionAIService.class);
-    private static final String MODEL = "gpt-4.1";
 
     private static final String STRICT_RULES = """
         STRICT RULES (must obey without exception):
@@ -69,6 +70,16 @@ public class InvoiceAttributionAIService {
 
     @ConfigProperty(name = "openai.api.key", defaultValue = "")
     String apiKey;
+
+    /**
+     * OpenAI chat model for attribution analysis. Configurable so the model can change without a
+     * redeploy (e.g. if the OpenAI project's model access changes). Default {@code gpt-4o}: it
+     * accepts the low temperature this service sets and returns reliable JSON. The gpt-5 family
+     * rejects non-default temperature, so do not point this at a gpt-5* model without also
+     * removing the temperature override in {@link #analyzeAttributions}.
+     */
+    @ConfigProperty(name = "openai.attribution-model", defaultValue = "gpt-4o")
+    String model;
 
     @Inject
     ObjectMapper objectMapper;
@@ -137,7 +148,7 @@ public class InvoiceAttributionAIService {
     // ── Public API ───────────────────────────────────────────────────
 
     /**
-     * Analyze ambiguous items using GPT-4.1. Returns updated ResolvedItems
+     * Analyze ambiguous items using the configured OpenAI model. Returns updated ResolvedItems
      * with AI-proposed attributions, confidence, and reasoning.
      * On failure, returns the input items unchanged (user resolves manually).
      */
@@ -151,7 +162,7 @@ public class InvoiceAttributionAIService {
             String prompt = buildPrompt(context);
 
             ChatCompletionCreateParams params = ChatCompletionCreateParams.builder()
-                .model(MODEL)
+                .model(model)
                 .addUserMessage(prompt)
                 .temperature(0.1)  // Low temperature for deterministic output
                 .build();
@@ -184,6 +195,15 @@ public class InvoiceAttributionAIService {
             }
             return validated;
 
+        } catch (PermissionDeniedException e) {
+            // Configuration problem — the OpenAI project/key cannot access the configured model —
+            // not a transient runtime error. The service still degrades gracefully to manual
+            // resolution, so log a concise, actionable WARN once per call instead of a per-call
+            // ERROR with a stack trace (which otherwise floods the production error taxonomy).
+            LOG.warnf("OpenAI attribution unavailable: the configured OpenAI project cannot access model '%s'. "
+                    + "Set openai.attribution-model to a model the project can access, or grant access in the "
+                    + "OpenAI dashboard. Falling back to manual resolution.", model);
+            return context.needsResolution();
         } catch (Exception e) {
             LOG.error("OpenAI attribution analysis failed -- falling back to manual", e);
             return context.needsResolution();

--- a/src/main/java/dk/trustworks/intranet/utils/ObjectMapperContextResolver.java
+++ b/src/main/java/dk/trustworks/intranet/utils/ObjectMapperContextResolver.java
@@ -1,0 +1,33 @@
+package dk.trustworks.intranet.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * Exposes the CDI-managed {@link ObjectMapper} — already configured with the JavaTimeModule by
+ * {@link JavaTimeObjectMapperCustomizer} — to JAX-RS response serialization via a
+ * {@link ContextResolver}.
+ *
+ * <p>Quarkus REST resolves the response writer's {@code ObjectMapper} differently for a resource
+ * method that returns a typed entity (e.g. {@code Client}) versus one that returns an untyped
+ * {@code Response.entity(...)}. The typed path already picked up the customized mapper, but the
+ * {@code Response.entity(Client)} path (e.g. {@code POST /clients}) resolved a mapper WITHOUT the
+ * JavaTimeModule and failed to serialize {@code Client.created} (a {@code LocalDateTime}) with an
+ * {@code InvalidDefinitionException} — surfacing as a 500 via {@code NativeInvalidDefinitionExceptionMapper}.
+ *
+ * <p>Registering this resolver makes every serialization path use the same jsr310-enabled mapper,
+ * so dates serialize as ISO-8601 strings consistently regardless of the return type.
+ */
+@Provider
+public class ObjectMapperContextResolver implements ContextResolver<ObjectMapper> {
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+        return objectMapper;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -345,6 +345,11 @@ openai:
   api:
     key: ${OPENAI_APIKEY:xx}
   model: gpt-5-nano #gpt-4o-mini
+  # Model for invoice-attribution AI (InvoiceAttributionAIService). Kept separate from openai.model
+  # because attribution sets a low temperature, which the gpt-5 family rejects with HTTP 400 — so
+  # this defaults to a gpt-4o-family model the project can access. Override per env with
+  # OPENAI_ATTRIBUTION_MODEL.
+  attribution-model: ${OPENAI_ATTRIBUTION_MODEL:gpt-4o}
   # Vision-strong model used only by vision + strict-schema calls (e.g. receipt OCR
   # in ExpenseClassificationService). Reasoning-class models like gpt-5-nano burn
   # their output budget on thinking and frequently emit empty structured output for

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/economics/customer/EconomicsCustomerContactSyncServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/economics/customer/EconomicsCustomerContactSyncServiceTest.java
@@ -255,6 +255,38 @@ class EconomicsCustomerContactSyncServiceTest {
                 org.mockito.ArgumentMatchers.anyString());
     }
 
+    @Test
+    void on_405_method_not_allowed_skips_without_recording_or_throwing() {
+        // e-conomic rejects the contact-update PUT with 405 for this agreement (observed in prod).
+        // 405 is permanent: the sync must skip gracefully — not throw, not record a failure (which
+        // would churn the shared customer/contact retry row), and not persist a mapping update.
+        Contract ct = makeContract("Thomas", "thomas@x.dk");
+        Client billing = makeClient("c-uuid");
+        when(customerRepo.findByClientAndCompany("c-uuid", COMPANY))
+                .thenReturn(Optional.of(makeCustomerMapping("c-uuid", COMPANY, 101)));
+
+        ClientEconomicsContact existing = new ClientEconomicsContact();
+        existing.setUuid("m");
+        existing.setClientUuid("c-uuid");
+        existing.setCompanyUuid(COMPANY);
+        existing.setContactName("Thomas");
+        existing.setCustomerContactNumber(777);
+        when(contactRepo.findByClientCompanyAndName("c-uuid", COMPANY, "Thomas"))
+                .thenReturn(Optional.of(existing));
+
+        EconomicsContactDto fresh = new EconomicsContactDto();
+        fresh.setCustomerContactNumber(777);
+        fresh.setObjectVersion("v1");
+        when(api.getContact(777)).thenReturn(fresh);
+        doThrow(new WebApplicationException(Response.status(405).build()))
+                .when(api).updateContact(eq(777), any());
+
+        service.syncContactToCompany(ct, billing, COMPANY);
+
+        verify(failureRecorder, never()).record(any(), any(), any());
+        verify(contactRepo, never()).persist(any(ClientEconomicsContact.class));
+    }
+
     // ----------------------- helpers -----------------------
 
     private static Contract makeContract(String attention, String email) {

--- a/src/test/java/dk/trustworks/intranet/utils/ObjectMapperContextResolverTest.java
+++ b/src/test/java/dk/trustworks/intranet/utils/ObjectMapperContextResolverTest.java
@@ -1,0 +1,57 @@
+package dk.trustworks.intranet.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import dk.trustworks.intranet.dao.crm.model.Client;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduces and guards the {@code POST /clients} 500 (InvalidDefinitionException on
+ * {@code Client.created}): a plain {@link ObjectMapper} cannot serialize a {@code LocalDateTime},
+ * the JavaTimeModule registered by {@link JavaTimeObjectMapperCustomizer} fixes it, and
+ * {@link ObjectMapperContextResolver} hands that mapper to JAX-RS response serialization.
+ */
+class ObjectMapperContextResolverTest {
+
+    private static Client clientWithCreated() {
+        Client c = new Client();
+        c.setUuid("c-1");
+        c.setName("Acme A/S");
+        c.setCreated(LocalDateTime.of(2026, 6, 8, 9, 23, 25));
+        return c;
+    }
+
+    @Test
+    void plain_mapper_fails_on_localDateTime_created() {
+        ObjectMapper plain = new ObjectMapper();
+        assertThrows(InvalidDefinitionException.class,
+                () -> plain.writeValueAsString(clientWithCreated()));
+    }
+
+    @Test
+    void customized_mapper_serializes_created_as_iso_string() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        new JavaTimeObjectMapperCustomizer().customize(mapper);
+
+        String json = mapper.writeValueAsString(clientWithCreated());
+
+        assertTrue(json.contains("\"created\":\"2026-06-08T09:23:25\""),
+                "created should serialize as an ISO-8601 string, was: " + json);
+    }
+
+    @Test
+    void resolver_returns_the_injected_mapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        new JavaTimeObjectMapperCustomizer().customize(mapper);
+        ObjectMapperContextResolver resolver = new ObjectMapperContextResolver();
+        resolver.objectMapper = mapper;
+
+        assertSame(mapper, resolver.getContext(Client.class));
+    }
+}


### PR DESCRIPTION
Promotes the three backend fixes from the 2026-06-08 production health sweep — already deployed and verified on **staging** (running PRIMARY image = this tip `e5183965`, rollout COMPLETED, 0 failed).

## Fixes
- **P1 — OpenAI attribution AI 403** (`48bdbf6d`): `InvoiceAttributionAIService` hardcoded `gpt-4.1`, which the OpenAI project can't access → AI off in prod, ERROR-spamming every invoice edit. Now reads `openai.attribution-model` (default `gpt-4o`; the gpt-5 family rejects the non-default temperature this service uses). Permission-denied fallback downgraded ERROR→WARN.
- **P2 — e-conomic contact sync 405** (`e850256e`): e-conomic returns HTTP 405 on the contact-update PUT (`/Contacts/{number}`) for some agreements. Now treated as a permanent skip (one concise WARN; no failure record, no throw) instead of churning the shared `client_economics_sync_failures` row (which could stall customer-sync retries). The underlying 405 still needs an e-conomic-side fix.
- **P3 — 500 serializing Client** (`e5183965`): `POST /clients` returned an untyped `Response.entity(Client)` serialized without jsr310 → `InvalidDefinitionException` on `Client.created`. Added a server-side `ObjectMapperContextResolver` so every serialization path uses the jsr310 CDI mapper. Server-only — classic REST clients register providers explicitly via `@RegisterProvider`, so outbound e-conomic/NextSign/CvTool payloads are unaffected.

## Safety
- Backend-only; **no Flyway migrations**; no API JSON-shape break (P3 fixes a previously-broken 500 response to valid ISO — no frontend coupling).
- Verified: `./mvnw clean test` green (16 targeted tests incl. new 405-skip + 3 jsr310 serialization tests); staging ECS rollout COMPLETED with PRIMARY image = `e5183965`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)