### PR TITLE
Promote to prod: KeyPurpose num normalization (V368) + salary null-type fix (V367)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/users/resources/SalaryResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/users/resources/SalaryResource.java
@@ -106,7 +106,10 @@ public class SalaryResource {
 
         // Process base salary based on type
         try {
-            if (baseSalary.getType().equals(SalaryType.NORMAL)) {
+            SalaryType salaryType = baseSalary.getType();
+            if (salaryType == null) {
+                log.warnf("Salary has null type for user: %s, month: %s — skipping base salary payment", useruuid, date);
+            } else if (salaryType == SalaryType.NORMAL) {
                 if (availability != null && availability.getGrossAvailableHours().doubleValue() > availability.getSalaryAwardingHours()) {
                     double adjustedSalary = baseSalary.calculateMonthNormAdjustedSalary(
                             availability.getGrossAvailableHours().doubleValue() / 7.4,
@@ -115,7 +118,7 @@ public class SalaryResource {
                     baseSalary.setSalary(convertDoubleToInt(adjustedSalary));
                 }
                 payments.add(new SalaryPayment(date, "Base salary", formatCurrency(baseSalary.getSalary())));
-            } else if (baseSalary.getType().equals(SalaryType.HOURLY)) {
+            } else if (salaryType == SalaryType.HOURLY) {
                 List<Work> workHoursList = workService.findByUserAndUnpaidAndMonthAndTaskuuid(useruuid, WORK_HOURS, date).stream()
                         .filter(w -> w.getRegistered().isBefore(date.plusMonths(1).withDayOfMonth(1)))
                         .toList();

--- a/src/main/java/dk/trustworks/intranet/cultureservice/services/KeyPurposeService.java
+++ b/src/main/java/dk/trustworks/intranet/cultureservice/services/KeyPurposeService.java
@@ -1,9 +1,11 @@
 package dk.trustworks.intranet.cultureservice.services;
 
 import dk.trustworks.intranet.cultureservice.model.KeyPurpose;
+import dk.trustworks.intranet.domain.user.entity.User;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
 import java.util.List;
 
 /**
@@ -19,6 +21,9 @@ public class KeyPurposeService {
 
     @Transactional
     public List<KeyPurpose> findByUseruuid(String useruuid) {
+        if (User.count("uuid = ?1", useruuid) == 0) {
+            throw new BadRequestException("Unknown useruuid: " + useruuid);
+        }
         List<KeyPurpose> keyPurposeList = KeyPurpose.find("useruuid = ?1", useruuid).list();
         if(keyPurposeList.size()<3) {
             for (int i = 0; i < 3; i++) {

--- a/src/main/java/dk/trustworks/intranet/cultureservice/services/KeyPurposeService.java
+++ b/src/main/java/dk/trustworks/intranet/cultureservice/services/KeyPurposeService.java
@@ -7,6 +7,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.BadRequestException;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Created by hans on 23/06/2017.
@@ -25,11 +27,19 @@ public class KeyPurposeService {
             throw new BadRequestException("Unknown useruuid: " + useruuid);
         }
         List<KeyPurpose> keyPurposeList = KeyPurpose.find("useruuid = ?1", useruuid).list();
-        if(keyPurposeList.size()<3) {
-            for (int i = 0; i < 3; i++) {
-                KeyPurpose keyPurpose = new KeyPurpose(useruuid, i, "");
-                create(keyPurpose);
-                keyPurposeList.add(keyPurpose);
+        // Lazily provision the three key purposes using a 1-based scheme (1, 2, 3).
+        // Only missing slots are created, so a user with a partial set is completed
+        // without ever producing duplicate num values.
+        if (keyPurposeList.size() < 3) {
+            Set<Integer> existingNums = keyPurposeList.stream()
+                    .map(KeyPurpose::getNum)
+                    .collect(Collectors.toSet());
+            for (int num = 1; num <= 3; num++) {
+                if (!existingNums.contains(num)) {
+                    KeyPurpose keyPurpose = new KeyPurpose(useruuid, num, "");
+                    create(keyPurpose);
+                    keyPurposeList.add(keyPurpose);
+                }
             }
         }
         return keyPurposeList;

--- a/src/main/resources/db/migration/V367__Backfill_null_salary_type.sql
+++ b/src/main/resources/db/migration/V367__Backfill_null_salary_type.sql
@@ -1,0 +1,21 @@
+-- ====================================================================
+-- V367: Backfill NULL salary.type to NORMAL.
+--
+-- A small number of legacy `salary` rows have a NULL `type`. They were
+-- created before the column was consistently populated: the Salary(...)
+-- entity constructors never set `type`, and the DB column historically
+-- allowed NULL even though the entity declares it non-null.
+--
+-- A NULL type makes Salary.getType() return null, which produced a
+-- NullPointerException in SalaryResource.listPayments (now additionally
+-- null-guarded in code). NORMAL is the standard salaried type; HOURLY is
+-- the rare exception, so NORMAL is the correct default for these legacy
+-- rows.
+--
+-- Idempotent: affects no rows once none remain NULL.
+-- Rollback: not reversible — the original NULLs are not recorded.
+-- ====================================================================
+
+UPDATE salary
+SET type = 'NORMAL'
+WHERE type IS NULL;

--- a/src/main/resources/db/migration/V368__Normalize_keypurpose_num_to_1_based.sql
+++ b/src/main/resources/db/migration/V368__Normalize_keypurpose_num_to_1_based.sql
@@ -1,0 +1,36 @@
+-- Normalize keypurpose.num to a single, consistent 1-based scheme (1, 2, 3).
+--
+-- Background
+-- ----------
+-- keypurpose.num was historically populated by two different conventions:
+--   * the legacy pre-intranetservices monolith (table dates to 2017): 1-based -> {1,2,3}
+--   * the current KeyPurposeService.findByUseruuid() lazy-create loop:  0-based -> {0,1,2}
+-- The data was never normalized, leaving 118 users on {0,1,2} and 89 on {1,2,3}.
+-- The mismatch caused real display bugs (profile Overview hid the first key
+-- purpose for 0-based users; the team-dashboard KPC tab defaulted to a
+-- non-existent "0" tab for 1-based users) and inconsistent "#0/#1/#2" vs
+-- "#1/#2/#3" labels. The backend lazy-create loop is switched to 1-based in the
+-- same change set, so new users are also provisioned as {1,2,3}.
+--
+-- Safety / no data loss
+-- ---------------------
+-- This shifts every 0-based user's rows up by one. It is LOSSLESS: only the num
+-- value changes (description / meeting_notes are untouched), no rows are inserted
+-- or deleted, and the total row count is unchanged.
+--
+-- Verified read-only against production before authoring:
+--   * 621 rows / 207 users, each user has exactly 3 rows
+--   * no NULL num; no num outside {0,1,2,3}; no duplicate (useruuid, num)
+--   * no user holds both num=0 and num=3, so +1 can never create a stray "4"
+--   * Pre-shift : num0=118  num1=207  num2=207  num3=89   (621 rows)
+--   * Post-shift: num1=207  num2=207  num3=207             (621 rows, unchanged)
+--
+-- The 89 users already on {1,2,3} have no num=0 row and are intentionally left
+-- untouched. The derived table is materialised first so MariaDB allows the
+-- self-referencing UPDATE and evaluates the IN-list against the pre-update state.
+
+UPDATE keypurpose
+SET num = num + 1
+WHERE useruuid IN (
+    SELECT u FROM (SELECT DISTINCT useruuid AS u FROM keypurpose WHERE num = 0) AS zero_based_users
+);


### PR DESCRIPTION
Promotes staging → production.

## Included
- **V368** Normalize `keypurpose.num` to 1-based — lossless `+1` shift of the 118 0-based users; 621 rows preserved. Fixes profile Overview hiding the first key purpose and the team KPC tab being blank for some users.
- `KeyPurposeService.findByUseruuid()` now provisions slots 1..3 idempotently (only fills missing nums; kills the duplicate-on-partial latent bug).
- **V367** Backfill NULL `salary.type` → NORMAL (idempotent; currently 0 NULL rows on prod → no-op).

## Validated on staging
- Flyway V367+V368 applied success; `keypurpose` uniform num 1/2/3 (207 each), 621 rows, zero data loss.
- ECS rolloutState COMPLETED, PRIMARY, image-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)