### PR TITLE
Promote to prod: Danløn proposals month-param → 400 hardening

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/accounting/resources/DanlonProposalResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/accounting/resources/DanlonProposalResource.java
@@ -19,6 +19,7 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 
@@ -128,8 +129,12 @@ public class DanlonProposalResource {
     private static LocalDate parseMonth(String strMonth) {
         if (strMonth == null || strMonth.isBlank()) return LocalDate.now().withDayOfMonth(1);
         String t = strMonth.trim();
-        LocalDate d = (t.length() == 7) ? LocalDate.parse(t + "-01") : LocalDate.parse(t);
-        return d.withDayOfMonth(1);
+        try {
+            LocalDate d = (t.length() == 7) ? LocalDate.parse(t + "-01") : LocalDate.parse(t);
+            return d.withDayOfMonth(1);
+        } catch (DateTimeParseException e) {
+            throw new BadRequestException("month must be YYYY-MM or YYYY-MM-DD");
+        }
     }
 
     public record ApproveRequest(String confirmedNumber) {}

--- a/src/test/java/dk/trustworks/intranet/aggregates/accounting/resources/DanlonProposalResourceTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/accounting/resources/DanlonProposalResourceTest.java
@@ -93,6 +93,16 @@ class DanlonProposalResourceTest {
     }
 
     @Test
+    @TestSecurity(user = "hr", roles = {"salaries:read"})
+    void malformedProposalMonthReturns400() {
+        given().header("X-Requested-By", "hr")
+        .when()
+                .get("/company/x/danlon/proposals?month=not-a-month")
+        .then()
+                .statusCode(400);
+    }
+
+    @Test
     @TestSecurity(user = "hr", roles = {"salaries:write"})
     void approveViaWrongCompanyPathReturns403() {  // cross-company BOLA guard (security review F2)
         String user = newUser();


### PR DESCRIPTION
## Harden `DanlonProposalResource` month parsing

Promotes `staging` (`eec9b531`) → `master`. Single commit, BE-only — no DB migration, no JSON-shape change.

`parseMonth(...)` now catches `DateTimeParseException` and throws `BadRequestException` (**400**) for a malformed `?month=` query param, instead of letting it surface as a generic **500**. Adds a RestAssured test (`malformedProposalMonthReturns400`).

### Verification
- `./mvnw -q clean test-compile` EXIT=0.
- Deployed to staging (`tw-quarkus-staging:eec9b531`, rollout COMPLETED, deployments=1, `/health` 200).
- The new RestAssured test needs a DB (deploys skip tests); the change is a self-contained try/catch.

### Rollback
Code-only revert; no DB impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)