### PR TITLE
Fix expense upload status-revert loop + journal-scope e-conomic idempotency key

### DIFF
--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
@@ -60,13 +60,20 @@ public class  EconomicsService {
      */
     private static final int MAX_PERIOD_SHIFT_DAYS = 7;
 
-    /** Builds the e-conomics Idempotency-Key header value for a voucher POST. */
-    String buildIdempotencyKey(Expense expense) {
+    /**
+     * Builds the e-conomics Idempotency-Key header value for a voucher POST.
+     * <p>Scoped to the target journal (URL = {@code /journals/{journalNumber}/vouchers}). e-conomic
+     * rejects a reused key against a different URL with HTTP 400 "URLChanged" — which happens when an
+     * expense is retried after its journal/company changed (e.g. an employee moved company). Including
+     * the journal keeps retries to the same journal idempotent (no duplicate voucher) while letting a
+     * different journal be treated as a fresh POST instead of failing.
+     */
+    String buildIdempotencyKey(Expense expense, int journalNumber) {
         if (expense.hasKnownCacheIssue() || Boolean.TRUE.equals(expense.getIsOrphaned())) {
-            return String.format("%s-expense-%s-retry-%d",
-                    environmentId, expense.getUuid(), expense.getSafeRetryCount());
+            return String.format("%s-expense-%s-j%d-retry-%d",
+                    environmentId, expense.getUuid(), journalNumber, expense.getSafeRetryCount());
         }
-        return environmentId + "-expense-" + expense.getUuid();
+        return String.format("%s-expense-%s-j%d", environmentId, expense.getUuid(), journalNumber);
     }
 
     /**
@@ -121,7 +128,7 @@ public class  EconomicsService {
                 voucher = buildJSONRequestWithDate(expense, userAccount, journal, text, voucherDate, defaultVatCode);
                 String json = new ObjectMapper().writeValueAsString(voucher);
                 String idempotencyKey = (shift == 0)
-                        ? buildIdempotencyKey(expense)
+                        ? buildIdempotencyKey(expense, journal.getJournalNumber())
                         : buildPeriodShiftIdempotencyKey(expense, shift);
 
                 if (shift == 0) {

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseService.java
@@ -346,6 +346,21 @@ public class ExpenseService {
             // for those is derived purely from status — review_state/hr_decision are not read.
             ExpenseStateDeriver.DerivedState derived = ExpenseStateDeriver.deriveFromStatus(status);
 
+            // Keep the passed entity in sync with the bulk update below. The upload path holds
+            // `expense` as a MANAGED entity inside an outer @Transactional chunk and mutates it
+            // (sendVoucher sets the voucher number). Without syncing status/state here, the outer
+            // persistence-context flush at commit re-derives state from the entity's STALE status
+            // (syncDerivedState @PreUpdate) and writes it back, clobbering this REQUIRES_NEW update.
+            // Observed symptom: the voucher number persists but status reverts to VALIDATED, so the
+            // reader re-posts the expense every hour and it never reaches BOOKED (also leaves rows
+            // stranded in PROCESSING when an UP_FAILED update is clobbered). Syncing the entity makes
+            // the flush a no-op overwrite; on an outer rollback the committed values here still win.
+            expense.setStatus(status);
+            expense.setErrorMessage(errorMessage);
+            expense.setState(derived.state());
+            expense.setAttentionOwner(derived.owner());
+            expense.setAttentionKind(derived.kind());
+
             // Positional params: ?1–?10 = existing fields, ?11 = uuid (WHERE), ?12–?14 = derived state columns.
             // ?12–?14 intentionally appear in SET before ?11 in WHERE; binding is by ordinal, not text order.
             // If you add a field, do NOT renumber ?11–?14 without updating both the SQL and the argument order.

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsIdempotencyKeyTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsIdempotencyKeyTest.java
@@ -23,8 +23,8 @@ class EconomicsIdempotencyKeyTest {
         Expense e = new Expense();
         e.setUuid("abc-123");
 
-        assertEquals("production-expense-abc-123",
-                serviceFor("production").buildIdempotencyKey(e));
+        assertEquals("production-expense-abc-123-j9",
+                serviceFor("production").buildIdempotencyKey(e, 9));
     }
 
     @Test
@@ -32,8 +32,8 @@ class EconomicsIdempotencyKeyTest {
         Expense e = new Expense();
         e.setUuid("abc-123");
 
-        assertEquals("production-expense-abc-123", serviceFor("production").buildIdempotencyKey(e));
-        assertEquals("staging-expense-abc-123",    serviceFor("staging").buildIdempotencyKey(e));
+        assertEquals("production-expense-abc-123-j9", serviceFor("production").buildIdempotencyKey(e, 9));
+        assertEquals("staging-expense-abc-123-j9",    serviceFor("staging").buildIdempotencyKey(e, 9));
     }
 
     @Test
@@ -43,8 +43,8 @@ class EconomicsIdempotencyKeyTest {
         e.markAsOrphaned();
         e.incrementRetryCount();
 
-        assertEquals("production-expense-abc-123-retry-1",
-                serviceFor("production").buildIdempotencyKey(e));
+        assertEquals("production-expense-abc-123-j9-retry-1",
+                serviceFor("production").buildIdempotencyKey(e, 9));
     }
 
     @Test
@@ -56,7 +56,7 @@ class EconomicsIdempotencyKeyTest {
         e.setErrorMessage("voucher not found in journal 16");
         e.incrementRetryCount();
 
-        assertEquals("production-expense-abc-123-retry-1",
-                serviceFor("production").buildIdempotencyKey(e));
+        assertEquals("production-expense-abc-123-j9-retry-1",
+                serviceFor("production").buildIdempotencyKey(e, 9));
     }
 }

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsPeriodClosedShiftTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsPeriodClosedShiftTest.java
@@ -47,11 +47,11 @@ class EconomicsPeriodClosedShiftTest {
         Expense e = new Expense();
         e.setUuid("abc-123");
 
-        String standard = s.buildIdempotencyKey(e);
+        String standard = s.buildIdempotencyKey(e, 9);
         String shift1 = s.buildPeriodShiftIdempotencyKey(e, 1);
         String shift7 = s.buildPeriodShiftIdempotencyKey(e, 7);
 
-        assertEquals("production-expense-abc-123", standard);
+        assertEquals("production-expense-abc-123-j9", standard);
         assertEquals("production-expense-abc-123-period-shift-1", shift1);
         assertEquals("production-expense-abc-123-period-shift-7", shift7);
     }


### PR DESCRIPTION
Two reliability fixes in the expense → e-conomic upload pipeline, found while investigating expenses that were stuck "needs attention" and never reimbursed.

## 1. Status-revert loop (`ExpenseService.updateStatus`)
`updateStatus` persists status via a `QuarkusTransaction.requiringNew()` bulk `Expense.update(...)`, but the upload path (`ExpenseItemWriter` → `processExpenseItem`) holds the row as a **managed** entity inside the outer `@Transactional` chunk and mutates it (`sendVoucher` sets the voucher number). At chunk-commit the persistence-context flush re-derives state from the entity's **stale** status (`syncDerivedState` `@PreUpdate`) and writes it back, clobbering the bulk update — so the voucher number persists but **status reverts to `VALIDATED`**. The reader (`state=APPROVED`) then re-posts the expense every hour (idempotent, no duplicate) and it never reaches `BOOKED`; the same clobber also stranded rows in `PROCESSING`.

Evidence on prod: rows with `status IN (VALIDATED,PROCESSING) AND vouchernumber>0` carrying `retry_count` of **13** and **37**, plus 26 rows stranded in `PROCESSING`.

**Fix:** sync `status/state/attentionOwner/attentionKind/errorMessage` onto the entity inside `updateStatus` so the flush is a consistent no-op overwrite. On an outer rollback the committed REQUIRES_NEW values still win (durability preserved).

## 2. `URLChanged` idempotency failure (`EconomicsService.buildIdempotencyKey`)
The voucher-POST idempotency key was `<env>-expense-<uuid>`, independent of the target journal. When an expense is retried after its journal/company changed (e.g. an employee moved company), e-conomic rejects the reused key against the new URL (`/journals/{journalNumber}/vouchers`) with HTTP 400 `URLChanged`, leaving it stuck `UP_FAILED`.

**Fix:** scope the key to the journal — `<env>-expense-<uuid>-j<journalNumber>`. Retries to the same journal stay idempotent; a different journal is treated as a fresh POST.

## Tests
`EconomicsIdempotencyKeyTest` + `EconomicsPeriodClosedShiftTest` updated to the journal-scoped format. `./mvnw test` on both: **8/8 pass, BUILD SUCCESS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)