### PR TITLE
feat(auto-fix): runtime-configurable worker settings + Settings tab

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/bugreport/resources/BugReportResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/bugreport/resources/BugReportResource.java
@@ -22,7 +22,10 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * REST resource for the Bug Report bounded context.
@@ -429,40 +432,91 @@ public class BugReportResource {
         return Response.ok(stats).build();
     }
 
-    // ---- 20. GET /bug-reports/auto-fix/config — Kill switch status ----
+    // Allowed values for the tunable auto-fix worker settings (validated on write).
+    // Model strings must be exact CLI model ids; effort must be a valid --effort level.
+    private static final Set<String> ALLOWED_EFFORTS = Set.of("low", "medium", "high", "xhigh", "max");
+    private static final Set<String> ALLOWED_MODELS = Set.of(
+            "claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5-20251001");
+    private static final String DEFAULT_MODEL = "claude-opus-4-8";
+    private static final String DEFAULT_EFFORT = "xhigh";
+    private static final String DEFAULT_MAX_TURNS = "150";
+    private static final String DEFAULT_MAX_BUDGET_USD = "10.00";
+
+    // ---- 20. GET /bug-reports/auto-fix/config — Auto-fix worker settings ----
     @GET
     @Path("/auto-fix/config")
     @RolesAllowed({"bugreports:admin"})
     public Response getAutoFixConfig() {
-        String enabled = autoFixService.getConfigValue("autofix.enabled", "true");
-        return Response.ok(Map.of("enabled", Boolean.parseBoolean(enabled))).build();
+        Map<String, Object> cfg = new LinkedHashMap<>();
+        cfg.put("enabled", Boolean.parseBoolean(autoFixService.getConfigValue("autofix.enabled", "true")));
+        cfg.put("model", autoFixService.getConfigValue("autofix.model", DEFAULT_MODEL));
+        cfg.put("effort", autoFixService.getConfigValue("autofix.effort", DEFAULT_EFFORT));
+        cfg.put("maxTurns", safeInt(autoFixService.getConfigValue("autofix.max_turns", DEFAULT_MAX_TURNS), 150));
+        cfg.put("maxBudgetUsd", autoFixService.getConfigValue("autofix.max_budget_usd", DEFAULT_MAX_BUDGET_USD));
+        // Surfaced so the Settings UI can render dropdowns without hardcoding choices.
+        cfg.put("allowedModels", ALLOWED_MODELS);
+        cfg.put("allowedEfforts", ALLOWED_EFFORTS);
+        return Response.ok(cfg).build();
     }
 
-    // ---- 21. PUT /bug-reports/auto-fix/config — Toggle kill switch ----
+    // ---- 21. PUT /bug-reports/auto-fix/config — Update auto-fix worker settings ----
+    // Accepts any subset of {enabled, model, effort, maxTurns, maxBudgetUsd}. Each
+    // provided field is validated, then upserted into autofix_config. Returns the
+    // full, current config (same shape as GET).
     @PUT
     @Path("/auto-fix/config")
     @RolesAllowed({"bugreports:admin"})
     @Transactional
     public Response updateAutoFixConfig(Map<String, Object> config) {
         String requestedBy = requestHeaderHolder.getUserUuid();
-        Boolean enabled = (Boolean) config.get("enabled");
-        if (enabled == null) {
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity("{\"error\":\"'enabled' field is required\"}").build();
+        Map<String, String> updates = new LinkedHashMap<>();
+
+        if (config.containsKey("enabled")) {
+            Object v = config.get("enabled");
+            if (!(v instanceof Boolean)) return badRequest("'enabled' must be a boolean");
+            updates.put("autofix.enabled", v.toString());
+        }
+        if (config.containsKey("model")) {
+            String model = String.valueOf(config.get("model"));
+            if (!ALLOWED_MODELS.contains(model)) return badRequest("Invalid model: " + model);
+            updates.put("autofix.model", model);
+        }
+        if (config.containsKey("effort")) {
+            String effort = String.valueOf(config.get("effort"));
+            if (!ALLOWED_EFFORTS.contains(effort)) return badRequest("Invalid effort: " + effort);
+            updates.put("autofix.effort", effort);
+        }
+        if (config.containsKey("maxTurns")) {
+            Integer turns = asInt(config.get("maxTurns"));
+            if (turns == null) return badRequest("'maxTurns' must be a number");
+            if (turns < 10 || turns > 300) return badRequest("'maxTurns' must be between 10 and 300");
+            updates.put("autofix.max_turns", turns.toString());
+        }
+        if (config.containsKey("maxBudgetUsd")) {
+            Double budget = asDouble(config.get("maxBudgetUsd"));
+            if (budget == null) return badRequest("'maxBudgetUsd' must be a number");
+            if (budget < 1.0 || budget > 50.0) return badRequest("'maxBudgetUsd' must be between 1 and 50");
+            updates.put("autofix.max_budget_usd", String.format(Locale.US, "%.2f", budget));
         }
 
-        em.createNativeQuery(
-            "INSERT INTO autofix_config (config_key, config_value, updated_by) " +
-            "VALUES ('autofix.enabled', :value, :updatedBy) " +
-            "ON DUPLICATE KEY UPDATE config_value = :value, updated_by = :updatedBy")
-            .setParameter("value", enabled.toString())
-            .setParameter("updatedBy", requestedBy)
-            .executeUpdate();
+        if (updates.isEmpty()) {
+            return badRequest("No valid settings provided");
+        }
+
+        for (Map.Entry<String, String> e : updates.entrySet()) {
+            em.createNativeQuery(
+                "INSERT INTO autofix_config (config_key, config_value, updated_by) " +
+                "VALUES (:key, :value, :updatedBy) " +
+                "ON DUPLICATE KEY UPDATE config_value = :value, updated_by = :updatedBy")
+                .setParameter("key", e.getKey())
+                .setParameter("value", e.getValue())
+                .setParameter("updatedBy", requestedBy)
+                .executeUpdate();
+        }
 
         autoFixService.invalidateConfigCache();
-
-        log.infof("Auto-fix %s by %s", enabled ? "enabled" : "disabled", requestedBy);
-        return Response.ok(Map.of("enabled", enabled)).build();
+        log.infof("Auto-fix config updated by %s: %s", requestedBy, updates.keySet());
+        return getAutoFixConfig();
     }
 
     // ---- Helpers ----
@@ -482,6 +536,39 @@ public class BugReportResource {
         } catch (Exception e) {
             log.debugf("Could not parse If-Match header: %s", ifMatchHeader);
             return null;
+        }
+    }
+
+    private static Response badRequest(String message) {
+        // Map entity is JSON-serialized by Jackson, so user-supplied values in the
+        // message are safely escaped (no manual string interpolation into JSON).
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(Map.of("error", message)).build();
+    }
+
+    private static Integer asInt(Object value) {
+        if (value instanceof Number n) return n.intValue();
+        try {
+            return Integer.valueOf(String.valueOf(value).trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static Double asDouble(Object value) {
+        if (value instanceof Number n) return n.doubleValue();
+        try {
+            return Double.valueOf(String.valueOf(value).trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static int safeInt(String value, int defaultValue) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return defaultValue;
         }
     }
 }

--- a/src/main/java/dk/trustworks/intranet/aggregates/bugreport/services/BugReportAutoFixService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/bugreport/services/BugReportAutoFixService.java
@@ -1032,6 +1032,18 @@ public class BugReportAutoFixService {
     }
 
     /**
+     * Read an integer configuration value from autofix_config, falling back to
+     * {@code defaultValue} if the key is missing or not a valid integer.
+     */
+    private int parseIntConfig(String key, int defaultValue) {
+        try {
+            return Integer.parseInt(getConfigValue(key, String.valueOf(defaultValue)));
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    /**
      * Invalidate the kill switch cache (called after config update).
      */
     public void invalidateConfigCache() {
@@ -1058,9 +1070,15 @@ public class BugReportAutoFixService {
             metadata.put("reporter_uuid", report.getReporterUuid());
             metadata.put("previous_status", previousStatus);
 
-            // Worker configuration (read by the Fargate worker from metadata)
+            // Worker configuration (read by the Fargate worker from metadata).
+            // Tunable values come from autofix_config (managed via the Auto-Fix
+            // Settings tab → PUT /auto-fix/config); the literals are fallback
+            // defaults if a key is missing. See auto-fix-pipeline.md §3.6.
             metadata.put("allowed_tools", "Read,Write,Edit,Bash,Glob,Grep");
-            metadata.put("max_turns", 150);
+            metadata.put("model", getConfigValue("autofix.model", "claude-opus-4-8"));
+            metadata.put("effort", getConfigValue("autofix.effort", "xhigh"));
+            metadata.put("max_turns", parseIntConfig("autofix.max_turns", 150));
+            metadata.put("max_budget_usd", getConfigValue("autofix.max_budget_usd", "10.00"));
 
             // Security policy decision (for audit)
             ObjectNode policyNode = metadata.putObject("policy_decision");

--- a/src/main/resources/db/migration/V373__Add_autofix_model_effort_config.sql
+++ b/src/main/resources/db/migration/V373__Add_autofix_model_effort_config.sql
@@ -1,0 +1,16 @@
+-- V373: Auto-fix worker tunable configuration (model, effort, turns, budget).
+--
+-- Adds tunable keys to autofix_config. BugReportAutoFixService.buildMetadataJson()
+-- reads these into each task's metadata JSON; the Fargate worker (worker.py) then
+-- applies them to the `claude` invocation. The values seeded here are the current
+-- defaults — admins change them via PUT /bug-reports/auto-fix/config (Settings UI).
+-- See docs/finalized/infrastructure/auto-fix-pipeline.md §3.6.
+--
+-- INSERT IGNORE: never clobber a value an admin already set (and safe to re-run
+-- under the nightly staging refresh).
+
+INSERT IGNORE INTO autofix_config (config_key, config_value, updated_by) VALUES
+    ('autofix.model',          'claude-opus-4-8', 'system:migration'),
+    ('autofix.effort',         'xhigh',           'system:migration'),
+    ('autofix.max_turns',      '150',             'system:migration'),
+    ('autofix.max_budget_usd', '10.00',           'system:migration');

--- a/src/main/resources/db/migration/V374__Register_autofix_settings_tab.sql
+++ b/src/main/resources/db/migration/V374__Register_autofix_settings_tab.sql
@@ -1,0 +1,25 @@
+-- ====================================================================
+-- V374: Register the settings-auto-fix tab in page_registry.
+--
+-- Adds 1 entry under section='SETTINGS' for the Auto-Fix Worker admin tab
+-- (display_order=110, required_roles='ADMIN', icon_name='Wrench'). The
+-- frontend maps page_key 'settings-auto-fix' → AutoFixSettingsTab and the
+-- 'Wrench' icon → lucide Wrench.
+--
+-- Idempotent (INSERT ... ON DUPLICATE KEY UPDATE).
+-- ====================================================================
+
+INSERT INTO page_registry
+    (page_key, page_label, is_visible, react_route, required_roles, display_order, section, icon_name, is_external, external_url)
+VALUES
+    ('settings-auto-fix', 'Auto-Fix', 1, '/settings?tab=auto-fix', 'ADMIN', 110, 'SETTINGS', 'Wrench', 0, NULL)
+ON DUPLICATE KEY UPDATE
+    page_label     = VALUES(page_label),
+    is_visible     = VALUES(is_visible),
+    react_route    = VALUES(react_route),
+    required_roles = VALUES(required_roles),
+    display_order  = VALUES(display_order),
+    section        = VALUES(section),
+    icon_name      = VALUES(icon_name),
+    is_external    = VALUES(is_external),
+    external_url   = VALUES(external_url);


### PR DESCRIPTION
Adds a Settings → Auto-Fix admin tab to configure the self-healing worker (model, effort, max turns, max budget, kill switch), backed by autofix_config → task metadata → worker.

- V373 seeds config keys; V374 registers the page_registry tab
- GET/PUT /bug-reports/auto-fix/config extended with validation
- Pairs with the worker image already deployed to staging+prod (Opus 4.8 / xhigh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)