### PR TITLE
feat(selfbilled): PHANTOM self-billed settlement backend (cross-company, work-period basis)

### DIFF
--- a/docs/superpowers/plans/2026-06-09-phantom-selfbilled-staging-runbook.md
+++ b/docs/superpowers/plans/2026-06-09-phantom-selfbilled-staging-runbook.md
@@ -1,0 +1,12 @@
+# Self-Billed Settlement — Staging Dry-Run Runbook
+
+Run with an `invoices:write` JWT against staging. Window: FY2025/26 → `from=2025-07-01 to=2026-06-30`, ym `from=202507 to=202606`.
+
+1. **Capture** — `POST /invoices/cross-company/selfbilled/capture?from=2025-07-01&to=2026-06-30`
+   - Expect ~170 lines across accounts 2104/2106. Spot-check `selfbilled_line`: Michelle MC 08-2025 amount −153525.00, status RESOLVED; the 4 correction vouchers (THG/TD/FSP/MHB) — confirm `SUM(amount) GROUP BY voucher_number` nets correctly AND every correction sibling carries a non-null `work_year`/`work_month`.
+2. **Restamp REPORT** — `POST /invoices/cross-company/selfbilled/restamp?from=202507&to=202606&apply=false`
+   - Expect Michelle Sep/Jan = RESTAMP, Aug/Jul/Nov = NO_CHANGE, Julie Apr = UNMATCHED (arrears — must NOT be reversed). Any AMBIGUOUS/UNMATCHED on a *billed* period → stop, investigate, do not apply.
+3. **Restamp APPLY** — only after the report is sane: same call with `apply=true`.
+4. **Settle (queue)** — `POST /invoices/cross-company/selfbilled/settle?from=202507&to=202606&queue=true`
+   - Expect Michelle Aug delta 0 (no doc), Sep/Jan now recognised (no duplicate), Julie Apr untouched. Re-running must create nothing new (duplicate guard).
+5. **Verify** vs the verification report's reconciliation tables. Prod re-derive is a separate, human-gated repeat.

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/RestampDecision.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/RestampDecision.java
@@ -1,0 +1,7 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.dto;
+
+/** What the re-stamp planner decided for one existing internal (carries the stamp target). */
+public record RestampDecision(String internalUuid, Outcome outcome, String clientUuid, String debtorCompanyUuid,
+                              int workYear, int workMonth, String detail) {
+    public enum Outcome { RESTAMP, NO_CHANGE, UNMATCHED, AMBIGUOUS }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/RestampReport.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/RestampReport.java
@@ -1,0 +1,7 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.dto;
+
+import java.util.List;
+import java.util.Map;
+
+/** Result of the re-stamp phase: counts by outcome + the per-internal decisions (audit). */
+public record RestampReport(boolean applied, Map<String, Integer> counts, List<RestampDecision> decisions) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/model/SelfBilledCodeMap.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/model/SelfBilledCodeMap.java
@@ -1,0 +1,47 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/** Magnit consultant code → Trustworks consultant. Unique per (agreement, account, code). */
+@Getter
+@Setter
+@Entity
+@Table(name = "selfbilled_code_map")
+public class SelfBilledCodeMap extends PanacheEntityBase {
+
+    @Id
+    public String uuid;
+
+    @Column(name = "agreement_company_uuid")
+    public String agreementCompanyUuid;
+
+    @Column(name = "account_number")
+    public int accountNumber;
+
+    public String code;
+
+    @Column(name = "consultant_uuid")
+    public String consultantUuid;
+
+    @Column(name = "created_at", updatable = false)
+    public LocalDateTime createdAt;
+
+    @Column(name = "created_by")
+    public String createdBy;
+
+    public SelfBilledCodeMap() {}
+
+    /** Resolve one code, or null. */
+    public static SelfBilledCodeMap findMapping(String agreementCompanyUuid, int accountNumber, String code) {
+        return find("agreementCompanyUuid = ?1 and accountNumber = ?2 and code = ?3",
+                agreementCompanyUuid, accountNumber, code).firstResult();
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/model/SelfBilledLine.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/model/SelfBilledLine.java
@@ -1,0 +1,53 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/** One captured e-conomic debtor line. Idempotent on entry_number. Period/code/consultant are voucher-resolved (D10). */
+@Getter
+@Setter
+@Entity
+@Table(name = "selfbilled_line")
+public class SelfBilledLine extends PanacheEntityBase {
+
+    @Id
+    public String uuid;
+
+    @Column(name = "source_uuid")          public String sourceUuid;
+    @Column(name = "client_uuid")          public String clientUuid;
+    @Column(name = "debtor_company_uuid")  public String debtorCompanyUuid;
+    @Column(name = "account_number")       public int accountNumber;
+    @Column(name = "voucher_number")       public int voucherNumber;
+    @Column(name = "entry_number")         public long entryNumber;
+    @Column(name = "faktura_number")       public String fakturaNumber;
+    @Column(name = "work_year")            public Integer workYear;
+    @Column(name = "work_month")           public Integer workMonth;
+    public String code;
+    @Column(name = "consultant_uuid")      public String consultantUuid;
+    @Column(name = "issuer_company_uuid")  public String issuerCompanyUuid;
+    public BigDecimal amount;
+    @Column(name = "source_text")          public String sourceText;
+
+    @Enumerated(EnumType.STRING)
+    public SelfBilledLineStatus status;
+
+    @Column(name = "created_at", updatable = false) public LocalDateTime createdAt;
+    @Column(name = "refreshed_at")                  public LocalDateTime refreshedAt;
+
+    public SelfBilledLine() {}
+
+    /** Existing row for an entry number (idempotency), or null. */
+    public static SelfBilledLine findByEntry(long entryNumber) {
+        return find("entryNumber", entryNumber).firstResult();
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/model/SelfBilledLineStatus.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/model/SelfBilledLineStatus.java
@@ -1,0 +1,11 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.model;
+
+/** Voucher-level resolution state stamped onto each captured line. */
+public enum SelfBilledLineStatus {
+    /** Voucher parsed and its code mapped to a consultant. */
+    RESOLVED,
+    /** Voucher parsed, but the code is not in selfbilled_code_map. */
+    UNMAPPED_CODE,
+    /** Voucher has no parseable line at all (a pure-correction orphan). */
+    UNPARSEABLE
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/model/SelfBilledSource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/model/SelfBilledSource.java
@@ -1,0 +1,46 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/** Config: one (agreement company, e-conomic account) → billing client. Active-record Panache. */
+@Getter
+@Setter
+@Entity
+@Table(name = "selfbilled_source")
+public class SelfBilledSource extends PanacheEntityBase {
+
+    @Id
+    public String uuid;
+
+    @Column(name = "agreement_company_uuid")
+    public String agreementCompanyUuid;
+
+    @Column(name = "account_number")
+    public int accountNumber;
+
+    @Column(name = "client_uuid")
+    public String clientUuid;
+
+    public boolean enabled;
+
+    public String label;
+
+    @Column(name = "created_at", updatable = false)
+    public LocalDateTime createdAt;
+
+    public SelfBilledSource() {}
+
+    /** All enabled sources, deterministic order (account asc). */
+    public static List<SelfBilledSource> listEnabled() {
+        return list("enabled = ?1 order by accountNumber", true);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/parse/ParsedLine.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/parse/ParsedLine.java
@@ -1,0 +1,4 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.parse;
+
+/** Pure value type: the parsed fields of one self-billed debtor line. */
+public record ParsedLine(String faktura, int workYear, int workMonth, String code) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/parse/SelfBilledTextParser.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/parse/SelfBilledTextParser.java
@@ -1,0 +1,33 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.parse;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses the per-consultant self-billed debtor-line text. Pure (no DB, no CDI).
+ * Tolerant of the verified real variants: "Faktura:" / "faktura:" / "Faktrua:"
+ * typo / "Faktura " (no colon), an optional leading space, and a faktura number
+ * of any length. Correction lines ("Forkert ...", "Bogført ...") and anything
+ * that doesn't match the shape return empty — they carry no code/period and are
+ * netted via their voucher (Decision D10), never guessed.
+ */
+public final class SelfBilledTextParser {
+
+    private SelfBilledTextParser() {}
+
+    // ^ \s* fak<2-4 letters> :?  <faktura> - MM-YYYY <CODE> $
+    private static final Pattern RX = Pattern.compile(
+            "^\\s*fak[a-z]{2,4}:?\\s+(\\S+)\\s*-\\s*(\\d{2})-(\\d{4})\\s+([\\p{L}]+)\\s*$",
+            Pattern.CASE_INSENSITIVE);
+
+    public static Optional<ParsedLine> parse(String text) {
+        if (text == null) return Optional.empty();
+        Matcher m = RX.matcher(text);
+        if (!m.matches()) return Optional.empty();
+        int month = Integer.parseInt(m.group(2));
+        int year = Integer.parseInt(m.group(3));
+        if (month < 1 || month > 12) return Optional.empty();
+        return Optional.of(new ParsedLine(m.group(1), year, month, m.group(4).toUpperCase()));
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/parse/SelfBilledVoucherAggregator.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/parse/SelfBilledVoucherAggregator.java
@@ -1,0 +1,71 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.parse;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Nets self-billed lines BY VOUCHER (Decision D10). Each e-conomic voucher is one
+ * (code, work-period); correction lines (Forkert/Bogført) carry no code/period of
+ * their own and are folded in via the voucher. Pure (no DB, no CDI).
+ *
+ * <p>A voucher is {@code resolved} iff exactly one (code, work-period) appears among
+ * its parseable lines. Zero parseable lines (a pure-correction orphan) or more than
+ * one (code, work-period) → unresolved → review queue. The signed amount is the sum
+ * of ALL lines of the voucher (so a duplicate booking reversed by an unparseable
+ * "Bogført 2 x" nets to its true value, never double). The persistence layer stamps
+ * this resolved (code, work-period) onto every sibling row so SQL SUMs include the
+ * corrections (Task D2).
+ */
+public final class SelfBilledVoucherAggregator {
+
+    private SelfBilledVoucherAggregator() {}
+
+    /** One e-conomic debtor line. {@code parsed} is null for a correction/unparseable line. */
+    public record LineInput(int account, int voucher, long entry, BigDecimal signedAmount,
+                            ParsedLine parsed, String text) {}
+
+    /**
+     * Voucher-netted result. When {@code resolved} is false, code/workYear/workMonth are UNSET
+     * (null/0) and MUST NOT be read — always check {@code resolved()} first (Task D2 does).
+     */
+    public record VoucherNet(int account, int voucher, String code, int workYear, int workMonth,
+                             BigDecimal signedAmount, boolean resolved, List<Long> entries) {}
+
+    public static List<VoucherNet> aggregate(List<LineInput> lines) {
+        Map<String, List<LineInput>> byVoucher = new LinkedHashMap<>();
+        for (LineInput l : lines) {
+            byVoucher.computeIfAbsent(l.account() + "|" + l.voucher(), k -> new ArrayList<>()).add(l);
+        }
+
+        List<VoucherNet> out = new ArrayList<>(byVoucher.size());
+        for (List<LineInput> group : byVoucher.values()) {
+            int account = group.get(0).account();
+            int voucher = group.get(0).voucher();
+
+            BigDecimal sum = BigDecimal.ZERO;
+            List<Long> entries = new ArrayList<>(group.size());
+            Map<String, ParsedLine> distinct = new LinkedHashMap<>();
+            for (LineInput l : group) {
+                sum = sum.add(l.signedAmount());
+                entries.add(l.entry());
+                if (l.parsed() != null) {
+                    ParsedLine p = l.parsed();
+                    distinct.putIfAbsent(p.code() + "|" + p.workYear() + "|" + p.workMonth(), p);
+                }
+            }
+            entries.sort(Comparator.naturalOrder());
+
+            if (distinct.size() == 1) {
+                ParsedLine p = distinct.values().iterator().next();
+                out.add(new VoucherNet(account, voucher, p.code(), p.workYear(), p.workMonth(), sum, true, entries));
+            } else {
+                out.add(new VoucherNet(account, voucher, null, 0, 0, sum, false, entries));
+            }
+        }
+        return out;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/resources/SelfBilledResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/resources/SelfBilledResource.java
@@ -1,0 +1,69 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.resources;
+
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.RestampReport;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.services.SelfBilledCodeResolver;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.services.SelfBilledMigrationService;
+import dk.trustworks.intranet.security.RequestHeaderHolder;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Path("/invoices/cross-company/selfbilled")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class SelfBilledResource {
+
+    @Inject SelfBilledMigrationService migration;
+    @Inject SelfBilledCodeResolver codeResolver;
+    @Inject RequestHeaderHolder requestHeaderHolder;   // X-Requested-By → acting user (R3)
+
+    /** Phase 1 — capture self-billed lines for the work window [from,to]. Idempotent on entry_number. */
+    @POST @Path("/capture")
+    @RolesAllowed({"invoices:write"})
+    public Map<String, Integer> capture(@QueryParam("from") String from, @QueryParam("to") String to) {
+        if (from == null || from.isBlank() || to == null || to.isBlank()) {
+            throw new WebApplicationException("from and to are required (yyyy-MM-dd)", Response.Status.BAD_REQUEST);
+        }
+        try {
+            return migration.phase1Capture(LocalDate.parse(from), LocalDate.parse(to));
+        } catch (java.time.format.DateTimeParseException e) {
+            throw new WebApplicationException("Invalid date format — use yyyy-MM-dd", Response.Status.BAD_REQUEST);
+        }
+    }
+
+    /** Phase 2 — re-stamp existing internals to work-period. Report-only unless apply=true. */
+    @POST @Path("/restamp")
+    @RolesAllowed({"invoices:write"})
+    public RestampReport restamp(@QueryParam("from") int fromYm, @QueryParam("to") int toYm,
+                                 @QueryParam("apply") @DefaultValue("false") boolean apply) {
+        if (fromYm == 0 || toYm == 0) {
+            throw new WebApplicationException("from and to ym params are required (yyyyMM)", Response.Status.BAD_REQUEST);
+        }
+        return migration.phase2Restamp(fromYm, toYm, apply);
+    }
+
+    /** Phase 3 — settle every in-scope work-period group. queue=true creates QUEUED docs. */
+    @POST @Path("/settle")
+    @RolesAllowed({"invoices:write"})
+    public List<String> settle(@QueryParam("from") int fromYm, @QueryParam("to") int toYm,
+                               @QueryParam("queue") @DefaultValue("true") boolean queue) {
+        if (fromYm == 0 || toYm == 0) {
+            throw new WebApplicationException("from and to ym params are required (yyyyMM)", Response.Status.BAD_REQUEST);
+        }
+        return migration.phase3Settle(fromYm, toYm, queue);
+    }
+
+    /** Confirm one code→consultant mapping (review-queue action). Acting user from X-Requested-By (R3). */
+    @POST @Path("/code-map")
+    @RolesAllowed({"invoices:write"})
+    public void confirmMapping(@QueryParam("agreement") String agreement, @QueryParam("account") int account,
+                               @QueryParam("code") String code, @QueryParam("consultant") String consultant) {
+        codeResolver.confirmMapping(agreement, account, code, consultant, requestHeaderHolder.getUserUuid());
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledCodeResolver.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledCodeResolver.java
@@ -1,0 +1,52 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
+
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.model.SelfBilledCodeMap;
+import dk.trustworks.intranet.aggregates.invoice.services.UserCompanyResolver;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/** Resolves a Magnit code to a consultant (via the map) and the issuer company; confirms mappings. */
+@ApplicationScoped
+public class SelfBilledCodeResolver {
+
+    @Inject UserCompanyResolver userCompanyResolver;
+
+    /** Mapped consultant uuid for a code, or null when unmapped. */
+    public String resolve(String agreementCompanyUuid, int accountNumber, String code) {
+        SelfBilledCodeMap m = SelfBilledCodeMap.findMapping(agreementCompanyUuid, accountNumber, code);
+        return m != null ? m.consultantUuid : null;
+    }
+
+    /** Consultant's company as-of the work-period first day (issuer side of the transfer); null if unresolved. */
+    public String resolveIssuerCompany(String consultantUuid, int workYear, int workMonth) {
+        if (consultantUuid == null) return null;
+        LocalDate asOf = LocalDate.of(workYear, workMonth, 1);
+        Map<String, String> companies = userCompanyResolver.resolveCompanies(Set.of(consultantUuid), asOf);
+        return companies.get(consultantUuid);
+    }
+
+    /** Confirm one code→consultant mapping (review-queue action). Re-capture re-resolves the lines. */
+    @Transactional
+    public void confirmMapping(String agreementCompanyUuid, int accountNumber, String code,
+                              String consultantUuid, String createdBy) {
+        SelfBilledCodeMap m = SelfBilledCodeMap.findMapping(agreementCompanyUuid, accountNumber, code);
+        if (m == null) {
+            m = new SelfBilledCodeMap();
+            m.uuid = UUID.randomUUID().toString();
+            m.agreementCompanyUuid = agreementCompanyUuid;
+            m.accountNumber = accountNumber;
+            m.code = code;
+            m.createdAt = LocalDateTime.now();
+            m.persist();
+        }
+        m.consultantUuid = consultantUuid;
+        m.createdBy = createdBy;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledImportService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledImportService.java
@@ -2,10 +2,19 @@ package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.model.SelfBilledLine;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.model.SelfBilledLineStatus;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.model.SelfBilledSource;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.parse.ParsedLine;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.parse.SelfBilledTextParser;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.parse.SelfBilledVoucherAggregator;
 import dk.trustworks.intranet.expenseservice.remote.EconomicsAPI;
 import dk.trustworks.intranet.financeservice.model.IntegrationKey;
 import dk.trustworks.intranet.financeservice.remote.EconomicsDynamicHeaderFilter;
+import dk.trustworks.intranet.model.Company;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.jboss.logging.Logger;
@@ -13,8 +22,12 @@ import org.jboss.logging.Logger;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /** Captures per-consultant self-billed lines from e-conomic into selfbilled_line. Augments — never touches — the lump-PHANTOM import. */
 @ApplicationScoped
@@ -22,6 +35,9 @@ public class SelfBilledImportService {
 
     private static final Logger log = Logger.getLogger(SelfBilledImportService.class);
     private final ObjectMapper mapper = new ObjectMapper();
+
+    @Inject SelfBilledCodeResolver codeResolver;
+    @Inject SelfBilledImportService self;   // proxy so REQUIRES_NEW engages on self-calls
 
     /** Raw e-conomic debtor line, before parsing. */
     public record RawLine(int account, int voucher, long entry, LocalDate date, String text, BigDecimal amount) {}
@@ -92,5 +108,109 @@ public class SelfBilledImportService {
         if (s == null || s.isBlank()) return null;
         try { return LocalDate.parse(s.substring(0, Math.min(10, s.length()))); }
         catch (Exception e) { return null; }
+    }
+
+    /** Capture all enabled sources over the work window [from,to]. Each source commits independently. */
+    public Map<String, Integer> capture(LocalDate from, LocalDate to) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        for (SelfBilledSource source : SelfBilledSource.listEnabled()) {
+            try {
+                counts.put(source.label + "(" + source.accountNumber + ")", self.captureSource(source, from, to));
+            } catch (RuntimeException e) {
+                log.errorf(e, "capture: source %s failed", source.accountNumber);
+                counts.put("ERROR:" + source.accountNumber, -1);
+            }
+        }
+        log.infof("SelfBilledImportService.capture %s..%s -> %s", from, to, counts);
+        return counts;
+    }
+
+    /** Fetch one source's lines from e-conomic, then process+upsert them. Own transaction. */
+    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    public int captureSource(SelfBilledSource source, LocalDate from, LocalDate to) {
+        Company company = Company.findById(source.agreementCompanyUuid);
+        if (company == null) { log.warnf("captureSource: company %s missing", source.agreementCompanyUuid); return 0; }
+        IntegrationKey.IntegrationKeyValue keys = IntegrationKey.getIntegrationKeyValue(company);
+
+        List<RawLine> raw = new ArrayList<>();
+        try (EconomicsAPI api = buildEconomicsApi(keys)) {
+            for (String yearCode : discoverAccountingYears(api, from, to)) {
+                raw.addAll(fetchAccountLines(api, source.accountNumber, yearCode));
+            }
+        } catch (Exception e) {
+            log.errorf(e, "captureSource: e-conomic fetch failed for account=%d", source.accountNumber);
+        }
+        return processLines(source, raw);
+    }
+
+    /**
+     * Pure-of-HTTP: voucher-net the raw lines (D10), resolve consultant + issuer once per voucher,
+     * and upsert each entry STAMPING the voucher-resolved period/code/consultant/status onto every
+     * sibling (so corrections net in the SQL aggregates). Idempotent on entry_number. Caller supplies
+     * the transaction (captureSource is REQUIRES_NEW; the IT wraps it @Transactional).
+     */
+    public int processLines(SelfBilledSource source, List<RawLine> raw) {
+        List<SelfBilledVoucherAggregator.LineInput> inputs = new ArrayList<>();
+        Map<Long, RawLine> byEntry = new LinkedHashMap<>();
+        for (RawLine l : raw) {
+            ParsedLine parsed = SelfBilledTextParser.parse(l.text()).orElse(null);
+            inputs.add(new SelfBilledVoucherAggregator.LineInput(l.account(), l.voucher(), l.entry(), l.amount(), parsed, l.text()));
+            byEntry.put(l.entry(), l);
+        }
+        List<SelfBilledVoucherAggregator.VoucherNet> vouchers = SelfBilledVoucherAggregator.aggregate(inputs);
+
+        int upserts = 0;
+        LocalDateTime now = LocalDateTime.now();
+        for (SelfBilledVoucherAggregator.VoucherNet v : vouchers) {
+            String consultantUuid = null, issuerCompanyUuid = null;
+            SelfBilledLineStatus status;
+            if (!v.resolved()) {
+                status = SelfBilledLineStatus.UNPARSEABLE;
+            } else {
+                consultantUuid = codeResolver.resolve(source.agreementCompanyUuid, source.accountNumber, v.code());
+                if (consultantUuid == null) {
+                    status = SelfBilledLineStatus.UNMAPPED_CODE;
+                } else {
+                    issuerCompanyUuid = codeResolver.resolveIssuerCompany(consultantUuid, v.workYear(), v.workMonth());
+                    status = SelfBilledLineStatus.RESOLVED;
+                }
+            }
+            for (Long entry : v.entries()) {
+                upsertLine(source, v, byEntry.get(entry), consultantUuid, issuerCompanyUuid, status, now);
+                upserts++;
+            }
+        }
+        log.infof("processLines account=%d vouchers=%d entries=%d", source.accountNumber, vouchers.size(), upserts);
+        return upserts;
+    }
+
+    /** Upsert one entry. Period/code/consultant/issuer/status are VOUCHER-resolved (stamped on every sibling); only faktura is per-line. */
+    private void upsertLine(SelfBilledSource source, SelfBilledVoucherAggregator.VoucherNet v, RawLine l,
+                            String consultantUuid, String issuerCompanyUuid,
+                            SelfBilledLineStatus status, LocalDateTime now) {
+        if (l == null) return;
+        SelfBilledLine row = SelfBilledLine.findByEntry(l.entry());
+        if (row == null) {
+            row = new SelfBilledLine();
+            row.uuid = UUID.randomUUID().toString();
+            row.entryNumber = l.entry();
+            row.createdAt = now;
+            row.persist();
+        }
+        row.sourceUuid = source.uuid;
+        row.clientUuid = source.clientUuid;
+        row.debtorCompanyUuid = source.agreementCompanyUuid;
+        row.accountNumber = l.account();
+        row.voucherNumber = l.voucher();
+        row.fakturaNumber = SelfBilledTextParser.parse(l.text()).map(ParsedLine::faktura).orElse(null); // per-line audit
+        row.workYear = v.resolved() ? v.workYear() : null;        // VOUCHER-resolved (corrections inherit) — F1 fix
+        row.workMonth = v.resolved() ? v.workMonth() : null;
+        row.code = v.resolved() ? v.code() : null;
+        row.consultantUuid = consultantUuid;                      // voucher-level
+        row.issuerCompanyUuid = issuerCompanyUuid;                // voucher-level
+        row.amount = l.amount();                                  // per-line signed amount (SUM nets the voucher)
+        row.sourceText = l.text() != null && l.text().length() > 255 ? l.text().substring(0, 255) : l.text();
+        row.status = status;                                      // voucher-level
+        row.refreshedAt = now;
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledImportService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledImportService.java
@@ -1,0 +1,96 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dk.trustworks.intranet.expenseservice.remote.EconomicsAPI;
+import dk.trustworks.intranet.financeservice.model.IntegrationKey;
+import dk.trustworks.intranet.financeservice.remote.EconomicsDynamicHeaderFilter;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+import org.jboss.logging.Logger;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Captures per-consultant self-billed lines from e-conomic into selfbilled_line. Augments — never touches — the lump-PHANTOM import. */
+@ApplicationScoped
+public class SelfBilledImportService {
+
+    private static final Logger log = Logger.getLogger(SelfBilledImportService.class);
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** Raw e-conomic debtor line, before parsing. */
+    public record RawLine(int account, int voucher, long entry, LocalDate date, String text, BigDecimal amount) {}
+
+    EconomicsAPI buildEconomicsApi(IntegrationKey.IntegrationKeyValue keys) {
+        return RestClientBuilder.newBuilder()
+                .baseUri(URI.create(keys.url()))
+                .register(new EconomicsDynamicHeaderFilter(keys.appSecretToken(), keys.agreementGrantToken()))
+                .build(EconomicsAPI.class);
+    }
+
+    /** Accounting-year codes overlapping [from,to]. Mirrors EconomicRevenueImportService.discoverAccountingYears. */
+    List<String> discoverAccountingYears(EconomicsAPI api, LocalDate from, LocalDate to) {
+        List<String> codes = new ArrayList<>();
+        try (Response r = api.getAccountingYears(50)) {
+            JsonNode root = mapper.readTree(r.readEntity(String.class));
+            JsonNode coll = root.has("collection") ? root.get("collection") : root;
+            for (JsonNode n : coll) {
+                LocalDate f = parseDate(n.path("fromDate").asText(null));
+                LocalDate t = parseDate(n.path("toDate").asText(null));
+                if (f == null || t == null || t.isBefore(from) || f.isAfter(to)) continue;
+                String self = n.path("self").asText("");
+                int slash = self.lastIndexOf('/');
+                if (slash >= 0 && slash < self.length() - 1) codes.add(self.substring(slash + 1));
+            }
+        } catch (Exception e) {
+            log.errorf(e, "SelfBilledImportService: discoverAccountingYears failed");
+        }
+        return codes;
+    }
+
+    /** All debtor lines on one account in one accounting year, paginated. */
+    List<RawLine> fetchAccountLines(EconomicsAPI api, int account, String yearCode) {
+        List<RawLine> out = new ArrayList<>();
+        int skip = 0;
+        while (true) {
+            try (Response r = api.getAccountEntries(account, yearCode, null, 1000, skip)) {
+                JsonNode root = mapper.readTree(r.readEntity(String.class));
+                JsonNode coll = root.has("collection") ? root.get("collection") : root;
+                int count = 0;
+                for (JsonNode n : coll) {
+                    BigDecimal amt = n.has("amountInBaseCurrency")
+                            ? new BigDecimal(n.get("amountInBaseCurrency").asText("0"))
+                            : new BigDecimal(n.path("amount").asText("0"));
+                    out.add(new RawLine(
+                            n.path("account").path("accountNumber").asInt(account),
+                            n.path("voucherNumber").asInt(),
+                            n.path("entryNumber").asLong(),
+                            parseDate(n.path("date").asText(null)),
+                            n.path("text").asText(""),
+                            amt));
+                    count++;
+                }
+                int pageSize = root.path("pagination").path("pageSize").asInt(1000);
+                int total = root.path("pagination").path("results").asInt(-1);
+                if (count < pageSize) break;
+                if (total >= 0 && (skip + 1) * pageSize >= total) break;
+                if (++skip > 50) { log.warnf("fetchAccountLines: skip cap account=%d year=%s", account, yearCode); break; }
+            } catch (Exception e) {
+                log.warnf(e, "fetchAccountLines: error account=%d year=%s skip=%d — stopping", account, yearCode, skip);
+                break;
+            }
+        }
+        return out;
+    }
+
+    static LocalDate parseDate(String s) {
+        if (s == null || s.isBlank()) return null;
+        try { return LocalDate.parse(s.substring(0, Math.min(10, s.length()))); }
+        catch (Exception e) { return null; }
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledMigrationService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledMigrationService.java
@@ -1,0 +1,144 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
+
+import dk.trustworks.intranet.aggregates.invoice.dto.SettlementGroupKey;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.RestampDecision;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.RestampReport;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.jboss.logging.Logger;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Orchestrates the gated 3-phase migration: capture -> re-stamp (report-first) -> settle. */
+@ApplicationScoped
+public class SelfBilledMigrationService {
+
+    private static final Logger log = Logger.getLogger(SelfBilledMigrationService.class);
+
+    @Inject EntityManager em;
+    @Inject SelfBilledImportService importService;
+    @Inject SelfBilledSettlementService settlementService;
+
+    /** Phase 1. */
+    public Map<String, Integer> phase1Capture(LocalDate from, LocalDate to) {
+        return importService.capture(from, to);
+    }
+
+    /**
+     * Phase 2 (report-first). Build internals + targets, plan, and when apply=true write
+     * settlement_* for RESTAMP outcomes using the decision's own client/debtor/period.
+     */
+    @Transactional
+    public RestampReport phase2Restamp(int fromYm, int toYm, boolean apply) {
+        List<SelfBilledRestampPlanner.Internal> internals = loadCrossCompanyInternals();
+        List<SelfBilledRestampPlanner.Target> targets = loadTargets(fromYm, toYm);
+        List<RestampDecision> decisions = SelfBilledRestampPlanner.plan(internals, targets);
+
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        for (RestampDecision d : decisions) counts.merge(d.outcome().name(), 1, Integer::sum);
+
+        if (apply) {
+            // Safety: a multi-consultant internal yields multiple RESTAMP decisions for the same
+            // invoice uuid; if they disagree on the target period, the per-row UPDATEs would silently
+            // last-write-win. Refuse to apply on such a conflict — the @Transactional rolls back so
+            // nothing is written, and report mode (apply=false) still shows the decisions for review.
+            Map<String, Set<String>> stampsByInternal = new HashMap<>();
+            for (RestampDecision d : decisions) {
+                if (d.outcome() != RestampDecision.Outcome.RESTAMP) continue;
+                stampsByInternal.computeIfAbsent(d.internalUuid(), k -> new HashSet<>())
+                        .add(d.workYear() + "-" + d.workMonth());
+            }
+            for (Map.Entry<String, Set<String>> e : stampsByInternal.entrySet()) {
+                if (e.getValue().size() > 1) {
+                    throw new IllegalStateException("Conflicting RESTAMP target periods for internal "
+                            + e.getKey() + ": " + e.getValue() + " — aborting apply");
+                }
+            }
+            for (RestampDecision d : decisions) {
+                if (d.outcome() != RestampDecision.Outcome.RESTAMP) continue;
+                em.createNativeQuery("""
+                        UPDATE invoices SET settlement_billing_client_uuid=:c, settlement_debtor_companyuuid=:d,
+                               settlement_year=:y, settlement_month=:m WHERE uuid=:u
+                        """).setParameter("c", d.clientUuid()).setParameter("d", d.debtorCompanyUuid())
+                        .setParameter("y", d.workYear()).setParameter("m", d.workMonth())
+                        .setParameter("u", d.internalUuid()).executeUpdate();
+            }
+        }
+        log.infof("phase2Restamp apply=%s counts=%s", apply, counts);
+        return new RestampReport(apply, counts, decisions);
+    }
+
+    /** Phase 3: settle every in-scope work-period group. */
+    public List<String> phase3Settle(int fromYm, int toYm, boolean queue) {
+        List<String> created = new ArrayList<>();
+        for (SettlementGroupKey key : settlementService.inScopeGroups(fromYm, toYm)) {
+            created.addAll(settlementService.settleGroup(key, queue));
+        }
+        log.infof("phase3Settle created=%d", created.size());
+        return created;
+    }
+
+    /**
+     * In-scope existing internals: cross-company INTERNAL/INTERNAL_SERVICE whose phantom ref's
+     * billing client is a configured self-billed source. client/debtor come from the phantom ref +
+     * the internal's own debtor column — deterministic, no consultant inference (review fix #5).
+     * Internals without a resolvable self-billed phantom ref are simply not in scope.
+     */
+    private List<SelfBilledRestampPlanner.Internal> loadCrossCompanyInternals() {
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery("""
+                SELECT i.uuid, p.billing_client_uuid, i.debtor_companyuuid, ii.consultantuuid,
+                       COALESCE(SUM(ii.hours*ii.rate),0), i.settlement_year, i.settlement_month
+                FROM invoices i
+                JOIN invoices p ON p.uuid = i.invoice_ref_uuid AND p.type = 'PHANTOM'
+                JOIN invoiceitems ii ON ii.invoiceuuid = i.uuid
+                WHERE i.type IN ('INTERNAL','INTERNAL_SERVICE')
+                  AND i.status IN ('PENDING_REVIEW','QUEUED','CREATED')
+                  AND i.companyuuid <> i.debtor_companyuuid
+                  AND p.billing_client_uuid IN (SELECT client_uuid FROM selfbilled_source WHERE enabled = 1)
+                GROUP BY i.uuid, p.billing_client_uuid, i.debtor_companyuuid, ii.consultantuuid,
+                         i.settlement_year, i.settlement_month
+                """).getResultList();
+        List<SelfBilledRestampPlanner.Internal> out = new ArrayList<>();
+        for (Object[] r : rows) {
+            out.add(new SelfBilledRestampPlanner.Internal((String) r[0], (String) r[1], (String) r[2], (String) r[3],
+                    toBig(r[4]), r[5] == null ? null : ((Number) r[5]).intValue(),
+                    r[6] == null ? null : ((Number) r[6]).intValue()));
+        }
+        return out;
+    }
+
+    private List<SelfBilledRestampPlanner.Target> loadTargets(int fromYm, int toYm) {
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery("""
+                SELECT client_uuid, debtor_company_uuid, consultant_uuid, work_year, work_month,
+                       COALESCE(SUM(amount),0)
+                FROM selfbilled_line
+                WHERE status='RESOLVED' AND issuer_company_uuid <> debtor_company_uuid
+                  AND (work_year*100 + work_month) BETWEEN :from AND :to
+                GROUP BY client_uuid, debtor_company_uuid, consultant_uuid, work_year, work_month
+                """).setParameter("from", fromYm).setParameter("to", toYm).getResultList();
+        List<SelfBilledRestampPlanner.Target> out = new ArrayList<>();
+        for (Object[] r : rows) {
+            out.add(new SelfBilledRestampPlanner.Target((String) r[0], (String) r[1], (String) r[2],
+                    ((Number) r[3]).intValue(), ((Number) r[4]).intValue(),
+                    toBig(r[5]).negate())); // negate signed revenue -> positive
+        }
+        return out;
+    }
+
+    private static BigDecimal toBig(Object o) {
+        if (o == null) return BigDecimal.ZERO;
+        return (o instanceof BigDecimal b) ? b : BigDecimal.valueOf(((Number) o).doubleValue());
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledRestampPlanner.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledRestampPlanner.java
@@ -1,0 +1,59 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
+
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.RestampDecision;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Pure matcher for the migration's re-stamp phase (Decision D6a, the F2 fix). Booking month
+ * != work period, so each existing internal is matched to the self-billing it covers by
+ * (client, consultant, amount within tolerance). Exactly one target -> RESTAMP; zero -> UNMATCHED
+ * (report, never guess, never reverse); many -> AMBIGUOUS. Already-correct stamp -> NO_CHANGE.
+ * Carrying clientUuid removes the fragile consultant-only join the apply step would otherwise need.
+ */
+public final class SelfBilledRestampPlanner {
+
+    private SelfBilledRestampPlanner() {}
+
+    private static final BigDecimal TOLERANCE = BigDecimal.ONE; // 1 kr
+
+    /** An existing cross-company settlement internal. clientUuid derived from its phantom ref (Task G1). */
+    public record Internal(String uuid, String clientUuid, String debtorCompanyUuid, String consultantUuid,
+                           BigDecimal amount, Integer settlementYear, Integer settlementMonth) {}
+
+    /** A voucher-netted self-billed target (client, consultant, work period, positive amount). */
+    public record Target(String clientUuid, String debtorCompanyUuid, String consultantUuid,
+                         int workYear, int workMonth, BigDecimal amount) {}
+
+    public static List<RestampDecision> plan(List<Internal> internals, List<Target> targets) {
+        List<RestampDecision> out = new ArrayList<>(internals.size());
+        for (Internal in : internals) {
+            List<Target> matches = new ArrayList<>();
+            for (Target t : targets) {
+                if (!t.clientUuid().equals(in.clientUuid())) continue;
+                if (!t.consultantUuid().equals(in.consultantUuid())) continue;
+                if (in.amount().subtract(t.amount()).abs().compareTo(TOLERANCE) <= 0) matches.add(t);
+            }
+            if (matches.isEmpty()) {
+                out.add(new RestampDecision(in.uuid(), RestampDecision.Outcome.UNMATCHED,
+                        in.clientUuid(), in.debtorCompanyUuid(), 0, 0,
+                        "no self-billed target within tolerance (arrears or non-self-billed work)"));
+            } else if (matches.size() > 1) {
+                out.add(new RestampDecision(in.uuid(), RestampDecision.Outcome.AMBIGUOUS,
+                        in.clientUuid(), in.debtorCompanyUuid(), 0, 0,
+                        matches.size() + " targets match amount; manual review"));
+            } else {
+                Target t = matches.get(0);
+                boolean already = in.settlementYear() != null && in.settlementMonth() != null
+                        && in.settlementYear() == t.workYear() && in.settlementMonth() == t.workMonth();
+                out.add(new RestampDecision(in.uuid(),
+                        already ? RestampDecision.Outcome.NO_CHANGE : RestampDecision.Outcome.RESTAMP,
+                        t.clientUuid(), t.debtorCompanyUuid(), t.workYear(), t.workMonth(),
+                        already ? "already stamped" : "unique match"));
+            }
+        }
+        return out;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledSettlementService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledSettlementService.java
@@ -1,0 +1,171 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
+
+import dk.trustworks.intranet.aggregates.invoice.dto.SettlementGroupKey;
+import dk.trustworks.intranet.aggregates.invoice.dto.SettlementGroupPreview;
+import dk.trustworks.intranet.aggregates.invoice.services.InternalInvoiceOrchestrator;
+import dk.trustworks.intranet.aggregates.invoice.services.InvoiceService;
+import dk.trustworks.intranet.aggregates.invoice.services.PhantomSettlementService;
+import dk.trustworks.intranet.aggregates.invoice.services.SettlementDeltaCalculator;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.jboss.logging.Logger;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Settles the self-billed clients from selfbilled_line (parallel to PhantomSettlementService,
+ * left inert for these clients). target = voucher-netted self-billed per (issuer, consultant),
+ * cross-company only; settled = work-period-stamped live internals; delta drives one internal /
+ * credit note per issuer, threshold |delta| >= 1 kr, with the existing double-settlement guard.
+ * Only work-periods with >=1 self-billed line are processed (D6b).
+ */
+@ApplicationScoped
+public class SelfBilledSettlementService {
+
+    private static final Logger log = Logger.getLogger(SelfBilledSettlementService.class);
+    private static final BigDecimal THRESHOLD = BigDecimal.ONE; // 1 kr
+
+    @Inject EntityManager em;
+    @Inject InvoiceService invoiceService;
+    @Inject InternalInvoiceOrchestrator orchestrator;
+    @Inject PhantomSettlementService phantomSettlementService;   // reuse settled + duplicate-guard logic (R1)
+    @Inject SelfBilledSettlementService self;
+
+    /** (client, debtor, year, month) keys with >=1 self-billed line in the work window [fromYm,toYm]. */
+    @Transactional
+    public List<SettlementGroupKey> inScopeGroups(int fromYm, int toYm) {
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery("""
+                SELECT client_uuid, debtor_company_uuid, work_year, work_month
+                FROM selfbilled_line
+                WHERE status = 'RESOLVED' AND work_year IS NOT NULL
+                  AND (work_year*100 + work_month) BETWEEN :from AND :to
+                GROUP BY client_uuid, debtor_company_uuid, work_year, work_month
+                ORDER BY work_year, work_month
+                """).setParameter("from", fromYm).setParameter("to", toYm).getResultList();
+        List<SettlementGroupKey> keys = new ArrayList<>();
+        for (Object[] r : rows) {
+            keys.add(new SettlementGroupKey((String) r[0], (String) r[1],
+                    ((Number) r[2]).intValue(), ((Number) r[3]).intValue()));
+        }
+        return keys;
+    }
+
+    /** Preview one work-period group: cross-company target vs work-period-stamped settled. Read-only. */
+    @Transactional
+    public SettlementGroupPreview previewGroup(SettlementGroupKey key) {
+        // Cross-company target, sign-flipped to positive, straight from SQL (R2): -SUM(amount) with
+        // issuer <> debtor. GROUP BY already nets per (issuer, consultant) — no separate calc class.
+        @SuppressWarnings("unchecked")
+        List<Object[]> tgt = em.createNativeQuery("""
+                SELECT issuer_company_uuid, consultant_uuid, -COALESCE(SUM(amount),0)
+                FROM selfbilled_line
+                WHERE status='RESOLVED' AND client_uuid=:c AND debtor_company_uuid=:d
+                  AND work_year=:y AND work_month=:m
+                  AND issuer_company_uuid IS NOT NULL
+                  AND issuer_company_uuid <> debtor_company_uuid
+                GROUP BY issuer_company_uuid, consultant_uuid
+                """).setParameter("c", key.billingClientUuid()).setParameter("d", key.debtorCompanyUuid())
+                .setParameter("y", key.year()).setParameter("m", key.month()).getResultList();
+        List<SettlementDeltaCalculator.TargetLine> targets = new ArrayList<>();
+        for (Object[] r : tgt) {
+            targets.add(new SettlementDeltaCalculator.TargetLine((String) r[0], (String) r[1],
+                    toBig(r[2]).setScale(2, RoundingMode.HALF_UP)));
+        }
+
+        // Settled side reused from PhantomSettlementService (R1) — one source of truth, identical query.
+        List<SettlementDeltaCalculator.SettledLine> settled = phantomSettlementService.settledLinesForGroup(key);
+
+        Map<String, String> consultantNames = resolveConsultantNames(targets, settled);
+        Map<String, String> companyNames = resolveCompanyNames(key, targets, settled);
+        return SettlementDeltaCalculator.compute(key, key.debtorCompanyUuid(), targets, settled,
+                consultantNames, companyNames, true);
+    }
+
+    /** Settle one group: one document per issuer whose |delta| >= 1 kr, skipping issuers with an open QUEUED doc. */
+    public List<String> settleGroup(SettlementGroupKey key, boolean queue) {
+        SettlementGroupPreview preview = self.previewGroup(key);
+        String representative = representativePhantom(key.billingClientUuid());
+        if (representative == null) { log.warnf("settleGroup: no representative phantom for client=%s", key.billingClientUuid()); return List.of(); }
+
+        List<String> created = new ArrayList<>();
+        for (SettlementGroupPreview.IssuerDelta issuer : preview.issuers()) {
+            if (issuer.delta().abs().compareTo(THRESHOLD) < 0) continue;   // threshold: skip øre-rounding
+            if (phantomSettlementService.hasOpenQueuedInternal(key, issuer.issuerCompanyUuid())) {   // reused guard (R1/#2)
+                log.warnf("settleGroup: open QUEUED internal for group=%s issuer=%s; skipping", key.asString(), issuer.issuerCompanyUuid());
+                continue;
+            }
+            List<InvoiceService.SettlementLineInput> lines = new ArrayList<>();
+            for (SettlementGroupPreview.ConsultantDelta c : issuer.consultants()) {
+                if (c.delta().abs().compareTo(THRESHOLD) < 0) continue;
+                lines.add(new InvoiceService.SettlementLineInput(c.consultantUuid(), c.consultantName(), c.delta()));
+            }
+            if (lines.isEmpty()) continue;
+            try {
+                String internalUuid = invoiceService.createSettlementInternal(
+                        representative, issuer.issuerCompanyUuid(), key.debtorCompanyUuid(), lines,
+                        key.billingClientUuid(), key.year(), key.month());
+                created.add(internalUuid);
+                if (!queue) orchestrator.finalizeAutomatically(internalUuid);
+            } catch (RuntimeException e) {
+                log.errorf(e, "settleGroup: issuer=%s group=%s failed; skipping", issuer.issuerCompanyUuid(), key.asString());
+            }
+        }
+        log.infof("settleGroup group=%s created=%d queue=%s", key.asString(), created.size(), queue);
+        return created;
+    }
+
+    String representativePhantom(String billingClientUuid) {
+        @SuppressWarnings("unchecked")
+        List<String> ids = em.createNativeQuery("""
+                SELECT uuid FROM invoices
+                WHERE type='PHANTOM' AND status='CREATED' AND economics_entry_number IS NOT NULL
+                  AND billing_client_uuid=:c ORDER BY uuid LIMIT 1
+                """).setParameter("c", billingClientUuid).getResultList();
+        return ids.isEmpty() ? null : ids.get(0);
+    }
+
+    private static BigDecimal toBig(Object o) {
+        if (o == null) return BigDecimal.ZERO;
+        return (o instanceof BigDecimal b) ? b : BigDecimal.valueOf(((Number) o).doubleValue());
+    }
+
+    private Map<String, String> resolveConsultantNames(List<SettlementDeltaCalculator.TargetLine> t,
+                                                       List<SettlementDeltaCalculator.SettledLine> s) {
+        Set<String> ids = new HashSet<>();
+        for (var x : t) ids.add(x.consultantUuid());
+        for (var x : s) ids.add(x.consultantUuid());
+        Map<String, String> out = new HashMap<>();
+        if (ids.isEmpty()) return out;
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery(
+                        "SELECT uuid, CONCAT(firstname,' ',lastname) FROM user WHERE uuid IN (:ids)")
+                .setParameter("ids", ids).getResultList();
+        for (Object[] r : rows) out.put((String) r[0], (String) r[1]);
+        return out;
+    }
+
+    private Map<String, String> resolveCompanyNames(SettlementGroupKey key,
+                                                    List<SettlementDeltaCalculator.TargetLine> t,
+                                                    List<SettlementDeltaCalculator.SettledLine> s) {
+        Set<String> ids = new HashSet<>();
+        ids.add(key.debtorCompanyUuid());
+        for (var x : t) ids.add(x.issuerCompanyUuid());
+        for (var x : s) ids.add(x.issuerCompanyUuid());
+        Map<String, String> out = new HashMap<>();
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery("SELECT uuid, name FROM companies WHERE uuid IN (:ids)")
+                .setParameter("ids", ids).getResultList();
+        for (Object[] r : rows) out.put((String) r[0], (String) r[1]);
+        return out;
+    }
+}

--- a/src/main/resources/db/migration/V364__Selfbilled_capture.sql
+++ b/src/main/resources/db/migration/V364__Selfbilled_capture.sql
@@ -1,0 +1,81 @@
+-- ====================================================================
+-- V364: Self-billed capture for cross-company PHANTOM settlement.
+--
+-- Additive only. Does NOT touch invoices, work_full, or the lump-PHANTOM
+-- import. Three tables:
+--   selfbilled_source    config: which (agreement company, e-conomic account)
+--                        maps to which billing client. Seeded with the two
+--                        known rows (2104 Vattenfall, 2106 Energinet).
+--   selfbilled_code_map  Magnit consultant code -> Trustworks consultant.
+--                        Codes are Magnit's, not initials, so the map is
+--                        mandatory. Unique per (agreement, account, code).
+--   selfbilled_line      one row per e-conomic debtor line (idempotent on
+--                        entry_number). Settlement nets these BY voucher_number
+--                        (Decision D10): the voucher-resolved work period/code/
+--                        consultant is stamped onto EVERY sibling row (incl.
+--                        correction lines) so SQL SUMs include the corrections.
+--                        amount is SIGNED as posted (revenue negative); the
+--                        settlement target negates the netted sum.
+--
+-- IDEMPOTENT (IF NOT EXISTS) so re-running after a partial failure is safe;
+-- MariaDB auto-commits each DDL statement.
+--
+-- Rollback: DROP TABLE selfbilled_line, selfbilled_code_map, selfbilled_source;
+-- ====================================================================
+
+CREATE TABLE IF NOT EXISTS selfbilled_source (
+    uuid                    VARCHAR(36)  NOT NULL COMMENT 'UUID primary key',
+    agreement_company_uuid  VARCHAR(36)  NOT NULL COMMENT 'Debtor company whose e-conomic agreement books the self-billing (A/S)',
+    account_number          INT          NOT NULL COMMENT 'e-conomic revenue account (2104 Vattenfall, 2106 Energinet)',
+    client_uuid             VARCHAR(36)  NOT NULL COMMENT 'Synthetic billing client this account maps to',
+    enabled                 TINYINT(1)   NOT NULL DEFAULT 1 COMMENT '0 = paused, not imported',
+    label                   VARCHAR(150) NULL     COMMENT 'Human label (e.g. "Vattenfall")',
+    created_at              DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (uuid),
+    UNIQUE KEY uq_selfbilled_source (agreement_company_uuid, account_number)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS selfbilled_code_map (
+    uuid                    VARCHAR(36) NOT NULL COMMENT 'UUID primary key',
+    agreement_company_uuid  VARCHAR(36) NOT NULL,
+    account_number          INT         NOT NULL,
+    code                    VARCHAR(40) NOT NULL COMMENT 'Magnit consultant code as it appears in the line text',
+    consultant_uuid         VARCHAR(36) NOT NULL COMMENT 'Resolved Trustworks consultant (user.uuid)',
+    created_at              DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by              VARCHAR(36) NULL     COMMENT 'Admin who confirmed the mapping',
+    PRIMARY KEY (uuid),
+    UNIQUE KEY uq_selfbilled_code (agreement_company_uuid, account_number, code)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS selfbilled_line (
+    uuid                  VARCHAR(36)   NOT NULL COMMENT 'UUID primary key',
+    source_uuid           VARCHAR(36)   NOT NULL COMMENT 'FK-by-value to selfbilled_source.uuid',
+    client_uuid           VARCHAR(36)   NOT NULL COMMENT 'Billing client (from the source)',
+    debtor_company_uuid   VARCHAR(36)   NOT NULL COMMENT 'Agreement/debtor company (A/S)',
+    account_number        INT           NOT NULL,
+    voucher_number        INT           NOT NULL COMMENT 'e-conomic voucher — the NETTING UNIT (D10)',
+    entry_number          BIGINT        NOT NULL COMMENT 'e-conomic entry — idempotency key',
+    faktura_number        VARCHAR(40)   NULL     COMMENT 'Per-line faktura ref (parsed from THIS line; null for corrections)',
+    work_year             INT           NULL     COMMENT 'Voucher-resolved work period year (stamped on every sibling; null only when the voucher is unresolved)',
+    work_month            INT           NULL     COMMENT 'Voucher-resolved work period month 1-12',
+    code                  VARCHAR(40)   NULL     COMMENT 'Voucher-resolved Magnit code',
+    consultant_uuid       VARCHAR(36)   NULL     COMMENT 'Resolved consultant (null until mapped)',
+    issuer_company_uuid   VARCHAR(36)   NULL     COMMENT 'Consultant company as-of work period (null until resolved)',
+    amount                DECIMAL(15,2) NOT NULL COMMENT 'Signed line amount as posted (revenue negative)',
+    source_text           VARCHAR(255)  NULL     COMMENT 'Raw e-conomic line text (audit)',
+    status                VARCHAR(20)   NOT NULL COMMENT 'RESOLVED | UNMAPPED_CODE | UNPARSEABLE (voucher-level)',
+    created_at            DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    refreshed_at          DATETIME      NULL,
+    PRIMARY KEY (uuid),
+    UNIQUE KEY uq_selfbilled_entry (entry_number),
+    KEY idx_selfbilled_voucher (account_number, voucher_number),
+    KEY idx_selfbilled_period (client_uuid, work_year, work_month),
+    KEY idx_selfbilled_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Seed the two known sources (Decision D4 "seeded with the two known rows").
+-- INSERT IGNORE so re-running the migration does not duplicate (uq guard).
+INSERT IGNORE INTO selfbilled_source (uuid, agreement_company_uuid, account_number, client_uuid, enabled, label)
+VALUES
+ ('5e1f0001-0000-4000-8000-000000002104', 'd8894494-2fb4-4f72-9e05-e6032e6dd691', 2104, '2cbb7f5e-9e2b-4edc-870b-e9591dc58891', 1, 'Vattenfall'),
+ ('5e1f0001-0000-4000-8000-000000002106', 'd8894494-2fb4-4f72-9e05-e6032e6dd691', 2106, '16e3ccad-f053-4804-bbcc-cde32de51006', 1, 'Energinet');

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/parse/SelfBilledTextParserTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/parse/SelfBilledTextParserTest.java
@@ -1,0 +1,64 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.parse;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SelfBilledTextParserTest {
+
+    @Test void standard() {
+        ParsedLine p = SelfBilledTextParser.parse("Faktura: 58484650180 - 08-2025 MC").orElseThrow();
+        assertEquals("58484650180", p.faktura());
+        assertEquals(2025, p.workYear());
+        assertEquals(8, p.workMonth());
+        assertEquals("MC", p.code());
+    }
+
+    @Test void typo_Faktrua() {
+        assertEquals("DV", SelfBilledTextParser.parse("Faktrua: 58484650161 - 05-2025 DV").orElseThrow().code());
+    }
+
+    @Test void lowercase_and_leadingSpace() {
+        assertEquals("TM", SelfBilledTextParser.parse("faktura: 58484650163 - 05-2025 TM").orElseThrow().code());
+        assertEquals("CNE", SelfBilledTextParser.parse(" Faktura: 58484650227 - 12-2025 CNE").orElseThrow().code());
+    }
+
+    @Test void noColon_and_variableLengthFaktura() {
+        assertEquals("MHB", SelfBilledTextParser.parse("Faktura 5105733453 - 09-2025 MHB").orElseThrow().code());
+        assertEquals("510761717", SelfBilledTextParser.parse("Faktura: 510761717 - 02-2026 JK").orElseThrow().faktura());
+        assertEquals("51057566880", SelfBilledTextParser.parse("Faktura: 51057566880 - 01-2026 MHB").orElseThrow().faktura());
+    }
+
+    @Test void corrections_and_blank_are_empty() {
+        assertTrue(SelfBilledTextParser.parse("Forkert kt ").isEmpty());
+        assertTrue(SelfBilledTextParser.parse("Forkert beløb ").isEmpty());
+        assertTrue(SelfBilledTextParser.parse("Bogført 2 x ").isEmpty());
+        assertTrue(SelfBilledTextParser.parse("").isEmpty());
+        assertEquals(Optional.empty(), SelfBilledTextParser.parse(null));
+    }
+
+    @Test void outOfWindow_period_still_parses() {
+        ParsedLine p = SelfBilledTextParser.parse("Faktura: 58484650002 - 05-2024 MDS").orElseThrow();
+        assertEquals(2024, p.workYear());
+        assertEquals(5, p.workMonth());
+    }
+
+    @Test void hyphenated_faktura_number() {
+        ParsedLine p = SelfBilledTextParser.parse("Faktura: 17-869 - 07-2025 TD").orElseThrow();
+        assertEquals("17-869", p.faktura());
+        assertEquals(2025, p.workYear());
+        assertEquals(7, p.workMonth());
+        assertEquals("TD", p.code());
+    }
+
+    @Test void code_is_normalized_to_uppercase() {
+        assertEquals("MHB", SelfBilledTextParser.parse("Faktura: 123 - 09-2025 mhb").orElseThrow().code());
+    }
+
+    @Test void invalid_month_is_empty() {
+        assertTrue(SelfBilledTextParser.parse("Faktura: 123 - 00-2025 TD").isEmpty());
+        assertTrue(SelfBilledTextParser.parse("Faktura: 123 - 13-2025 TD").isEmpty());
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/parse/SelfBilledVoucherAggregatorTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/parse/SelfBilledVoucherAggregatorTest.java
@@ -1,0 +1,73 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.parse;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SelfBilledVoucherAggregatorTest {
+
+    private static SelfBilledVoucherAggregator.LineInput line(int voucher, long entry, String text, String amt) {
+        return new SelfBilledVoucherAggregator.LineInput(2106, voucher, entry,
+                new BigDecimal(amt), SelfBilledTextParser.parse(text).orElse(null), text);
+    }
+
+    @Test void duplicateBooking_reversal_nets_to_single_amount() {
+        // Verified TD 07-2025: real booking (v1771) + duplicate (v2291) reversed by an
+        // unparseable "Bogført 2 x" that shares v2291. Voucher-net must yield -55,963.44 total,
+        // never -111,926.88. (Two vouchers, same TD 07-2025.)
+        List<SelfBilledVoucherAggregator.LineInput> in = List.of(
+                line(1771, 128956, "Faktura: 17-869 - 07-2025 TD", "-55963.44"),
+                line(2291, 134124, "Faktura: 5105723572 - 07-2025 TD", "-55963.44"),
+                line(2291, 134647, "Bogført 2 x ", "55963.44"));
+        List<SelfBilledVoucherAggregator.VoucherNet> out = SelfBilledVoucherAggregator.aggregate(in);
+
+        assertEquals(2, out.size());
+        BigDecimal total = out.stream().map(SelfBilledVoucherAggregator.VoucherNet::signedAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertEquals(new BigDecimal("-55963.44"), total);
+        assertTrue(out.stream().allMatch(v -> v.resolved() && v.code().equals("TD")
+                && v.workYear() == 2025 && v.workMonth() == 7));
+    }
+
+    @Test void correction_with_parseable_sibling_inherits_period() {
+        // MHB 09-2025: real -162,537.65 + extra -78,647.26 + "Forkert beløb" +162,537.65, all v1924.
+        List<SelfBilledVoucherAggregator.LineInput> in = List.of(
+                line(1924, 128943, "Faktura: 5105733453 - 09-2025 MHB", "-162537.65"),
+                line(1924, 129029, "Faktura 5105733453 - 09-2025 MHB", "-78647.26"),
+                line(1924, 129031, "Forkert beløb ", "162537.65"));
+        List<SelfBilledVoucherAggregator.VoucherNet> out = SelfBilledVoucherAggregator.aggregate(in);
+        assertEquals(1, out.size());
+        assertEquals(new BigDecimal("-78647.26"), out.get(0).signedAmount());
+        assertTrue(out.get(0).resolved());
+    }
+
+    @Test void voucher_with_no_parseable_line_is_unresolved() {
+        List<SelfBilledVoucherAggregator.LineInput> in = List.of(
+                line(9999, 1, "Forkert kt ", "100.00"));
+        SelfBilledVoucherAggregator.VoucherNet v = SelfBilledVoucherAggregator.aggregate(in).get(0);
+        assertFalse(v.resolved());
+        assertNull(v.code());
+    }
+
+    @Test void twoParseableLinesSamePeriod_resolved_sumsBoth() {
+        List<SelfBilledVoucherAggregator.LineInput> in = List.of(
+                line(5, 1, "Faktura: INV-A - 07-2025 TD", "-100.00"),
+                line(5, 2, "Faktura: INV-B - 07-2025 TD", "-200.00"));
+        SelfBilledVoucherAggregator.VoucherNet v = SelfBilledVoucherAggregator.aggregate(in).get(0);
+        assertTrue(v.resolved());
+        assertEquals("TD", v.code());
+        assertEquals(new BigDecimal("-300.00"), v.signedAmount());
+        assertEquals(2, v.entries().size());
+    }
+
+    @Test void multiCode_voucher_is_unresolved_hardError() {
+        List<SelfBilledVoucherAggregator.LineInput> in = List.of(
+                line(7, 1, "Faktura: 1 - 07-2025 TD", "-100.00"),
+                line(7, 2, "Faktura: 2 - 07-2025 FSP", "-200.00"));
+        SelfBilledVoucherAggregator.VoucherNet v = SelfBilledVoucherAggregator.aggregate(in).get(0);
+        assertFalse(v.resolved());
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledImportServiceIT.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledImportServiceIT.java
@@ -1,0 +1,74 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
+
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.model.SelfBilledLine;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.model.SelfBilledSource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.TestTransaction;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(SelfBilledImportServiceIT.NoDevServicesProfile.class)
+class SelfBilledImportServiceIT {
+
+    public static class NoDevServicesProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.s3.devservices.enabled", "false",
+                    "cvtool.username", "test-placeholder",
+                    "cvtool.password", "test-placeholder"
+            );
+        }
+    }
+
+    @Inject SelfBilledImportService service;
+    @Inject SelfBilledCodeResolver resolver;
+
+    private SelfBilledSource source() {
+        SelfBilledSource s = new SelfBilledSource();
+        s.uuid = "5e1f0001-0000-4000-8000-000000002104";
+        s.agreementCompanyUuid = "d8894494-2fb4-4f72-9e05-e6032e6dd691";
+        s.accountNumber = 2104;
+        s.clientUuid = "2cbb7f5e-9e2b-4edc-870b-e9591dc58891";
+        s.enabled = true; s.label = "Vattenfall";
+        return s;
+    }
+
+    @Test
+    @TestTransaction
+    void processLines_nets_corrections_into_voucher_period_and_is_idempotent() {
+        // Map TESTCODE so the voucher resolves (issuer may be null in test — irrelevant to this assertion).
+        resolver.confirmMapping(source().agreementCompanyUuid, 2104, "TESTCODE", "test-consultant", "it");
+
+        // One voucher (1771): a parseable Faktura line + a "Bogført 2 x" correction sharing it.
+        List<SelfBilledImportService.RawLine> raw = List.of(
+                new SelfBilledImportService.RawLine(2104, 1771, 990001L, LocalDate.of(2025, 11, 1),
+                        "Faktura: 99 - 07-2025 TESTCODE", new BigDecimal("-55963.44")),
+                new SelfBilledImportService.RawLine(2104, 1771, 990002L, LocalDate.of(2025, 12, 1),
+                        "Bogført 2 x ", new BigDecimal("0.00")));
+
+        int n1 = service.processLines(source(), raw);
+        assertEquals(2, n1);
+
+        // F1 fix: the correction sibling inherits the voucher's work period (not null).
+        SelfBilledLine correction = SelfBilledLine.findByEntry(990002L);
+        assertEquals(Integer.valueOf(2025), correction.workYear, "F1: correction 990002 must inherit voucher work-year from its parseable sibling");
+        assertEquals(Integer.valueOf(7), correction.workMonth, "F1: correction 990002 must inherit voucher work-month");
+        assertEquals("TESTCODE", correction.code, "F1: correction 990002 must inherit voucher code");
+
+        // Idempotent: re-running keeps one row per entry.
+        service.processLines(source(), raw);
+        assertEquals(1, SelfBilledLine.count("entryNumber", 990001L));
+        assertEquals(1, SelfBilledLine.count("entryNumber", 990002L));
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledRestampPlannerTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledRestampPlannerTest.java
@@ -1,0 +1,79 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
+
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.RestampDecision;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SelfBilledRestampPlannerTest {
+
+    private static final String VAT = "vat", ENE = "ene", AS = "as";
+
+    private static SelfBilledRestampPlanner.Internal internal(String uuid, String client, String cons, String amt, Integer sy, Integer sm) {
+        return new SelfBilledRestampPlanner.Internal(uuid, client, AS, cons, new BigDecimal(amt), sy, sm);
+    }
+    private static SelfBilledRestampPlanner.Target target(String client, String cons, int y, int m, String amt) {
+        return new SelfBilledRestampPlanner.Target(client, AS, cons, y, m, new BigDecimal(amt));
+    }
+
+    @Test void unstamped_internal_with_unique_match_is_restamped() {
+        // Michelle Sep 78,200 exists (settlement_* NULL); self-billed Sep 78,200 -> re-stamp to VAT 2025-09.
+        List<RestampDecision> d = SelfBilledRestampPlanner.plan(
+                List.of(internal("i-sep", VAT, "michelle", "78200.00", null, null)),
+                List.of(target(VAT, "michelle", 2025, 9, "78200.00")));
+        assertEquals(RestampDecision.Outcome.RESTAMP, d.get(0).outcome());
+        assertEquals(VAT, d.get(0).clientUuid());
+        assertEquals(2025, d.get(0).workYear());
+        assertEquals(9, d.get(0).workMonth());
+    }
+
+    @Test void arrears_internal_with_no_target_is_unmatched_not_reversed() {
+        // Julie Apr 132,651.70 exists but April is not self-billed yet -> UNMATCHED (leave alone, no clawback).
+        List<RestampDecision> d = SelfBilledRestampPlanner.plan(
+                List.of(internal("i-apr", ENE, "julie", "132651.70", 2026, 4)),
+                List.of());
+        assertEquals(RestampDecision.Outcome.UNMATCHED, d.get(0).outcome());
+    }
+
+    @Test void already_correctly_stamped_is_no_change() {
+        List<RestampDecision> d = SelfBilledRestampPlanner.plan(
+                List.of(internal("i-aug", VAT, "michelle", "153525.00", 2025, 8)),
+                List.of(target(VAT, "michelle", 2025, 8, "153525.00")));
+        assertEquals(RestampDecision.Outcome.NO_CHANGE, d.get(0).outcome());
+    }
+
+    @Test void different_client_does_not_match() {
+        // A self-billed target on Energinet must NOT re-stamp a Vattenfall internal even at equal amount.
+        List<RestampDecision> d = SelfBilledRestampPlanner.plan(
+                List.of(internal("i-x", VAT, "michelle", "100000.00", null, null)),
+                List.of(target(ENE, "michelle", 2025, 7, "100000.00")));
+        assertEquals(RestampDecision.Outcome.UNMATCHED, d.get(0).outcome());
+    }
+
+    @Test void ambiguous_when_two_same_client_targets_match_amount() {
+        List<RestampDecision> d = SelfBilledRestampPlanner.plan(
+                List.of(internal("i-x", VAT, "michelle", "100000.00", null, null)),
+                List.of(target(VAT, "michelle", 2025, 7, "100000.00"), target(VAT, "michelle", 2025, 9, "100000.00")));
+        assertEquals(RestampDecision.Outcome.AMBIGUOUS, d.get(0).outcome());
+    }
+
+    @Test void wrong_period_stamp_with_unique_match_is_restamped_to_correct_period() {
+        // THE primary migration scenario: internal stamped to the wrong period, unique self-billed target -> RESTAMP.
+        List<RestampDecision> d = SelfBilledRestampPlanner.plan(
+                List.of(internal("i-x", VAT, "michelle", "78200.00", 2025, 7)), // stamped wrong (Jul)
+                List.of(target(VAT, "michelle", 2025, 9, "78200.00")));         // correct period (Sep)
+        assertEquals(RestampDecision.Outcome.RESTAMP, d.get(0).outcome());
+        assertEquals(2025, d.get(0).workYear());
+        assertEquals(9, d.get(0).workMonth());
+    }
+
+    @Test void amount_just_outside_tolerance_is_unmatched() {
+        List<RestampDecision> d = SelfBilledRestampPlanner.plan(
+                List.of(internal("i-x", VAT, "michelle", "100000.00", null, null)),
+                List.of(target(VAT, "michelle", 2025, 7, "99998.99"))); // diff = 1001.01 kr > 1 kr
+        assertEquals(RestampDecision.Outcome.UNMATCHED, d.get(0).outcome());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a self-contained `aggregates/invoice/selfbilled/` package that settles **cross-company self-billed labour at the exact e-conomic self-billed amount** — per consultant, per **work** period (sourced from the per-consultant debtor lines on accounts 2104 Vattenfall / 2106 Energinet) — so each cross-company internal equals the external revenue, never the timesheet value. It runs **alongside the untouched lump-PHANTOM import**; no pre-existing file is modified.

13 commits, one per plan task. Built via subagent-driven development with per-task spec + code-quality review and a final holistic review (**READY TO MERGE**).

### What's in it
- **V364** migration: 3 additive tables (`selfbilled_source` seeded with the 2 known sources, `selfbilled_code_map`, `selfbilled_line`) + 4 Panache entities.
- **Pure core (TDD):** tolerant line-text parser + voucher-grain netting. **F1 fix** — the voucher-resolved code/period/consultant/issuer is stamped onto *every* sibling row (incl. corrections) so SQL aggregates net correctly (e.g. a duplicate booking reversed by a "Bogført 2 x" nets to its true single value).
- **Capture:** e-conomic fetch + `processLines` upsert (idempotent on `entry_number`).
- **Settlement:** `SelfBilledSettlementService` **injects `PhantomSettlementService`** and reuses its public `settledLinesForGroup` + `hasOpenQueuedInternal` (one source of truth, **R1**); the cross-company target is inline `-SUM(amount)` SQL filtered `issuer <> debtor` and `issuer IS NOT NULL` (**R2**). Dedup is keyed entirely off the `settlement_*` stamp.
- **Migration (3-phase, gated, report-first):** capture → re-stamp existing internals to work-period (**F2** — matched by phantom-ref client + consultant + amount±1kr; UNMATCHED never reverses) → settle. A safety guard aborts (rolls back) on any conflicting RESTAMP target period.
- **Endpoints:** `POST /invoices/cross-company/selfbilled/{capture,restamp,settle,code-map}`, each `@RolesAllowed({"invoices:write"})`; code-map acting user from `RequestHeaderHolder` (`X-Requested-By`), no spoofable param (**R3**); `restamp` defaults `apply=false` (report-only).

### Safety posture
The endpoints are **inert** until an accountant maps consultant codes and runs the gated phases. `restamp` is report-first; `settle` reuses the existing double-settlement guard; the migration is fully human-gated.

## Test Plan
- [x] 21 pure unit tests pass — parser (9), voucher aggregator (5), re-stamp planner (7). Full-module `test-compile` green.
- [x] `SelfBilledImportServiceIT` (`@QuarkusTest`, `@TestTransaction`) exercises the real `processLines` path; **DB-gated** (boots on CI/staging only — locally the compile is the gate).
- [ ] **Staging dry-run is the real gate for the DB-dependent SQL** — execute `docs/superpowers/plans/2026-06-09-phantom-selfbilled-staging-runbook.md` (window FY2025/26): capture (~170 lines) → restamp REPORT (Michelle Sep/Jan=RESTAMP, Julie Apr=UNMATCHED arrears) → restamp APPLY → settle (queue) → reconcile vs the verification report. Re-run must create nothing (dup guard).

## Notes / follow-ups (non-blocking, by design)
- Frontend (Settings tab + review queue, incl. the deferred code auto-suggestion ranker) is a separate plan.
- `confirmMapping` writes the map only; a re-capture re-resolves `UNMAPPED_CODE` lines (runbook ordering handles this).
- `captureSource` logs+continues on a partial e-conomic fetch error (acceptable for idempotent re-runnable capture; the runbook's ~170-line check catches under-capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)