### PR TITLE
Workbench usability batch: assign-modal context, bulk-accept preview, link-queue prefill, paid-gated settlement lifecycle

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/jobs/QueuedInternalInvoiceProcessorBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/jobs/QueuedInternalInvoiceProcessorBatchlet.java
@@ -13,12 +13,15 @@ import dk.trustworks.intranet.aggregates.invoice.services.InternalInvoiceOrchest
 import dk.trustworks.intranet.aggregates.invoice.services.InvoiceAttributionService;
 import dk.trustworks.intranet.aggregates.invoice.services.SourceItemMerger;
 import dk.trustworks.intranet.aggregates.invoice.services.UserCompanyResolver;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.services.SelfBilledDeltaQuery;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.services.SelfBilledPaidGate;
 import dk.trustworks.intranet.batch.monitoring.BatchExceptionTracking;
 import dk.trustworks.intranet.contracts.model.ContractTypeItem;
 import jakarta.batch.api.AbstractBatchlet;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import lombok.extern.jbosslog.JBossLog;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -69,6 +72,12 @@ public class QueuedInternalInvoiceProcessorBatchlet extends AbstractBatchlet {
 
     @Inject
     PricingEngine pricingEngine;
+
+    @Inject
+    SelfBilledDeltaQuery selfBilledDeltaQuery;
+
+    @Inject
+    EntityManager em;
 
     @ConfigProperty(name = "feature.invoicing.internal.attribution-driven", defaultValue = "true")
     boolean attributionDrivenInternalInvoices;
@@ -149,7 +158,97 @@ public class QueuedInternalInvoiceProcessorBatchlet extends AbstractBatchlet {
         log.infof("QueuedInternalInvoiceProcessorBatchlet completed: total=%d, processed=%d, skipped=%d, failed=%d",
                 queuedInvoices.size(), processed, skipped, failed);
 
+        processSettlementInternals();
+
         return "COMPLETED";
+    }
+
+    /**
+     * Second pass (Feature 3c): auto-finalize QUEUED settlement INTERNALs that reference a PHANTOM source.
+     *
+     * <p>These never match the first pass — a settlement internal references a PHANTOM (not a real source
+     * invoice with {@code economics_status = PAID}), and it carries DELTA lines that must NOT be regenerated
+     * from source attribution (that would re-derive the full amount and over-book). Instead they go through
+     * the self-billed paid-gate: a settlement internal may finalize only when the client has paid every
+     * self-billing voucher backing its (client, consultant, work-period) group — i.e. every backing
+     * voucher's 8610 'Samlekonto debitorer' remainder is exactly 0 (reusing
+     * {@link SelfBilledDeltaQuery#voucherRemainders} + {@link SelfBilledPaidGate#allPaid}, the SAME lookup
+     * as the workbench {@code /internals/queued} read — no duplicated SQL). Fail-closed: a voucher with no
+     * 8610 row (null remainder) or an empty backing set means NOT paid -> skip. No item regeneration.
+     */
+    private void processSettlementInternals() {
+        // Native, parameter-bound discovery (selfbilled idiom): QUEUED settlement INTERNALs whose
+        // invoice_ref_uuid points at a PHANTOM source. A separate native query keeps the PHANTOM-type
+        // join out of HQL (no Panache active-record subquery precedent in this codebase).
+        @SuppressWarnings("unchecked")
+        List<String> uuids = em.createNativeQuery("""
+                SELECT i.uuid
+                FROM invoices i
+                JOIN invoices src ON src.uuid = i.invoice_ref_uuid
+                WHERE i.type = 'INTERNAL' AND i.status = 'QUEUED'
+                  AND i.settlement_billing_client_uuid IS NOT NULL
+                  AND i.settlement_year IS NOT NULL AND i.settlement_month IS NOT NULL
+                  AND src.type = 'PHANTOM'
+                """).getResultList();
+        List<Invoice> settlementInternals = uuids.isEmpty()
+                ? List.of()
+                : Invoice.list("uuid in ?1", uuids);
+
+        log.infof("Found %d queued settlement internals (PHANTOM-referenced) to evaluate", settlementInternals.size());
+
+        int processed = 0, skipped = 0, failed = 0;
+        for (Invoice internal : settlementInternals) {
+            try {
+                String consultant = settlementConsultant(internal);
+                if (consultant == null) {
+                    log.warnf("Settlement internal %s has no single item consultant — skipping", internal.getUuid());
+                    skipped++;
+                    continue;
+                }
+                List<SelfBilledPaidGate.VoucherRemainder> remainders = selfBilledDeltaQuery.voucherRemainders(
+                        internal.getSettlementBillingClientUuid(), internal.getSettlementDebtorCompanyuuid(),
+                        consultant, internal.getSettlementYear(), internal.getSettlementMonth());
+
+                if (!SelfBilledPaidGate.allPaid(remainders)) {
+                    log.debugf("Settlement internal %s not yet paid (client=%s consultant=%s %d-%02d, "
+                                    + "backingVouchers=%d) — skipping",
+                            internal.getUuid(), internal.getSettlementBillingClientUuid(), consultant,
+                            internal.getSettlementYear(), internal.getSettlementMonth(), remainders.size());
+                    skipped++;
+                    continue;
+                }
+
+                internal.setInvoicedate(LocalDate.now());
+                internal.setDuedate(LocalDate.now().plusDays(1));
+                log.infof("Auto-finalizing settlement internal %s (self-billing vouchers paid)", internal.getUuid());
+                internalOrchestrator.finalizeAutomatically(internal.getUuid());
+                log.infof("Successfully auto-finalized settlement internal %s", internal.getUuid());
+                processed++;
+            } catch (Exception e) {
+                log.warnf(e, "Auto-finalize failed for settlement internal %s", internal.getUuid());
+                failed++;
+            }
+        }
+
+        log.infof("QueuedInternalInvoiceProcessorBatchlet settlement pass completed: total=%d, processed=%d, "
+                        + "skipped=%d, failed=%d",
+                settlementInternals.size(), processed, skipped, failed);
+    }
+
+    /** The single consultant on a settlement internal's items, or null if items carry zero or >1 consultants. */
+    private String settlementConsultant(Invoice internal) {
+        List<InvoiceItem> items = internal.getInvoiceitems();
+        if (items == null || items.isEmpty()) return null;
+        String consultant = null;
+        for (InvoiceItem item : items) {
+            if (item.consultantuuid == null || item.consultantuuid.isBlank()) continue;
+            if (consultant == null) {
+                consultant = item.consultantuuid;
+            } else if (!consultant.equals(item.consultantuuid)) {
+                return null;   // ambiguous — never guess
+            }
+        }
+        return consultant;
     }
 
     /**

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/AcceptResult.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/AcceptResult.java
@@ -1,0 +1,9 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.dto;
+
+/**
+ * Outcome of a bulk same-company accept (Feature 1b): {@code accepted} = vouchers placed,
+ * {@code skipped} = candidates re-checked server-side and rejected (no longer same-company,
+ * already placed, or unknown). Returned by BOTH the no-body ≥90 auto-path and the explicit
+ * lineUuids path so the workbench reports a consistent count.
+ */
+public record AcceptResult(int accepted, int skipped) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/AcceptSuggestedRequest.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/AcceptSuggestedRequest.java
@@ -1,0 +1,11 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.dto;
+
+import java.util.List;
+
+/**
+ * Optional body for {@code POST /assignments/accept-suggested} (Feature 1b). When present,
+ * accept exactly these voucher anchor lines (each re-checked server-side: still same-company
+ * AND still UNASSIGNED) instead of the ≥90 auto-sweep. A null/empty body keeps the original
+ * no-body ≥90 behaviour unchanged.
+ */
+public record AcceptSuggestedRequest(List<String> lineUuids) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/AssignContextDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/AssignContextDTO.java
@@ -1,0 +1,14 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.dto;
+
+/**
+ * Assign-modal consequence preview (spec §5.3): ties the caller-selected
+ * consultant + work period (which may differ from the suggestion) to its
+ * cross-company verdict, the issuer/debtor companies, and the registered-work
+ * CROSS-CHECK value (never a settlement basis — AC1). issuerCompanyUuid/Name are
+ * null when the consultant's company can't be resolved for the period; workValue
+ * is normalized positive and 0.0 when no work is registered.
+ */
+public record AssignContextDTO(boolean crossCompany,
+                               String issuerCompanyUuid, String issuerCompanyName,
+                               String debtorCompanyUuid, String debtorCompanyName,
+                               double workValue) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/QueuedInternalRow.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/QueuedInternalRow.java
@@ -1,0 +1,14 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.dto;
+
+/**
+ * One QUEUED settlement INTERNAL (Feature 3b) for the workbench's queued lane: a
+ * settlement-stamped INTERNAL whose (settlement_year*100 + settlement_month) is in the
+ * requested window. {@code total} = Σ items (hours*rate). {@code paid}/{@code outstanding}
+ * come from the underlying self-billing vouchers' 8610 'Samlekonto debitorer' remainder at
+ * the source's debtor company — paid when every backing voucher's remainder is exactly 0
+ * (the client has paid the self-billing invoice); outstanding = Σ positive remainders.
+ * Consultant identity is masked without {@code users:read}.
+ */
+public record QueuedInternalRow(String invoiceUuid, String consultantUuid, String consultantName,
+                                int workYear, int workMonth, double total,
+                                boolean paid, double outstanding) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/SameCompanyCandidateDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/SameCompanyCandidateDTO.java
@@ -1,0 +1,15 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.dto;
+
+/**
+ * One same-company bulk-accept candidate (Feature 1a): an UNASSIGNED voucher whose
+ * suggested consultant's company as-of the suggested work period equals the source's
+ * debtor (agreement) company — so accepting it never crosses companies (AC2). Unlike
+ * {@link SelfBilledAssignmentService#acceptSuggestedSameCompany}'s ≥90 auto-path, the
+ * preview returns candidates at ANY confidence so a human can review the long tail
+ * before an explicit accept. amount is normalized positive; consultant identity is
+ * masked at the resource without {@code users:read} (mirrors maskDocuments).
+ */
+public record SameCompanyCandidateDTO(String lineUuid, int voucherNumber, String bookingDate,
+                                      double amount, String suggestedCode,
+                                      String consultantUuid, String consultantName,
+                                      int workYear, int workMonth, int confidence) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/UnlinkedInternalRow.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/dto/UnlinkedInternalRow.java
@@ -4,9 +4,18 @@ import java.util.List;
 
 /**
  * Link-queue candidate (AC8): a live cross-company INTERNAL/INTERNAL_SERVICE to an
- * in-scope debtor company with NO settlement stamp. Loose, read-only discovery —
- * a human links it; nothing is auto-matched. total normalized positive.
+ * in-scope debtor company with NO settlement stamp, narrowed to internals that are
+ * self-billed-related (no source ref, missing source row, or a source whose client is
+ * an enabled self-billed source). Loose, read-only discovery — a human links it;
+ * nothing is auto-matched. total normalized positive.
+ *
+ * <p>Prefill (Feature 2b): {@code suggestedConsultant*} come from the internal's own
+ * items when they all carry the SAME consultant (else null); {@code suggestedWork*}
+ * come from the referenced source invoice's period when the source exists (else null).
+ * The suggested consultant uuid+name are masked without {@code users:read}; periods stay.
  */
 public record UnlinkedInternalRow(String invoiceUuid, int invoicenumber, String type, String status,
                                   String issuerCompanyName, String debtorCompanyName, String invoicedate,
-                                  String description, double total, List<String> itemNames) {}
+                                  String description, double total, List<String> itemNames,
+                                  String suggestedConsultantUuid, String suggestedConsultantName,
+                                  Integer suggestedWorkYear, Integer suggestedWorkMonth) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/resources/SelfBilledResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/resources/SelfBilledResource.java
@@ -1,8 +1,11 @@
 package dk.trustworks.intranet.aggregates.invoice.selfbilled.resources;
 
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.AcceptResult;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.AcceptSuggestedRequest;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.AssignContextDTO;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.AssignRequest;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.ConsultantPeriodRow;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.SameCompanyCandidateDTO;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.HistoryRow;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.LinkRequest;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.SelfBilledAssignmentDTO;
@@ -110,16 +113,38 @@ public class SelfBilledResource {
         assignmentService.unmark(lineUuid, requireActor());
     }
 
-    /** Bulk-accept high-confidence SAME-COMPANY suggestions only (AC2). Returns {accepted: n}. */
+    /**
+     * Preview ALL same-company candidates in the window (any confidence) — UNASSIGNED vouchers
+     * whose suggested consultant is same-company as the source's debtor (AC2). Read-only; the
+     * human reviews the long tail before an explicit accept (POST below with a lineUuids body).
+     */
+    @GET @Path("/assignments/accept-suggested/preview")
+    @RolesAllowed({"invoices:read"})
+    public List<SameCompanyCandidateDTO> acceptSuggestedPreview(@QueryParam("client") String client,
+                                                               @QueryParam("from") String from,
+                                                               @QueryParam("to") String to) {
+        requireClient(client);
+        return maskCandidates(assignmentService.sameCompanyCandidatePreview(
+                client, parseDate(from, "from"), parseDate(to, "to")));
+    }
+
+    /**
+     * Bulk-accept SAME-COMPANY suggestions only (AC2). No body = the original ≥90 auto-sweep;
+     * a {@code {"lineUuids":[...]}} body = accept exactly those lines (each re-checked server-side:
+     * still same-company AND still UNASSIGNED). Returns {accepted, skipped} in both modes.
+     */
     @POST @Path("/assignments/accept-suggested")
     @RolesAllowed({"invoices:write"})
-    public Map<String, Integer> acceptSuggested(@QueryParam("client") String client,
-                                                @QueryParam("from") String from,
-                                                @QueryParam("to") String to) {
+    public AcceptResult acceptSuggested(@QueryParam("client") String client,
+                                        @QueryParam("from") String from,
+                                        @QueryParam("to") String to,
+                                        AcceptSuggestedRequest req) {
         requireClient(client);
-        int n = assignmentService.acceptSuggestedSameCompany(client, parseDate(from, "from"),
-                parseDate(to, "to"), requireActor());
-        return Map.of("accepted", n);
+        LocalDate fromDate = parseDate(from, "from"), toDate = parseDate(to, "to");
+        if (req != null && req.lineUuids() != null && !req.lineUuids().isEmpty()) {
+            return assignmentService.acceptSuggestedLines(client, fromDate, toDate, req.lineUuids(), requireActor());
+        }
+        return assignmentService.acceptSuggestedSameCompany(client, fromDate, toDate, requireActor());
     }
 
     /** Confirm one code→consultant mapping (kept from the capture stack). */
@@ -281,6 +306,15 @@ public class SelfBilledResource {
                         a.workYear(), a.workMonth(), a.shareAmount(), a.source(), null, a.assignedAt())).toList()))
                 .toList();
         return new SelfBilledDocumentsResponse(docs, r.coverage(), r.tieOut());
+    }
+
+    // Same boundary as maskDocuments: strip the resolved consultant uuid + name without
+    // users:read. suggestedCode is the issuer's own e-conomic booking text (accepted boundary).
+    private List<SameCompanyCandidateDTO> maskCandidates(List<SameCompanyCandidateDTO> rows) {
+        if (scopeContext.hasScope("users:read")) return rows;
+        return rows.stream().map(c -> new SameCompanyCandidateDTO(c.lineUuid(), c.voucherNumber(),
+                c.bookingDate(), c.amount(), c.suggestedCode(), null, null,
+                c.workYear(), c.workMonth(), c.confidence())).toList();
     }
 
     private List<ConsultantPeriodRow> maskConsultants(List<ConsultantPeriodRow> rows) {

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/resources/SelfBilledResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/resources/SelfBilledResource.java
@@ -8,6 +8,7 @@ import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.ConsultantPeriod
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.SameCompanyCandidateDTO;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.HistoryRow;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.LinkRequest;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.QueuedInternalRow;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.SelfBilledAssignmentDTO;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.SelfBilledDocumentDTO;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.SelfBilledDocumentsResponse;
@@ -219,6 +220,21 @@ public class SelfBilledResource {
         return maskUnlinked(historyService.unlinkedInternals());
     }
 
+    /**
+     * Queued-lane read (Feature 3b): settlement-stamped QUEUED INTERNALs for the client whose settlement
+     * period is in the window, each carrying paid/outstanding from the underlying self-billing vouchers'
+     * 8610 remainder. Consultant identity masked without users:read.
+     */
+    @GET @Path("/internals/queued")
+    @RolesAllowed({"invoices:read"})
+    public List<QueuedInternalRow> queuedInternals(@QueryParam("client") String client,
+                                                   @QueryParam("fromYm") int fromYm,
+                                                   @QueryParam("toYm") int toYm) {
+        requireClient(client);
+        requireYmWindow(fromYm, toYm);
+        return maskQueued(settlementService.queuedInternals(client, fromYm, toYm));
+    }
+
     @POST @Path("/internals/{invoiceUuid}/link")
     @RolesAllowed({"invoices:write"})
     public void link(@PathParam("invoiceUuid") String invoiceUuid, LinkRequest req) {
@@ -322,6 +338,13 @@ public class SelfBilledResource {
         return rows.stream().map(c -> new ConsultantPeriodRow(null, null, c.workYear(), c.workMonth(),
                 c.issuerCompanyUuid(), c.issuerCompanyName(), c.assigned(), c.settled(), c.delta(),
                 c.workValue(), c.canSettle(), c.unlinkedCandidates())).toList();
+    }
+
+    // Strip consultant uuid + name without users:read; paid/outstanding/total/period are not identity.
+    private List<QueuedInternalRow> maskQueued(List<QueuedInternalRow> rows) {
+        if (scopeContext.hasScope("users:read")) return rows;
+        return rows.stream().map(q -> new QueuedInternalRow(q.invoiceUuid(), null, null,
+                q.workYear(), q.workMonth(), q.total(), q.paid(), q.outstanding())).toList();
     }
 
     private List<HistoryRow> maskHistory(List<HistoryRow> rows) {

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/resources/SelfBilledResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/resources/SelfBilledResource.java
@@ -332,11 +332,13 @@ public class SelfBilledResource {
 
     // itemNames carry the attributed consultant's FULL NAME (InternalInvoiceLineGenerator labels
     // each line with attribution.consultantName); description (specificdescription) is free text
-    // that may also name the consultant. Strip both without users:read; keep every other component.
+    // that may also name the consultant; the Feature 2b prefill resolves the item consultant uuid
+    // to a name. Strip all three (uuid + name) without users:read; periods are not identity and stay.
     private List<UnlinkedInternalRow> maskUnlinked(List<UnlinkedInternalRow> rows) {
         if (scopeContext.hasScope("users:read")) return rows;
         return rows.stream().map(u -> new UnlinkedInternalRow(u.invoiceUuid(), u.invoicenumber(),
                 u.type(), u.status(), u.issuerCompanyName(), u.debtorCompanyName(), u.invoicedate(),
-                null, u.total(), List.of())).toList();
+                null, u.total(), List.of(),
+                null, null, u.suggestedWorkYear(), u.suggestedWorkMonth())).toList();
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/resources/SelfBilledResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/resources/SelfBilledResource.java
@@ -1,5 +1,6 @@
 package dk.trustworks.intranet.aggregates.invoice.selfbilled.resources;
 
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.AssignContextDTO;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.AssignRequest;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.ConsultantPeriodRow;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.HistoryRow;
@@ -140,6 +141,28 @@ public class SelfBilledResource {
         requireClient(client);
         requireYmWindow(fromYm, toYm);
         return maskConsultants(settlementService.consultantRows(client, fromYm, toYm));
+    }
+
+    /**
+     * Assign-modal consequence preview for the SELECTED (consultant, work-period) — which may differ
+     * from the row's suggestion: cross-company verdict, issuer/debtor companies, and the registered-work
+     * cross-check. No masking is applied: the response ties a CALLER-SUPPLIED consultant uuid to a work
+     * value and a company — the uuid is the caller's own input, never resolved to a name here, so no
+     * identity is leaked (uuid→identity resolution still requires users:read elsewhere). Mirrors the
+     * data-boundary reasoning of maskConsultants without needing to strip anything.
+     */
+    @GET @Path("/assign-context")
+    @RolesAllowed({"invoices:read"})
+    public AssignContextDTO assignContext(@QueryParam("client") String client,
+                                          @QueryParam("consultant") String consultant,
+                                          @QueryParam("year") int year,
+                                          @QueryParam("month") int month) {
+        requireClient(client);
+        if (consultant == null || consultant.isBlank()) {
+            throw new WebApplicationException("consultant is required", Response.Status.BAD_REQUEST);
+        }
+        requireWorkPeriod(year, month);
+        return settlementService.assignContext(client, consultant, year, month);
     }
 
     /** Book the pass-through internal / credit note for one (consultant, work-period). */

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/HistoryReconciliationService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/HistoryReconciliationService.java
@@ -101,14 +101,24 @@ public class HistoryReconciliationService {
     }
 
     /**
-     * Loose read-only discovery (spec §6.2/§8): unstamped live cross-company internals to in-scope debtors.
+     * Loose read-only discovery (spec §6.2/§8): unstamped live cross-company internals to in-scope debtors,
+     * NARROWED (Feature 2a) to internals that are self-billed-related.
      *
-     * <p>Global by design (security review L-1): this queue spans ALL enabled self-billed clients and
-     * cannot be scoped to a single client. An unlinked internal has no settlement key yet, so it carries
-     * no client linkage until a human links it; and enabled sources can share a debtor company, so a
-     * per-client filter could not discriminate between them. The result is therefore scoped only to
-     * enabled self-billed debtors ({@code selfbilled_source.enabled = 1}). Consultant identity is masked
-     * downstream for callers lacking the {@code users:read} scope.
+     * <p>Scope (security review L-1): still spans ALL enabled self-billed clients — an unlinked internal
+     * has no settlement key yet, so it carries no client linkage until a human links it, and enabled
+     * sources can share a debtor company. The queue therefore stays scoped only to enabled self-billed
+     * debtors ({@code selfbilled_source.enabled = 1}). On top of that the Feature 2a filter EXCLUDES any
+     * internal whose referenced source invoice belongs to a client that is NOT an enabled self-billed
+     * source: an internal is kept when it has no source ref ({@code invoice_ref_uuid IS NULL}), its source
+     * row is missing, OR its source's self-billed client is enabled. Settlement internals reference a
+     * PHANTOM source, and a phantom carries its synthetic self-billed client in {@code billing_client_uuid}
+     * (legacy/non-phantom sources may instead carry it in {@code clientuuid}); the filter matches EITHER
+     * column against {@code selfbilled_source.client_uuid} so both shapes are kept. Consultant identity is
+     * masked downstream for callers lacking the {@code users:read} scope.
+     *
+     * <p>Prefill (Feature 2b): the suggested consultant is the internal's own item consultant when ALL
+     * items carry the same non-null {@code consultantuuid} (else null — never guessed), and the suggested
+     * work period is the source invoice's {@code year}/{@code month} when the source exists (else null).
      */
     @Transactional
     public List<UnlinkedInternalRow> unlinkedInternals() {
@@ -116,28 +126,47 @@ public class HistoryReconciliationService {
         List<Object[]> rows = em.createNativeQuery("""
                 SELECT i.uuid, i.invoicenumber, i.type, i.status, ic.name, dc.name, i.invoicedate,
                        i.specificdescription, COALESCE(SUM(ii.hours*ii.rate), 0),
-                       GROUP_CONCAT(DISTINCT ii.itemname SEPARATOR ' | ')
+                       GROUP_CONCAT(DISTINCT ii.itemname SEPARATOR ' | '),
+                       CASE WHEN COUNT(DISTINCT ii.consultantuuid) = 1 THEN MAX(ii.consultantuuid) END,
+                       src.year, src.month
                 FROM invoices i
                 JOIN invoiceitems ii ON ii.invoiceuuid = i.uuid
                 LEFT JOIN companies ic ON ic.uuid = i.companyuuid
                 LEFT JOIN companies dc ON dc.uuid = i.debtor_companyuuid
+                LEFT JOIN invoices src ON src.uuid = i.invoice_ref_uuid
                 WHERE i.type IN ('INTERNAL','INTERNAL_SERVICE')
                   AND i.status IN ('PENDING_REVIEW','QUEUED','CREATED')
                   AND i.settlement_year IS NULL
                   AND i.companyuuid <> i.debtor_companyuuid
                   AND i.debtor_companyuuid IN (SELECT agreement_company_uuid FROM selfbilled_source WHERE enabled = 1)
-                GROUP BY i.uuid, i.invoicenumber, i.type, i.status, ic.name, dc.name, i.invoicedate, i.specificdescription
+                  AND (i.invoice_ref_uuid IS NULL
+                       OR src.uuid IS NULL
+                       OR COALESCE(src.billing_client_uuid, src.clientuuid)
+                            IN (SELECT client_uuid FROM selfbilled_source WHERE enabled = 1))
+                GROUP BY i.uuid, i.invoicenumber, i.type, i.status, ic.name, dc.name, i.invoicedate,
+                         i.specificdescription, src.year, src.month
                 ORDER BY i.invoicedate DESC
                 """).getResultList();
         List<UnlinkedInternalRow> out = new ArrayList<>(rows.size());
         for (Object[] r : rows) {
+            String consultant = (String) r[10];   // null unless all items share one consultant
+            Integer year = r[11] == null ? null : ((Number) r[11]).intValue();
+            Integer month = r[12] == null ? null : ((Number) r[12]).intValue();
             out.add(new UnlinkedInternalRow((String) r[0], r[1] == null ? 0 : ((Number) r[1]).intValue(),
                     (String) r[2], (String) r[3], (String) r[4], (String) r[5],
                     r[6] == null ? null : r[6].toString(), (String) r[7],
                     toBig(r[8]).doubleValue(),
-                    r[9] == null ? List.of() : List.of(((String) r[9]).split(" \\| "))));
+                    r[9] == null ? List.of() : List.of(((String) r[9]).split(" \\| ")),
+                    consultant, null /* name filled below */, year, month));
         }
-        return out;
+        Set<String> ids = new HashSet<>();
+        out.forEach(u -> { if (u.suggestedConsultantUuid() != null) ids.add(u.suggestedConsultantUuid()); });
+        Map<String, String> names = consultantNames(ids);
+        return out.stream().map(u -> new UnlinkedInternalRow(u.invoiceUuid(), u.invoicenumber(), u.type(),
+                u.status(), u.issuerCompanyName(), u.debtorCompanyName(), u.invoicedate(), u.description(),
+                u.total(), u.itemNames(), u.suggestedConsultantUuid(),
+                u.suggestedConsultantUuid() == null ? null : names.get(u.suggestedConsultantUuid()),
+                u.suggestedWorkYear(), u.suggestedWorkMonth())).toList();
     }
 
     /** Count only — feeds the Consultants-tab "unlinked candidates exist" warning (AC8). */

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/HistoryReconciliationService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/HistoryReconciliationService.java
@@ -108,13 +108,20 @@ public class HistoryReconciliationService {
      * has no settlement key yet, so it carries no client linkage until a human links it, and enabled
      * sources can share a debtor company. The queue therefore stays scoped only to enabled self-billed
      * debtors ({@code selfbilled_source.enabled = 1}). On top of that the Feature 2a filter EXCLUDES any
-     * internal whose referenced source invoice belongs to a client that is NOT an enabled self-billed
-     * source: an internal is kept when it has no source ref ({@code invoice_ref_uuid IS NULL}), its source
-     * row is missing, OR its source's self-billed client is enabled. Settlement internals reference a
-     * PHANTOM source, and a phantom carries its synthetic self-billed client in {@code billing_client_uuid}
-     * (legacy/non-phantom sources may instead carry it in {@code clientuuid}); the filter matches EITHER
-     * column against {@code selfbilled_source.client_uuid} so both shapes are kept. Consultant identity is
-     * masked downstream for callers lacking the {@code users:read} scope.
+     * internal whose referenced source invoice belongs to a work client that is NOT an enabled self-billed
+     * source. An internal is kept when it has no source ref ({@code invoice_ref_uuid IS NULL}), its source
+     * row is missing, OR its source resolves to an enabled self-billed client by either rule below:
+     * <ul>
+     *   <li>an INVOICE source's REAL work client is its {@code project.clientuuid} (joined via
+     *       {@code src.projectuuid}); an INVOICE's {@code billing_client_uuid} is the contract billing
+     *       entity (e.g. a broker), never the work client, so it is NOT used for INVOICE sources;</li>
+     *   <li>a PHANTOM source has no project but carries its synthetic self-billed client in
+     *       {@code billing_client_uuid} — kept as the phantom-shaped fallback.</li>
+     * </ul>
+     * The {@code invoices} table has NO {@code clientuuid} column (only {@code billing_client_uuid} and the
+     * denormalized {@code clientname}); the work client is reachable only through the project join — using
+     * {@code src.clientuuid} would throw SQL 1054. Consultant identity is masked downstream for callers
+     * lacking the {@code users:read} scope.
      *
      * <p>Prefill (Feature 2b): the suggested consultant is the internal's own item consultant when ALL
      * items carry the same non-null {@code consultantuuid} (else null — never guessed), and the suggested
@@ -134,6 +141,7 @@ public class HistoryReconciliationService {
                 LEFT JOIN companies ic ON ic.uuid = i.companyuuid
                 LEFT JOIN companies dc ON dc.uuid = i.debtor_companyuuid
                 LEFT JOIN invoices src ON src.uuid = i.invoice_ref_uuid
+                LEFT JOIN project p ON p.uuid = src.projectuuid
                 WHERE i.type IN ('INTERNAL','INTERNAL_SERVICE')
                   AND i.status IN ('PENDING_REVIEW','QUEUED','CREATED')
                   AND i.settlement_year IS NULL
@@ -141,8 +149,8 @@ public class HistoryReconciliationService {
                   AND i.debtor_companyuuid IN (SELECT agreement_company_uuid FROM selfbilled_source WHERE enabled = 1)
                   AND (i.invoice_ref_uuid IS NULL
                        OR src.uuid IS NULL
-                       OR COALESCE(src.billing_client_uuid, src.clientuuid)
-                            IN (SELECT client_uuid FROM selfbilled_source WHERE enabled = 1))
+                       OR p.clientuuid IN (SELECT client_uuid FROM selfbilled_source WHERE enabled = 1)
+                       OR src.billing_client_uuid IN (SELECT client_uuid FROM selfbilled_source WHERE enabled = 1))
                 GROUP BY i.uuid, i.invoicenumber, i.type, i.status, ic.name, dc.name, i.invoicedate,
                          i.specificdescription, src.year, src.month
                 ORDER BY i.invoicedate DESC

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledAssignmentService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledAssignmentService.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -372,8 +373,10 @@ public class SelfBilledAssignmentService {
                                              List<String> lineUuids, String actor) {
         Map<String, SameCompanyCandidate> byLine = new HashMap<>();
         for (SameCompanyCandidate c : sameCompanyCandidates(clientUuid, from, to)) byLine.put(c.lineUuid(), c);
+        // De-dupe (M-3): a uuid sent twice must not double-assign the same voucher / inflate accepted.
+        Set<String> requested = new LinkedHashSet<>(lineUuids);
         int accepted = 0, skipped = 0;
-        for (String lineUuid : lineUuids) {
+        for (String lineUuid : requested) {
             SameCompanyCandidate c = byLine.get(lineUuid);
             if (c == null) { skipped++; continue; }   // no longer same-company / not UNASSIGNED / unknown
             assignVoucher(c.lineUuid(), List.of(new AssignmentInput(
@@ -381,8 +384,8 @@ public class SelfBilledAssignmentService {
                     actor, AssignmentSourceType.AUTO_SAMECOMPANY);
             accepted++;
         }
-        log.infof("acceptSuggestedLines client=%s requested=%d accepted=%d skipped=%d by=%s",
-                clientUuid, lineUuids.size(), accepted, skipped, actor);
+        log.infof("acceptSuggestedLines client=%s requested=%d unique=%d accepted=%d skipped=%d by=%s",
+                clientUuid, lineUuids.size(), requested.size(), accepted, skipped, actor);
         return new AcceptResult(accepted, skipped);
     }
 

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledAssignmentService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledAssignmentService.java
@@ -1,6 +1,8 @@
 package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
 
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.AcceptResult;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.AssignmentInput;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.SameCompanyCandidateDTO;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.SelfBilledAssignmentDTO;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.SelfBilledCoverage;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.SelfBilledDocumentDTO;
@@ -320,29 +322,98 @@ public class SelfBilledAssignmentService {
     }
 
     /**
-     * Bulk-accept high-confidence SAME-COMPANY suggestions (AC2: cross-company is
-     * never auto-assigned). Returns the number of vouchers placed.
+     * Bulk-accept high-confidence SAME-COMPANY suggestions (AC2: cross-company is never
+     * auto-assigned). Sweeps the window's same-company candidates (any confidence) but
+     * places only those at or above {@link AssignmentSuggester#HIGH_CONFIDENCE}; the long
+     * tail is left for {@link #acceptSuggestedLines} after a human reviews the preview.
+     * Returns {accepted = vouchers placed, skipped = same-company candidates below the gate}.
      */
     @Transactional
-    public int acceptSuggestedSameCompany(String clientUuid, LocalDate from, LocalDate to, String actor) {
-        SelfBilledDocumentsResponse current = documents(clientUuid, from, to);
-        int accepted = 0;
-        for (SelfBilledDocumentDTO d : current.documents()) {
-            if (!SelfBilledLineStatus.UNASSIGNED.name().equals(d.status())) continue;
-            if (d.suggestedConsultantUuid() == null
-                    || d.suggestionConfidence() < AssignmentSuggester.HIGH_CONFIDENCE) continue;
-            String issuer = codeResolver.resolveIssuerCompany(
-                    d.suggestedConsultantUuid(), d.suggestedWorkYear(), d.suggestedWorkMonth());
-            SelfBilledLine anchor = SelfBilledLine.findById(d.lineUuid());
-            if (issuer == null || !issuer.equals(anchor.debtorCompanyUuid)) continue;   // cross-company -> human
-            assignVoucher(d.lineUuid(), List.of(new AssignmentInput(
-                    d.suggestedConsultantUuid(), d.suggestedWorkYear(), d.suggestedWorkMonth(), null)),
+    public AcceptResult acceptSuggestedSameCompany(String clientUuid, LocalDate from, LocalDate to, String actor) {
+        int accepted = 0, skipped = 0;
+        for (SameCompanyCandidate c : sameCompanyCandidates(clientUuid, from, to)) {
+            if (c.confidence() < AssignmentSuggester.HIGH_CONFIDENCE) { skipped++; continue; }
+            assignVoucher(c.lineUuid(), List.of(new AssignmentInput(
+                    c.consultantUuid(), c.workYear(), c.workMonth(), null)),
                     actor, AssignmentSourceType.AUTO_SAMECOMPANY);
             accepted++;
         }
-        log.infof("acceptSuggestedSameCompany client=%s window=%s..%s accepted=%d by=%s",
-                clientUuid, from, to, accepted, actor);
-        return accepted;
+        log.infof("acceptSuggestedSameCompany client=%s window=%s..%s accepted=%d skipped=%d by=%s",
+                clientUuid, from, to, accepted, skipped, actor);
+        return new AcceptResult(accepted, skipped);
+    }
+
+    /**
+     * Feature 1a preview: ALL same-company candidates in the window (any confidence) —
+     * UNASSIGNED vouchers carrying a suggestion whose suggested consultant's company
+     * (as-of the suggested period) equals the source's debtor company. Names resolved;
+     * masking applied at the resource. Read-only; reuses the SAME suggestion machinery
+     * as {@link #documents} via {@link #sameCompanyCandidates}.
+     */
+    @Transactional
+    public List<SameCompanyCandidateDTO> sameCompanyCandidatePreview(String clientUuid, LocalDate from, LocalDate to) {
+        List<SameCompanyCandidate> candidates = sameCompanyCandidates(clientUuid, from, to);
+        Map<String, String> names = consultantNames(
+                candidates.stream().map(SameCompanyCandidate::consultantUuid).collect(java.util.stream.Collectors.toSet()));
+        return candidates.stream().map(c -> new SameCompanyCandidateDTO(
+                c.lineUuid(), c.voucherNumber(), c.bookingDate(), c.amount(), c.suggestedCode(),
+                c.consultantUuid(), names.get(c.consultantUuid()), c.workYear(), c.workMonth(), c.confidence()))
+                .toList();
+    }
+
+    /**
+     * Feature 1b explicit accept: place exactly these voucher anchor lines, each re-checked
+     * server-side — the suggestion is recomputed and applied ONLY if it is still same-company
+     * and the voucher is still UNASSIGNED (skip silently and count otherwise). Same assignment
+     * semantics as the ≥90 path (source AUTO_SAMECOMPANY, mirror sync, status recompute).
+     */
+    @Transactional
+    public AcceptResult acceptSuggestedLines(String clientUuid, LocalDate from, LocalDate to,
+                                             List<String> lineUuids, String actor) {
+        Map<String, SameCompanyCandidate> byLine = new HashMap<>();
+        for (SameCompanyCandidate c : sameCompanyCandidates(clientUuid, from, to)) byLine.put(c.lineUuid(), c);
+        int accepted = 0, skipped = 0;
+        for (String lineUuid : lineUuids) {
+            SameCompanyCandidate c = byLine.get(lineUuid);
+            if (c == null) { skipped++; continue; }   // no longer same-company / not UNASSIGNED / unknown
+            assignVoucher(c.lineUuid(), List.of(new AssignmentInput(
+                    c.consultantUuid(), c.workYear(), c.workMonth(), null)),
+                    actor, AssignmentSourceType.AUTO_SAMECOMPANY);
+            accepted++;
+        }
+        log.infof("acceptSuggestedLines client=%s requested=%d accepted=%d skipped=%d by=%s",
+                clientUuid, lineUuids.size(), accepted, skipped, actor);
+        return new AcceptResult(accepted, skipped);
+    }
+
+    /** Internal same-company candidate (pre-name-resolution) — the shared shape of 1a/1b/the ≥90 sweep. */
+    private record SameCompanyCandidate(String lineUuid, int voucherNumber, String bookingDate, double amount,
+                                        String suggestedCode, String consultantUuid, int workYear, int workMonth,
+                                        int confidence) {}
+
+    /**
+     * The shared same-company filter behind {@link #acceptSuggestedSameCompany},
+     * {@link #sameCompanyCandidatePreview}, and {@link #acceptSuggestedLines}: from the window's
+     * documents keep every UNASSIGNED voucher that carries a suggestion whose suggested consultant's
+     * company (via {@code resolveIssuerCompany} for the suggested period) equals the source's debtor
+     * company. amounts are already normalized positive on the document DTO.
+     */
+    private List<SameCompanyCandidate> sameCompanyCandidates(String clientUuid, LocalDate from, LocalDate to) {
+        SelfBilledDocumentsResponse current = documents(clientUuid, from, to);
+        List<SameCompanyCandidate> out = new ArrayList<>();
+        for (SelfBilledDocumentDTO d : current.documents()) {
+            if (!SelfBilledLineStatus.UNASSIGNED.name().equals(d.status())) continue;
+            if (d.suggestedConsultantUuid() == null
+                    || d.suggestedWorkYear() == null || d.suggestedWorkMonth() == null) continue;
+            String issuer = codeResolver.resolveIssuerCompany(
+                    d.suggestedConsultantUuid(), d.suggestedWorkYear(), d.suggestedWorkMonth());
+            SelfBilledLine anchor = SelfBilledLine.findById(d.lineUuid());
+            if (anchor == null || issuer == null || !issuer.equals(anchor.debtorCompanyUuid)) continue;
+            out.add(new SameCompanyCandidate(d.lineUuid(), d.voucherNumber(), d.bookingDate(), d.amount(),
+                    d.suggestedCode(), d.suggestedConsultantUuid(), d.suggestedWorkYear(), d.suggestedWorkMonth(),
+                    d.suggestionConfidence()));
+        }
+        return out;
     }
 
     // ── read helpers ─────────────────────────────────────────────────

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledDeltaQuery.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledDeltaQuery.java
@@ -9,6 +9,7 @@ import jakarta.persistence.EntityManager;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -69,6 +70,48 @@ public class SelfBilledDeltaQuery {
         SettlementGroupKey key = new SettlementGroupKey(clientUuid, debtorCompanyUuid, workYear, workMonth);
         return target(clientUuid, consultantUuid, workYear, workMonth)
                 .subtract(settled(key, consultantUuid));
+    }
+
+    /**
+     * 8610 'Samlekonto debitorer' remainder per self-billing voucher backing one
+     * (client, consultant, work-period) — the shared lookup feeding {@link SelfBilledPaidGate#allPaid}
+     * for BOTH the workbench read ({@code /internals/queued}) and the nightly auto-finalize batchlet.
+     *
+     * <p>The self-billing vouchers are the distinct {@code selfbilled_line.voucher_number}s carrying a
+     * HUMAN/AUTO assignment for the group. Their debtor leg is booked on account 8610 at the agreement
+     * (debtor) company; the e-conomic {@code remainder} on that 8610 row is the still-unpaid balance, so
+     * remainder == 0 means the client has paid the self-billing invoice. A voucher with NO 8610
+     * finance_details row yields a {@code null} remainder (fail closed — never auto-finalize on missing
+     * evidence). Returns one {@link SelfBilledPaidGate.VoucherRemainder} per backing voucher (empty when
+     * the group has no assigned vouchers).
+     */
+    public List<SelfBilledPaidGate.VoucherRemainder> voucherRemainders(
+            String clientUuid, String debtorCompanyUuid, String consultantUuid, int workYear, int workMonth) {
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery("""
+                SELECT v.voucher_number, fd.remainder
+                FROM (
+                    SELECT DISTINCT l.voucher_number
+                    FROM selfbilled_assignment a
+                    JOIN selfbilled_line l ON l.uuid = a.selfbilled_line_uuid
+                    WHERE l.client_uuid = :c AND a.consultant_uuid = :u
+                      AND a.work_year = :y AND a.work_month = :m
+                ) v
+                LEFT JOIN finance_details fd
+                       ON fd.vouchernumber = v.voucher_number
+                      AND fd.companyuuid = :debtor
+                      AND fd.accountnumber = 8610
+                """).setParameter("c", clientUuid).setParameter("u", consultantUuid)
+                .setParameter("y", workYear).setParameter("m", workMonth)
+                .setParameter("debtor", debtorCompanyUuid)
+                .getResultList();
+        List<SelfBilledPaidGate.VoucherRemainder> out = new ArrayList<>(rows.size());
+        for (Object[] r : rows) {
+            int voucher = ((Number) r[0]).intValue();
+            BigDecimal remainder = r[1] == null ? null : toBig(r[1]);
+            out.add(new SelfBilledPaidGate.VoucherRemainder(voucher, remainder));
+        }
+        return out;
     }
 
     private static BigDecimal toBig(Object o) {

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledDeltaQuery.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledDeltaQuery.java
@@ -84,6 +84,16 @@ public class SelfBilledDeltaQuery {
      * finance_details row yields a {@code null} remainder (fail closed — never auto-finalize on missing
      * evidence). Returns one {@link SelfBilledPaidGate.VoucherRemainder} per backing voucher (empty when
      * the group has no assigned vouchers).
+     *
+     * <p>FISCAL-YEAR ANCHOR (I-1): voucher numbers are NOT globally unique — e-conomic resets them per
+     * accounting year (the codebase's own uniqueness domain is {@code (vouchernumber, journalnumber,
+     * accountingyear)}, see Expense / ExpenseOrphanDetectionBatchlet), and FinanceLoadJob loads several
+     * fiscal years concurrently, so a same-numbered 8610 row from a DIFFERENT year is co-resident. Without
+     * a year constraint a collision could fail OPEN (real row missing + foreign-year row with remainder 0
+     * → allPaid → auto-finalize an UNPAID group). We therefore constrain the 8610 row's {@code expensedate}
+     * to the SAME fiscal year (Jul 1 → Jun 30, the project-wide convention) as the voucher's
+     * {@code selfbilled_line.booking_date} — the exact uniqueness domain (a fiscal-year WINDOW, not exact-
+     * date equality, so correction entries booked on other days within the year still match).
      */
     public List<SelfBilledPaidGate.VoucherRemainder> voucherRemainders(
             String clientUuid, String debtorCompanyUuid, String consultantUuid, int workYear, int workMonth) {
@@ -91,16 +101,20 @@ public class SelfBilledDeltaQuery {
         List<Object[]> rows = em.createNativeQuery("""
                 SELECT v.voucher_number, fd.remainder
                 FROM (
-                    SELECT DISTINCT l.voucher_number
+                    SELECT l.voucher_number, MIN(l.booking_date) AS booking_date
                     FROM selfbilled_assignment a
                     JOIN selfbilled_line l ON l.uuid = a.selfbilled_line_uuid
                     WHERE l.client_uuid = :c AND a.consultant_uuid = :u
                       AND a.work_year = :y AND a.work_month = :m
+                    GROUP BY l.voucher_number
                 ) v
                 LEFT JOIN finance_details fd
                        ON fd.vouchernumber = v.voucher_number
                       AND fd.companyuuid = :debtor
                       AND fd.accountnumber = 8610
+                      AND fd.expensedate BETWEEN
+                            DATE(CONCAT(YEAR(v.booking_date) - (MONTH(v.booking_date) < 7), '-07-01'))
+                        AND DATE(CONCAT(YEAR(v.booking_date) + (MONTH(v.booking_date) >= 7), '-06-30'))
                 """).setParameter("c", clientUuid).setParameter("u", consultantUuid)
                 .setParameter("y", workYear).setParameter("m", workMonth)
                 .setParameter("debtor", debtorCompanyUuid)

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledPaidGate.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledPaidGate.java
@@ -1,0 +1,39 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * The paid-gate for queued settlement internals (Feature 3).
+ *
+ * <p>Deliberately PURE: no DB, no CDI, no Quarkus imports — like {@link AssignmentSuggester}.
+ * The caller fetches one {@link VoucherRemainder} per self-billing voucher backing a group
+ * (the 8610 'Samlekonto debitorer' remainder at the agreement company) and asks whether the
+ * client has settled them all.
+ *
+ * <p>FAIL CLOSED: only a NON-EMPTY list whose every remainder is non-null and exactly zero is
+ * paid. An empty list (no vouchers found) is NOT paid; a null remainder (a voucher with no
+ * finance_details 8610 row) is NOT paid — never auto-finalize on missing evidence.
+ */
+public final class SelfBilledPaidGate {
+
+    private SelfBilledPaidGate() {}
+
+    /**
+     * One self-billing voucher and its 8610 debtor remainder.
+     *
+     * @param voucherNumber e-conomic voucher number of the self-billing invoice
+     * @param remainder     remaining unpaid amount on account 8610 for this voucher (null when no row exists);
+     *                      0 means the client has paid the self-billing invoice
+     */
+    public record VoucherRemainder(int voucherNumber, BigDecimal remainder) {}
+
+    /** True only when the list is non-empty and EVERY remainder is non-null and exactly 0 (compareTo). */
+    public static boolean allPaid(List<VoucherRemainder> vouchers) {
+        if (vouchers == null || vouchers.isEmpty()) return false;
+        for (VoucherRemainder v : vouchers) {
+            if (v.remainder() == null || v.remainder().compareTo(BigDecimal.ZERO) != 0) return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledSettlementService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledSettlementService.java
@@ -3,6 +3,7 @@ package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
 import dk.trustworks.intranet.aggregates.invoice.dto.SettlementGroupKey;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.AssignContextDTO;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.ConsultantPeriodRow;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.QueuedInternalRow;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.SettleRequest;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.model.SelfBilledAssignment;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.model.SelfBilledLine;
@@ -99,6 +100,57 @@ public class SelfBilledSettlementService {
                     issuer, companies.getOrDefault(issuer, issuer),
                     assigned.doubleValue(), settled.doubleValue(), delta.doubleValue(),
                     work.doubleValue(), delta.abs().compareTo(THRESHOLD) > 0, unlinked));
+        }
+        return out;
+    }
+
+    /**
+     * Queued-lane read (Feature 3b): settlement-stamped QUEUED INTERNAL invoices for the client whose
+     * settlement period (settlement_year*100 + settlement_month) falls in the window [fromYm,toYm]. Per
+     * invoice: total = Σ items (hours*rate), consultant = the items' consultant, and paid/outstanding from
+     * the underlying self-billing vouchers' 8610 remainder (via {@link SelfBilledDeltaQuery#voucherRemainders}
+     * + {@link SelfBilledPaidGate#allPaid}) — paid when every backing voucher's 8610 remainder is exactly 0
+     * (the client paid the self-billing invoice). Consultant identity is masked at the resource.
+     */
+    @Transactional
+    public List<QueuedInternalRow> queuedInternals(String clientUuid, int fromYm, int toYm) {
+        String debtor = requireDebtor(clientUuid);
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = em.createNativeQuery("""
+                SELECT i.uuid, MAX(ii.consultantuuid), i.settlement_year, i.settlement_month,
+                       COALESCE(SUM(ii.hours*ii.rate), 0)
+                FROM invoices i
+                JOIN invoiceitems ii ON ii.invoiceuuid = i.uuid
+                WHERE i.type = 'INTERNAL' AND i.status = 'QUEUED'
+                  AND i.settlement_billing_client_uuid = :c
+                  AND i.settlement_year IS NOT NULL AND i.settlement_month IS NOT NULL
+                  AND (i.settlement_year*100 + i.settlement_month) BETWEEN :from AND :to
+                  AND ii.consultantuuid IS NOT NULL
+                GROUP BY i.uuid, i.settlement_year, i.settlement_month
+                ORDER BY i.settlement_year, i.settlement_month
+                """).setParameter("c", clientUuid).setParameter("from", fromYm).setParameter("to", toYm)
+                .getResultList();
+
+        Set<String> consultantUuids = new HashSet<>();
+        for (Object[] r : rows) consultantUuids.add((String) r[1]);
+        Map<String, String> names = consultantNames(consultantUuids);
+
+        List<QueuedInternalRow> out = new ArrayList<>(rows.size());
+        for (Object[] r : rows) {
+            String invoiceUuid = (String) r[0];
+            String consultant = (String) r[1];
+            int y = ((Number) r[2]).intValue(), m = ((Number) r[3]).intValue();
+            double total = toBig(r[4]).setScale(2, RoundingMode.HALF_UP).doubleValue();
+            List<SelfBilledPaidGate.VoucherRemainder> remainders =
+                    deltaQuery.voucherRemainders(clientUuid, debtor, consultant, y, m);
+            boolean paid = SelfBilledPaidGate.allPaid(remainders);
+            BigDecimal outstanding = remainders.stream()
+                    .map(SelfBilledPaidGate.VoucherRemainder::remainder)
+                    .filter(rem -> rem != null && rem.signum() > 0)
+                    .reduce(BigDecimal.ZERO, BigDecimal::add)
+                    .setScale(2, RoundingMode.HALF_UP);
+            out.add(new QueuedInternalRow(invoiceUuid, consultant, names.getOrDefault(consultant, consultant),
+                    y, m, total, paid, outstanding.doubleValue()));
         }
         return out;
     }

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledSettlementService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledSettlementService.java
@@ -1,6 +1,7 @@
 package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
 
 import dk.trustworks.intranet.aggregates.invoice.dto.SettlementGroupKey;
+import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.AssignContextDTO;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.ConsultantPeriodRow;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.dto.SettleRequest;
 import dk.trustworks.intranet.aggregates.invoice.selfbilled.model.SelfBilledAssignment;
@@ -100,6 +101,32 @@ public class SelfBilledSettlementService {
                     work.doubleValue(), delta.abs().compareTo(THRESHOLD) > 0, unlinked));
         }
         return out;
+    }
+
+    /**
+     * Assign-modal context for the SELECTED (client, consultant, work-period) — which may differ
+     * from the row's suggestion. Read-only composition: same debtor resolution as settle, the
+     * issuer resolved as-of the work period (null when unresolvable), the cross-company verdict,
+     * both company names, and the registered-work CROSS-CHECK value (never a settlement basis — AC1).
+     * No @Transactional needed: pure reads through the same helpers consultantRows uses.
+     */
+    public AssignContextDTO assignContext(String clientUuid, String consultantUuid, int year, int month) {
+        String debtor = requireDebtor(clientUuid);
+        String issuer = codeResolver.resolveIssuerCompany(consultantUuid, year, month);
+        boolean crossCompany = issuer != null && !issuer.equals(debtor);
+
+        Set<String> companyUuids = new HashSet<>();
+        companyUuids.add(debtor);
+        if (issuer != null) companyUuids.add(issuer);
+        Map<String, String> companies = companyNames(companyUuids);
+
+        double workValue = workValues(clientUuid, year, month)
+                .getOrDefault(consultantUuid, BigDecimal.ZERO).doubleValue();
+
+        return new AssignContextDTO(crossCompany,
+                issuer, issuer == null ? null : companies.getOrDefault(issuer, issuer),
+                debtor, companies.getOrDefault(debtor, debtor),
+                workValue);
     }
 
     /**

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledPaidGateTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledPaidGateTest.java
@@ -1,0 +1,52 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure gate behind the queued-settlement-internal lifecycle (Feature 3): a settlement internal
+ * may auto-finalize only when EVERY self-billing voucher backing its group has been paid by the
+ * client (8610 remainder == 0). Fail-closed — empty list or any null remainder is NOT paid.
+ */
+class SelfBilledPaidGateTest {
+
+    private static SelfBilledPaidGate.VoucherRemainder vr(int voucher, String remainder) {
+        return new SelfBilledPaidGate.VoucherRemainder(voucher, remainder == null ? null : new BigDecimal(remainder));
+    }
+
+    @Test
+    void empty_list_is_not_paid() {
+        assertFalse(SelfBilledPaidGate.allPaid(List.of()));
+    }
+
+    @Test
+    void null_remainder_is_not_paid() {
+        // A voucher with no finance_details 8610 row yields a null remainder -> fail closed.
+        assertFalse(SelfBilledPaidGate.allPaid(List.of(vr(2069, "0.00"), vr(2070, null))));
+    }
+
+    @Test
+    void mixed_remainders_are_not_paid() {
+        assertFalse(SelfBilledPaidGate.allPaid(List.of(vr(2069, "0.00"), vr(2070, "153525.00"))));
+    }
+
+    @Test
+    void all_zero_remainders_are_paid() {
+        assertTrue(SelfBilledPaidGate.allPaid(List.of(vr(2069, "0.00"), vr(2070, "0"))));
+    }
+
+    @Test
+    void single_zero_remainder_is_paid() {
+        assertTrue(SelfBilledPaidGate.allPaid(List.of(vr(2069, "0.00"))));
+    }
+
+    @Test
+    void non_zero_single_remainder_is_not_paid() {
+        assertFalse(SelfBilledPaidGate.allPaid(List.of(vr(2069, "0.01"))));
+    }
+}


### PR DESCRIPTION
Pairs with trustworks-intranet-v3 PR (deploy together). Adds to the self-billed settlement workbench:

- assign-context read (cross-company + work-value preview for the selected consultant/period)
- bulk-accept preview endpoint + explicit lineUuids accept with {accepted, skipped} counts
- link queue scoped to self-billed-related internals (source project client join; src.clientuuid crash fixed) + consultant/period prefill
- queued settlement internal lifecycle: pure SelfBilledPaidGate on finance_details 8610 remainder (fiscal-year-anchored voucher match), GET /internals/queued with paid/outstanding, nightly auto-finalize pass (no source-PAID gate, no item regeneration)

Reviews: spec-compliance pass (2 contract fixes + filter rewrite, prod-data-verified: queue shrinks 245→~11 true rows), quality pass APPROVED after I-1 fiscal-year fix. Gates: test-compile 0, 33/33 pure tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)