### PR TITLE
Promote staging → master: expense upload status-revert + URLChanged idempotency fixes

### DIFF
--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
@@ -60,13 +60,20 @@ public class  EconomicsService {
      */
     private static final int MAX_PERIOD_SHIFT_DAYS = 7;
 
-    /** Builds the e-conomics Idempotency-Key header value for a voucher POST. */
-    String buildIdempotencyKey(Expense expense) {
+    /**
+     * Builds the e-conomics Idempotency-Key header value for a voucher POST.
+     * <p>Scoped to the target journal (URL = {@code /journals/{journalNumber}/vouchers}). e-conomic
+     * rejects a reused key against a different URL with HTTP 400 "URLChanged" — which happens when an
+     * expense is retried after its journal/company changed (e.g. an employee moved company). Including
+     * the journal keeps retries to the same journal idempotent (no duplicate voucher) while letting a
+     * different journal be treated as a fresh POST instead of failing.
+     */
+    String buildIdempotencyKey(Expense expense, int journalNumber) {
         if (expense.hasKnownCacheIssue() || Boolean.TRUE.equals(expense.getIsOrphaned())) {
-            return String.format("%s-expense-%s-retry-%d",
-                    environmentId, expense.getUuid(), expense.getSafeRetryCount());
+            return String.format("%s-expense-%s-j%d-retry-%d",
+                    environmentId, expense.getUuid(), journalNumber, expense.getSafeRetryCount());
         }
-        return environmentId + "-expense-" + expense.getUuid();
+        return String.format("%s-expense-%s-j%d", environmentId, expense.getUuid(), journalNumber);
     }
 
     /**
@@ -121,7 +128,7 @@ public class  EconomicsService {
                 voucher = buildJSONRequestWithDate(expense, userAccount, journal, text, voucherDate, defaultVatCode);
                 String json = new ObjectMapper().writeValueAsString(voucher);
                 String idempotencyKey = (shift == 0)
-                        ? buildIdempotencyKey(expense)
+                        ? buildIdempotencyKey(expense, journal.getJournalNumber())
                         : buildPeriodShiftIdempotencyKey(expense, shift);
 
                 if (shift == 0) {

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseService.java
@@ -346,6 +346,21 @@ public class ExpenseService {
             // for those is derived purely from status — review_state/hr_decision are not read.
             ExpenseStateDeriver.DerivedState derived = ExpenseStateDeriver.deriveFromStatus(status);
 
+            // Keep the passed entity in sync with the bulk update below. The upload path holds
+            // `expense` as a MANAGED entity inside an outer @Transactional chunk and mutates it
+            // (sendVoucher sets the voucher number). Without syncing status/state here, the outer
+            // persistence-context flush at commit re-derives state from the entity's STALE status
+            // (syncDerivedState @PreUpdate) and writes it back, clobbering this REQUIRES_NEW update.
+            // Observed symptom: the voucher number persists but status reverts to VALIDATED, so the
+            // reader re-posts the expense every hour and it never reaches BOOKED (also leaves rows
+            // stranded in PROCESSING when an UP_FAILED update is clobbered). Syncing the entity makes
+            // the flush a no-op overwrite; on an outer rollback the committed values here still win.
+            expense.setStatus(status);
+            expense.setErrorMessage(errorMessage);
+            expense.setState(derived.state());
+            expense.setAttentionOwner(derived.owner());
+            expense.setAttentionKind(derived.kind());
+
             // Positional params: ?1–?10 = existing fields, ?11 = uuid (WHERE), ?12–?14 = derived state columns.
             // ?12–?14 intentionally appear in SET before ?11 in WHERE; binding is by ordinal, not text order.
             // If you add a field, do NOT renumber ?11–?14 without updating both the SQL and the argument order.

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsIdempotencyKeyTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsIdempotencyKeyTest.java
@@ -23,8 +23,8 @@ class EconomicsIdempotencyKeyTest {
         Expense e = new Expense();
         e.setUuid("abc-123");
 
-        assertEquals("production-expense-abc-123",
-                serviceFor("production").buildIdempotencyKey(e));
+        assertEquals("production-expense-abc-123-j9",
+                serviceFor("production").buildIdempotencyKey(e, 9));
     }
 
     @Test
@@ -32,8 +32,8 @@ class EconomicsIdempotencyKeyTest {
         Expense e = new Expense();
         e.setUuid("abc-123");
 
-        assertEquals("production-expense-abc-123", serviceFor("production").buildIdempotencyKey(e));
-        assertEquals("staging-expense-abc-123",    serviceFor("staging").buildIdempotencyKey(e));
+        assertEquals("production-expense-abc-123-j9", serviceFor("production").buildIdempotencyKey(e, 9));
+        assertEquals("staging-expense-abc-123-j9",    serviceFor("staging").buildIdempotencyKey(e, 9));
     }
 
     @Test
@@ -43,8 +43,8 @@ class EconomicsIdempotencyKeyTest {
         e.markAsOrphaned();
         e.incrementRetryCount();
 
-        assertEquals("production-expense-abc-123-retry-1",
-                serviceFor("production").buildIdempotencyKey(e));
+        assertEquals("production-expense-abc-123-j9-retry-1",
+                serviceFor("production").buildIdempotencyKey(e, 9));
     }
 
     @Test
@@ -56,7 +56,7 @@ class EconomicsIdempotencyKeyTest {
         e.setErrorMessage("voucher not found in journal 16");
         e.incrementRetryCount();
 
-        assertEquals("production-expense-abc-123-retry-1",
-                serviceFor("production").buildIdempotencyKey(e));
+        assertEquals("production-expense-abc-123-j9-retry-1",
+                serviceFor("production").buildIdempotencyKey(e, 9));
     }
 }

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsPeriodClosedShiftTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsPeriodClosedShiftTest.java
@@ -47,11 +47,11 @@ class EconomicsPeriodClosedShiftTest {
         Expense e = new Expense();
         e.setUuid("abc-123");
 
-        String standard = s.buildIdempotencyKey(e);
+        String standard = s.buildIdempotencyKey(e, 9);
         String shift1 = s.buildPeriodShiftIdempotencyKey(e, 1);
         String shift7 = s.buildPeriodShiftIdempotencyKey(e, 7);
 
-        assertEquals("production-expense-abc-123", standard);
+        assertEquals("production-expense-abc-123-j9", standard);
         assertEquals("production-expense-abc-123-period-shift-1", shift1);
         assertEquals("production-expense-abc-123-period-shift-7", shift7);
     }


### PR DESCRIPTION
Promotes the expense → e-conomic upload reliability fixes from `staging` to prod. Clean scope — `staging` is exactly 2 commits ahead of `master`, both below; **code-only, no Flyway migration**.

Originally reviewed/merged to staging as #107.

## What's promoted
1. **Status-revert loop fix** (`ExpenseService.updateStatus`) — sync `status/state/owner/kind/errorMessage` onto the managed entity so the chunk-commit flush can't clobber the REQUIRES_NEW bulk update. Fixes expenses that got a voucher but reverted to `VALIDATED` and re-posted hourly forever (seen with `retry_count` 13 & 37), and rows stranded in `PROCESSING`. Also makes the reconciliation job's own status writes stick (`UPLOADED → VERIFIED_BOOKED`).
2. **Journal-scoped idempotency key** (`EconomicsService.buildIdempotencyKey`) — key now includes the journal (`-j<journalNumber>`) so an expense retried after a journal/company change is a fresh POST instead of a 400 `URLChanged`.

Tests: `EconomicsIdempotencyKeyTest` + `EconomicsPeriodClosedShiftTest` (8/8 pass).

## After this deploys to prod
- Verify the prod task-def image SHA matches the build (ECS Express canary can roll back invisibly).
- Re-queue **Jakob Geitner-Andersen** (econ `9818`) and the **20 URLChanged** rows — they'll then post & book cleanly.
- Confirm the 6 already-finalized rows (Stephan ×4 + 2 loopers) reach `VERIFIED_BOOKED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)