### PR TITLE
Credited internals are void: exclude from link queue, block linking; assignment year bound

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/HistoryReconciliationService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/HistoryReconciliationService.java
@@ -188,7 +188,12 @@ public class HistoryReconciliationService {
                 u.suggestedWorkYear(), u.suggestedWorkMonth())).toList();
     }
 
-    /** Count only — feeds the Consultants-tab "unlinked candidates exist" warning (AC8). */
+    /**
+     * Count only — feeds the Consultants-tab "unlinked candidates exist" warning (AC8). Mirrors the
+     * {@link #unlinkedInternals()} discovery scope INCLUDING the live-credit-note exclusion, so the banner
+     * count stays in parity with the queue: a credited (void) internal is hidden from both, never leaving
+     * the banner showing a non-zero count over an empty queue with an unfollowable instruction.
+     */
     @Transactional
     public int unlinkedCandidateCount() {
         Object v = em.createNativeQuery("""
@@ -204,6 +209,10 @@ public class HistoryReconciliationService {
                        OR src.uuid IS NULL
                        OR p.clientuuid IN (SELECT client_uuid FROM selfbilled_source WHERE enabled = 1)
                        OR src.billing_client_uuid IN (SELECT client_uuid FROM selfbilled_source WHERE enabled = 1))
+                  AND NOT EXISTS (SELECT 1 FROM invoices cn
+                                  WHERE cn.creditnote_for_uuid = i.uuid
+                                    AND cn.type = 'CREDIT_NOTE'
+                                    AND cn.status IN ('PENDING_REVIEW','QUEUED','CREATED'))
                 """).getSingleResult();
         return ((Number) v).intValue();
     }

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/HistoryReconciliationService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/HistoryReconciliationService.java
@@ -126,6 +126,13 @@ public class HistoryReconciliationService {
      * <p>Prefill (Feature 2b): the suggested consultant is the internal's own item consultant when ALL
      * items carry the same non-null {@code consultantuuid} (else null — never guessed), and the suggested
      * work period is the source invoice's {@code year}/{@code month} when the source exists (else null).
+     *
+     * <p>Cancelled-internal exclusion: any internal referenced by a LIVE credit note
+     * ({@code creditnote_for_uuid = i.uuid}, {@code type = 'CREDIT_NOTE'}, status in
+     * PENDING_REVIEW/QUEUED/CREATED) is void and dropped — linking it would stamp a cancelled document
+     * into settled totals, producing phantom mismatches (prod-observed: 10 such credited internals matched
+     * the queue). A DRAFT credit note does not yet void the internal. ANY live credit note voids it; the
+     * full-amount credit note is the observed reality, so partial credits are NOT distinguished here.
      */
     @Transactional
     public List<UnlinkedInternalRow> unlinkedInternals() {
@@ -151,6 +158,10 @@ public class HistoryReconciliationService {
                        OR src.uuid IS NULL
                        OR p.clientuuid IN (SELECT client_uuid FROM selfbilled_source WHERE enabled = 1)
                        OR src.billing_client_uuid IN (SELECT client_uuid FROM selfbilled_source WHERE enabled = 1))
+                  AND NOT EXISTS (SELECT 1 FROM invoices cn
+                                  WHERE cn.creditnote_for_uuid = i.uuid
+                                    AND cn.type = 'CREDIT_NOTE'
+                                    AND cn.status IN ('PENDING_REVIEW','QUEUED','CREATED'))
                 GROUP BY i.uuid, i.invoicenumber, i.type, i.status, ic.name, dc.name, i.invoicedate,
                          i.specificdescription, src.year, src.month
                 ORDER BY i.invoicedate DESC
@@ -181,12 +192,18 @@ public class HistoryReconciliationService {
     @Transactional
     public int unlinkedCandidateCount() {
         Object v = em.createNativeQuery("""
-                SELECT COUNT(*) FROM invoices i
+                SELECT COUNT(DISTINCT i.uuid) FROM invoices i
+                LEFT JOIN invoices src ON src.uuid = i.invoice_ref_uuid
+                LEFT JOIN project p ON p.uuid = src.projectuuid
                 WHERE i.type IN ('INTERNAL','INTERNAL_SERVICE')
                   AND i.status IN ('PENDING_REVIEW','QUEUED','CREATED')
                   AND i.settlement_year IS NULL
                   AND i.companyuuid <> i.debtor_companyuuid
                   AND i.debtor_companyuuid IN (SELECT agreement_company_uuid FROM selfbilled_source WHERE enabled = 1)
+                  AND (i.invoice_ref_uuid IS NULL
+                       OR src.uuid IS NULL
+                       OR p.clientuuid IN (SELECT client_uuid FROM selfbilled_source WHERE enabled = 1)
+                       OR src.billing_client_uuid IN (SELECT client_uuid FROM selfbilled_source WHERE enabled = 1))
                 """).getSingleResult();
         return ((Number) v).intValue();
     }
@@ -234,6 +251,16 @@ public class HistoryReconciliationService {
             throw new WebApplicationException("Internal is not in a live status (PENDING_REVIEW/QUEUED/CREATED) — cannot link",
                     Response.Status.CONFLICT);
         }
+        // A live credit note voids the internal: linking a cancelled document would stamp it into
+        // settled totals (phantom mismatch). Mirrors the discovery query's NOT EXISTS — protects the
+        // direct API path. ANY live credit note voids it; partial credits are not distinguished (DRAFT
+        // credit notes do not yet void). 409.
+        if (cancelledByLiveCreditNote(invoiceUuid)) {
+            throw new WebApplicationException(
+                    "Internal #" + internal.getInvoicenumber()
+                            + " has been cancelled by a credit note and cannot be linked",
+                    Response.Status.CONFLICT);
+        }
         List<InvoiceItem> items = internal.getInvoiceitems();
         if (items == null || items.isEmpty()) {
             throw new WebApplicationException("Internal has no items to stamp", Response.Status.CONFLICT);
@@ -263,6 +290,17 @@ public class HistoryReconciliationService {
                 oldState, newState, "Workbench link of pre-existing internal").persist();
         log.infof("linkInternal: %s -> (%s, %s, %d-%02d) by=%s",
                 invoiceUuid, req.clientUuid(), req.consultantUuid(), req.workYear(), req.workMonth(), actor);
+    }
+
+    /** True when a LIVE credit note (PENDING_REVIEW/QUEUED/CREATED) references this internal — voids it for linking. */
+    private boolean cancelledByLiveCreditNote(String invoiceUuid) {
+        Object v = em.createNativeQuery("""
+                SELECT COUNT(*) FROM invoices cn
+                WHERE cn.creditnote_for_uuid = :uuid
+                  AND cn.type = 'CREDIT_NOTE'
+                  AND cn.status IN ('PENDING_REVIEW','QUEUED','CREATED')
+                """).setParameter("uuid", invoiceUuid).getSingleResult();
+        return ((Number) v).intValue() > 0;
     }
 
     private Map<String, String> consultantNames(Set<String> ids) {

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledAssignmentService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledAssignmentService.java
@@ -76,12 +76,11 @@ public class SelfBilledAssignmentService {
         Set<String> seenTuples = new HashSet<>(inputs.size());
         BigDecimal signedSum = BigDecimal.ZERO;
         for (AssignmentInput in : inputs) {
-            if (in.consultantUuid() == null || in.consultantUuid().isBlank()
-                    || in.workYear() == null || in.workMonth() == null
-                    || in.workMonth() < 1 || in.workMonth() > 12) {
-                throw new WebApplicationException("consultantUuid, workYear and workMonth are required",
+            if (in.consultantUuid() == null || in.consultantUuid().isBlank()) {
+                throw new WebApplicationException("consultantUuid is required",
                         Response.Status.BAD_REQUEST);
             }
+            requireAssignmentPeriod(in.workYear(), in.workMonth());
             if (isSplit && in.shareAmount() != null && in.shareAmount().signum() <= 0) {
                 throw new WebApplicationException("shareAmount must be positive on a split",
                         Response.Status.BAD_REQUEST);
@@ -232,6 +231,14 @@ public class SelfBilledAssignmentService {
             throw new WebApplicationException("shareAmount is required on a split", Response.Status.BAD_REQUEST);
         }
         return voucherNet.signum() < 0 ? normalized.negate() : normalized;
+    }
+
+    static void requireAssignmentPeriod(Integer workYear, Integer workMonth) {
+        if (workYear == null || workYear < 1 || workYear > 9999
+                || workMonth == null || workMonth < 1 || workMonth > 12) {
+            throw new WebApplicationException("workYear and workMonth are required (workMonth 1-12)",
+                    Response.Status.BAD_REQUEST);
+        }
     }
 
     private static SelfBilledLine require(String lineUuid) {

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledAssignmentServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/selfbilled/services/SelfBilledAssignmentServiceTest.java
@@ -1,0 +1,35 @@
+package dk.trustworks.intranet.aggregates.invoice.selfbilled.services;
+
+import jakarta.ws.rs.WebApplicationException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SelfBilledAssignmentServiceTest {
+
+    @Test
+    void assignment_period_rejects_missing_or_impossible_years() {
+        assertThrows(WebApplicationException.class,
+                () -> SelfBilledAssignmentService.requireAssignmentPeriod(null, 8));
+        assertThrows(WebApplicationException.class,
+                () -> SelfBilledAssignmentService.requireAssignmentPeriod(0, 8));
+        assertThrows(WebApplicationException.class,
+                () -> SelfBilledAssignmentService.requireAssignmentPeriod(10000, 8));
+    }
+
+    @Test
+    void assignment_period_rejects_missing_or_impossible_months() {
+        assertThrows(WebApplicationException.class,
+                () -> SelfBilledAssignmentService.requireAssignmentPeriod(2025, null));
+        assertThrows(WebApplicationException.class,
+                () -> SelfBilledAssignmentService.requireAssignmentPeriod(2025, 0));
+        assertThrows(WebApplicationException.class,
+                () -> SelfBilledAssignmentService.requireAssignmentPeriod(2025, 13));
+    }
+
+    @Test
+    void assignment_period_accepts_plausible_work_period() {
+        assertDoesNotThrow(() -> SelfBilledAssignmentService.requireAssignmentPeriod(2025, 8));
+    }
+}


### PR DESCRIPTION
Backend-only. Internals cancelled via credit note (e.g. #70177/#70211, 10 on prod) no longer appear in the AC8 link queue, cannot be linked (409), and the banner count stays in parity with the queue. Also bounds assignment work-year (1-9999) via extracted requireAssignmentPeriod with a pure test. Review-verified (clause parity checked mechanically; validation rejection-set proven identical plus the stated delta). Gates: test-compile 0, 36/36 pure tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)