### PR TITLE
Fix prod top-expense-consultants 500 + orphan-detection request context

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CostAnalyticsResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/finance/resources/CostAnalyticsResource.java
@@ -134,7 +134,7 @@ public class CostAnalyticsResource {
         if (companyIds != null && !companyIds.isEmpty()) {
             sql.append("  AND EXISTS (SELECT 1 FROM userstatus us2 WHERE us2.useruuid = e.useruuid ");
             sql.append("    AND us2.statusdate = (SELECT MAX(us3.statusdate) FROM userstatus us3 WHERE us3.useruuid = e.useruuid AND us3.statusdate <= CURDATE()) ");
-            sql.append("    AND us2.company IN (:companyIds)) ");
+            sql.append("    AND us2.companyuuid IN (:companyIds)) ");
         }
         sql.append("GROUP BY e.useruuid, u.firstname, u.lastname ");
         sql.append("ORDER BY total_expenses DESC LIMIT 10");

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseOrphanDetectionBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseOrphanDetectionBatchlet.java
@@ -2,6 +2,8 @@ package dk.trustworks.intranet.expenseservice.services;
 
 import dk.trustworks.intranet.batch.monitoring.BatchExceptionTracking;
 import dk.trustworks.intranet.expenseservice.model.Expense;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ManagedContext;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import jakarta.batch.api.AbstractBatchlet;
 import jakarta.enterprise.context.Dependent;
@@ -46,6 +48,17 @@ public class ExpenseOrphanDetectionBatchlet extends AbstractBatchlet {
     @Override
     @ActivateRequestContext
     public String process() throws Exception {
+        // Guarantee an active CDI request context. The @ActivateRequestContext interceptor
+        // (above) is not reliably applied when JBeret invokes this batchlet — it intermittently
+        // threw ContextNotActiveException on the first EntityManager/@RequestScoped access
+        // (observed on prod on a small fraction of hourly runs). Activating explicitly removes
+        // the dependency on the interceptor firing.
+        ManagedContext requestContext = Arc.container().requestContext();
+        boolean activatedHere = false;
+        if (!requestContext.isActive()) {
+            requestContext.activate();
+            activatedHere = true;
+        }
         try {
             log.info("Starting orphaned voucher detection job");
 
@@ -122,6 +135,10 @@ public class ExpenseOrphanDetectionBatchlet extends AbstractBatchlet {
         } catch (Exception e) {
             log.error("ExpenseOrphanDetectionBatchlet failed", e);
             throw e;
+        } finally {
+            if (activatedHere) {
+                requestContext.terminate();
+            }
         }
     }
 }

--- a/src/main/resources/META-INF/batch-jobs/expense-orphan-detection.xml
+++ b/src/main/resources/META-INF/batch-jobs/expense-orphan-detection.xml
@@ -3,7 +3,13 @@
     <properties>
         <property name="job.description" value="Detects and marks orphaned expense vouchers in e-conomics"/>
     </properties>
+    <listeners>
+        <listener ref="jobMonitoringListener"/>
+    </listeners>
     <step id="expense-orphan-detection-step">
+        <listeners>
+            <listener ref="stepProgressListener"/>
+        </listeners>
         <batchlet ref="expenseOrphanDetectionBatchlet"/>
     </step>
 </job>


### PR DESCRIPTION
Promotes two backend fixes (validated on staging — deploy COMPLETED, image f33b3bf2, healthy boot):

**Bug 1 — user-facing 500 (deterministic).** `CostAnalyticsResource#getTopExpenseConsultants` native query referenced `us2.company` (entity field) instead of the DB column `us2.companyuuid` on `userstatus` → SQLGrammarException (1054) whenever the endpoint is called with a company filter. One-token fix; only occurrence in the codebase.

**Bug 2 — intermittent ContextNotActiveException in ExpenseOrphanDetectionBatchlet.** The batchlet relied solely on @ActivateRequestContext, which JBeret applies unreliably here (~2.4% of hourly prod runs threw ContextNotActiveException on the first EntityManager/@RequestScoped access — e.g. 06-09 13:15Z, 06-10 14:15Z, 06-12 00:15Z). Fix: (a) activate the CDI request context programmatically so it never depends on the interceptor; (b) register jobMonitoringListener + stepProgressListener (it was the only batch job lacking the listener chain — restores batch tracking/observability).

Commits: 2e19e1f2, f33b3bf2

🤖 Generated with [Claude Code](https://claude.com/claude-code)