### PR TITLE
Release: receipt-image NPE guard + orphan-batchlet tx fix + notification-time fix

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/bugreport/dto/BugReportNotificationDTO.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/bugreport/dto/BugReportNotificationDTO.java
@@ -1,7 +1,7 @@
 package dk.trustworks.intranet.aggregates.bugreport.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 public record BugReportNotificationDTO(
     String uuid,
@@ -10,5 +10,5 @@ public record BugReportNotificationDTO(
     String type,
     String message,
     @JsonProperty("isRead") boolean isRead,
-    LocalDateTime createdAt
+    OffsetDateTime createdAt
 ) {}

--- a/src/main/java/dk/trustworks/intranet/aggregates/bugreport/services/BugReportService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/bugreport/services/BugReportService.java
@@ -863,6 +863,8 @@ public class BugReportService {
                 notification.getType().name(),
                 notification.getMessage(),
                 notification.isRead(),
-                notification.getCreatedAt());
+                notification.getCreatedAt() != null
+                        ? notification.getCreatedAt().atOffset(java.time.ZoneOffset.UTC)
+                        : null);
     }
 }

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseOrphanDetectionBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseOrphanDetectionBatchlet.java
@@ -67,8 +67,17 @@ public class ExpenseOrphanDetectionBatchlet extends AbstractBatchlet {
             AtomicInteger errorsFound = new AtomicInteger(0);
 
             // Find expenses with voucher numbers that might be orphaned
-            // Check multiple statuses as vouchers can become orphaned at any stage
-            List<Expense> expensesToCheck = Expense.<Expense>find(
+            // Check multiple statuses as vouchers can become orphaned at any stage.
+            //
+            // The read runs inside an explicit transaction. JBeret invokes this batchlet without an
+            // ambient transaction, so a bare Panache read executes against a Hibernate session whose
+            // JDBC connection has already been released — failing with
+            // "LogicalConnectionManagedImpl is closed". Opening a transaction (requiringNew) acquires
+            // a valid, open connection for the query. The returned entities are detached afterwards,
+            // which is safe here because Expense is a flat (relationship-free) entity and the loop
+            // below only reads already-loaded scalar fields and re-looks-up by uuid.
+            List<Expense> expensesToCheck = QuarkusTransaction.requiringNew().call(() ->
+                Expense.<Expense>find(
                 "vouchernumber > 0 AND journalnumber IS NOT NULL AND accountingyear IS NOT NULL " +
                 "AND status IN (?1, ?2, ?3, ?4) " +
                 "AND (isOrphaned = false OR isOrphaned IS NULL) " +
@@ -78,7 +87,7 @@ public class ExpenseOrphanDetectionBatchlet extends AbstractBatchlet {
                 ExpenseService.STATUS_UP_FAILED,
                 ExpenseService.STATUS_VERIFIED_UNBOOKED)
                 .page(0, MAX_EXPENSES_TO_CHECK)
-                .list();
+                .list());
 
             log.infof("Found %d expenses with voucher references to verify", expensesToCheck.size());
 
@@ -89,26 +98,32 @@ public class ExpenseOrphanDetectionBatchlet extends AbstractBatchlet {
 
                 for (Expense expense : batch) {
                     try {
-                        boolean voucherExists = economicsService.verifyVoucherExists(expense);
-                        totalChecked.incrementAndGet();
+                        // Process each expense in its own transaction. verifyVoucherExists builds the
+                        // e-conomic client via getApiForExpense -> userService.findById, which is a DB
+                        // read; without an explicit transaction that read fails with
+                        // "LogicalConnectionManagedImpl is closed" on the JBeret worker thread. The
+                        // orphan-marking update needs a transaction too. Scoping it per expense keeps
+                        // the connection out of the inter-batch sleeps and releases it between
+                        // expenses, instead of holding one transaction across the whole job.
+                        QuarkusTransaction.requiringNew().run(() -> {
+                            boolean voucherExists = economicsService.verifyVoucherExists(expense);
+                            totalChecked.incrementAndGet();
 
-                        if (!voucherExists) {
-                            log.warnf("Orphaned voucher detected: expense=%s, voucher=%d, journal=%d, year=%s",
-                                expense.getUuid(), expense.getVouchernumber(),
-                                expense.getJournalnumber(), expense.getAccountingyear());
+                            if (!voucherExists) {
+                                log.warnf("Orphaned voucher detected: expense=%s, voucher=%d, journal=%d, year=%s",
+                                    expense.getUuid(), expense.getVouchernumber(),
+                                    expense.getJournalnumber(), expense.getAccountingyear());
 
-                            // Mark as orphaned
-                            expense.markAsOrphaned();
-                            expense.setLastRetryAt(LocalDateTime.now());
+                                // Mark as orphaned (persisted via the bulk update below)
+                                expense.markAsOrphaned();
+                                expense.setLastRetryAt(LocalDateTime.now());
 
-                            // Update database in its own transaction to avoid TransactionRequiredException
-                            QuarkusTransaction.requiringNew().run(() -> {
                                 Expense.update("isOrphaned = ?1, lastRetryAt = ?2 WHERE uuid = ?3",
                                         true, LocalDateTime.now(), expense.getUuid());
-                            });
 
-                            orphansFound.incrementAndGet();
-                        }
+                                orphansFound.incrementAndGet();
+                            }
+                        });
                     } catch (Exception e) {
                         log.errorf(e, "Error checking voucher existence for expense %s", expense.getUuid());
                         errorsFound.incrementAndGet();

--- a/src/main/java/dk/trustworks/intranet/utils/ImageProcessor.java
+++ b/src/main/java/dk/trustworks/intranet/utils/ImageProcessor.java
@@ -18,6 +18,18 @@ public class ImageProcessor {
         ByteArrayInputStream bais = new ByteArrayInputStream(imageBytes);
         BufferedImage image = ImageIO.read(bais);
 
+        // ImageIO.read() RETURNS null (it does not throw) when the bytes are not a decodable
+        // image — e.g. a PDF, HEIC, or a corrupt/empty receipt. Passing that null straight into
+        // Thumbnailator below throws a cryptic NullPointerException("Image cannot be null."),
+        // which then surfaces on the expense as an opaque "Unexpected error: NullPointerException".
+        // Fail with an actionable IOException instead, so the upload path marks the single expense
+        // as failed (its uuid is already logged by EconomicsService.sendFile) and the chunk
+        // continues, rather than the next reader having to guess what went wrong.
+        if (image == null) {
+            throw new IOException("Receipt is not a decodable image (e.g. PDF, HEIC, or corrupt file); "
+                    + "cannot compress for e-conomic upload");
+        }
+
         // Use Thumbnailator to compress and resize the image
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 

--- a/src/test/java/dk/trustworks/intranet/utils/ImageProcessorTest.java
+++ b/src/test/java/dk/trustworks/intranet/utils/ImageProcessorTest.java
@@ -1,0 +1,58 @@
+package dk.trustworks.intranet.utils;
+
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the e-conomic receipt upload path (EconomicsService.sendFile -> ExpenseService).
+ *
+ * ImageIO.read() RETURNS null (it does not throw) for content it cannot decode — e.g. a PDF,
+ * HEIC, or a corrupt receipt. Before the null guard in ImageProcessor, that null flowed straight
+ * into Thumbnailator and surfaced on the expense as a cryptic
+ * NullPointerException("Image cannot be null."), seen once on prod (2026-06-13, expense
+ * 78c1d153). The guard turns it into an actionable IOException so the single expense is failed
+ * (with its uuid already logged) and the chunk continues.
+ */
+class ImageProcessorTest {
+
+    /** Non-image content (a PDF here) must fail with an actionable IOException, not a cryptic NPE. */
+    @Test
+    void nonDecodableReceiptThrowsActionableIOException() {
+        // Valid bytes, but ImageIO cannot decode them into a BufferedImage (returns null).
+        byte[] pdfBytes = "%PDF-1.7 fake pdf receipt, not a real image".getBytes(StandardCharsets.US_ASCII);
+        String base64Pdf = Base64.getEncoder().encodeToString(pdfBytes);
+
+        IOException ex = assertThrows(IOException.class,
+                () -> ImageProcessor.convertBase64ToImageAndCompress(base64Pdf));
+        assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("not a decodable image"),
+                "message should identify the non-image receipt, was: " + ex.getMessage());
+    }
+
+    /** A genuine image still compresses to a non-empty JPEG (happy path unchanged by the guard). */
+    @Test
+    void decodableImageIsCompressed() throws Exception {
+        BufferedImage img = new BufferedImage(64, 64, BufferedImage.TYPE_INT_RGB);
+        for (int x = 0; x < 64; x++) {
+            for (int y = 0; y < 64; y++) {
+                img.setRGB(x, y, ((x * 4) << 16) | ((y * 4) << 8));
+            }
+        }
+        ByteArrayOutputStream png = new ByteArrayOutputStream();
+        ImageIO.write(img, "png", png);
+        String base64Png = Base64.getEncoder().encodeToString(png.toByteArray());
+
+        byte[] jpg = ImageProcessor.convertBase64ToImageAndCompress(base64Png);
+        assertNotNull(jpg);
+        assertTrue(jpg.length > 0, "compressed jpg should be non-empty");
+    }
+}


### PR DESCRIPTION
## Release Summary (staging → production)
- **fix(expenses): guard non-decodable receipt images** — ImageProcessor now throws an actionable IOException instead of a cryptic NPE("Image cannot be null.") when ImageIO.read() returns null for PDF/HEIC/corrupt receipts (prod NPE 2026-06-13, expense 78c1d153). Single expense fails+logs, chunk continues. Adds ImageProcessorTest.
- **fix: orphan-batchlet transaction** — ExpenseOrphanDetectionBatchlet wraps its read + per-expense work in QuarkusTransaction.requiringNew() so it stops failing with "LogicalConnectionManagedImpl is closed". (Committed as 341cac67 under a mislabeled "fix(contracts)" message — content is the orphan fix.)
- **fix: Notification time is wrong** — BugReport notification DTO/service (carried over from staging).

## Pre-merge checklist
- [x] Staging deploy verified: ECS tw-quarkus-staging task-def 256 (image fc8df379), rollout COMPLETED, deployments=1, clean startup
- [x] Merged tree compiles (BUILD SUCCESS); ImageProcessorTest passes
- [x] No Flyway migrations (no schema coupling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)