### PR TITLE
fix(invoicing): issuer-aware cost account for internal-invoice debtor vouchers

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/IntercompanyAccountMapping.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/IntercompanyAccountMapping.java
@@ -1,0 +1,43 @@
+package dk.trustworks.intranet.aggregates.invoice.economics;
+
+import dk.trustworks.intranet.model.Company;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Maps a (debtor company x issuer company) pair to the e-conomic cost account in
+ * the DEBTOR's chart of accounts for an inter-company purchase (the debtor-side
+ * SupplierInvoice voucher). E.g. debtor A/S + issuer Technology -> 3050,
+ * debtor A/S + issuer Cyber -> 3055.
+ *
+ * Spec: 2026-06-15-internal-invoice-debtor-cost-account-mapping-design.md §4.2.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "intercompany_account_mapping")
+public class IntercompanyAccountMapping extends PanacheEntityBase {
+
+    @Id
+    private String uuid;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "debtor_company_uuid", nullable = false)
+    private Company debtorCompany;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "issuer_company_uuid", nullable = false)
+    private Company issuerCompany;
+
+    @NotNull
+    @Column(name = "economics_cost_account_number", nullable = false)
+    private Integer economicsCostAccountNumber;
+
+    @Column(name = "economics_cost_account_name", length = 100)
+    private String economicsCostAccountName;
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/IntercompanyAccountMappingRepository.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/IntercompanyAccountMappingRepository.java
@@ -1,0 +1,23 @@
+package dk.trustworks.intranet.aggregates.invoice.economics;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Optional;
+
+/**
+ * Panache repository for IntercompanyAccountMapping. Lookups are by the
+ * (debtor, issuer) company pair, which is unique (see V375 UNIQUE KEY).
+ */
+@ApplicationScoped
+public class IntercompanyAccountMappingRepository
+        implements PanacheRepositoryBase<IntercompanyAccountMapping, String> {
+
+    public Optional<IntercompanyAccountMapping> findByDebtorAndIssuer(
+            String debtorCompanyUuid, String issuerCompanyUuid) {
+        if (debtorCompanyUuid == null) throw new IllegalArgumentException("debtorCompanyUuid is required");
+        if (issuerCompanyUuid == null) throw new IllegalArgumentException("issuerCompanyUuid is required");
+        return find("debtorCompany.uuid = ?1 and issuerCompany.uuid = ?2",
+                debtorCompanyUuid, issuerCompanyUuid).firstResultOptional();
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/EconomicsAgreementResolver.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/EconomicsAgreementResolver.java
@@ -1,5 +1,7 @@
 package dk.trustworks.intranet.aggregates.invoice.services;
 
+import dk.trustworks.intranet.aggregates.invoice.economics.IntercompanyAccountMapping;
+import dk.trustworks.intranet.aggregates.invoice.economics.IntercompanyAccountMappingRepository;
 import dk.trustworks.intranet.aggregates.invoice.economics.PaymentTermsMapping;
 import dk.trustworks.intranet.aggregates.invoice.economics.PaymentTermsMappingRepository;
 import dk.trustworks.intranet.aggregates.invoice.economics.VatZoneMapping;
@@ -13,6 +15,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.ws.rs.BadRequestException;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 /**
  * Thin wrapper that resolves e-conomic agreement-level configuration for a given
@@ -31,6 +34,9 @@ public class EconomicsAgreementResolver {
 
     @Inject
     VatZoneMappingRepository vatZoneRepo;
+
+    @Inject
+    IntercompanyAccountMappingRepository intercompanyAccountRepo;
 
     @Inject
     EntityManager em;
@@ -169,6 +175,22 @@ public class EconomicsAgreementResolver {
         }
         IntegrationKey.IntegrationKeyValue kv = IntegrationKey.getIntegrationKeyValue(company);
         return kv.internalJournalNumber();
+    }
+
+    /**
+     * Cost account in the DEBTOR's chart of accounts for an inter-company purchase
+     * from the ISSUER (e.g. debtor A/S + issuer Technology = 3050, Cyber = 3055).
+     *
+     * <p>Returns {@link Optional#empty()} when the (debtor, issuer) pair is not
+     * mapped — or when either UUID is null — so the caller can fall back gracefully
+     * without an exception (see EconomicsInvoiceService.buildJSONRequest).
+     */
+    public Optional<Integer> intercompanyCostAccount(String debtorCompanyUuid, String issuerCompanyUuid) {
+        if (debtorCompanyUuid == null || issuerCompanyUuid == null) {
+            return Optional.empty();
+        }
+        return intercompanyAccountRepo.findByDebtorAndIssuer(debtorCompanyUuid, issuerCompanyUuid)
+                .map(IntercompanyAccountMapping::getEconomicsCostAccountNumber);
     }
 
     /**

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -37,7 +37,8 @@ import java.util.Optional;
 @ApplicationScoped
 public class EconomicsInvoiceService {
 
-    /** Hardcoded Danish 25% purchase VAT code applied to account 2101 on INTERNAL invoices. */
+    /** Hardcoded Danish 25% purchase (input) VAT code (I25), applied to the issuer-aware
+     *  intercompany cost account (e.g. 3050/3055) on INTERNAL invoices. */
     private static final String INTERCOMPANY_VAT_CODE = "I25";
 
     @Inject
@@ -156,12 +157,37 @@ public class EconomicsInvoiceService {
         // Check if this is an internal journal (supplier invoice) or regular journal (customer invoice)
         if (journal.getJournalNumber() == integrationKeyValue.internalJournalNumber()) {
             log.info("Creating supplier invoice for number " + invoice.getInvoicenumber());
+
+            // Resolve the issuer-aware intercompany cost account in the DEBTOR's chart of accounts.
+            // issuer = invoice.getCompany(); debtor = targetCompany. When the pair is mapped
+            // (e.g. Technology -> A/S = 3050, Cyber -> A/S = 3055) the cost lands on that account and
+            // NO contra account is set: the CVR-resolved supplier (kreditor) drives the AP credit.
+            // When the pair is unmapped, keep today's behaviour EXACTLY (invoice-account-number for
+            // both the cost account and the contra account) so out-of-scope intercompany flows are
+            // untouched. See spec 2026-06-15-internal-invoice-debtor-cost-account-mapping-design.md §4.5.
+            String issuerCompanyUuid = invoice.getCompany() != null ? invoice.getCompany().getUuid() : null;
+            Optional<Integer> mappedCostAccount =
+                    agreementResolver.intercompanyCostAccount(targetCompany.getUuid(), issuerCompanyUuid);
+
+            ExpenseAccount supplierAccount;
+            ContraAccount supplierContraAccount;
+            if (mappedCostAccount.isPresent()) {
+                supplierAccount = new ExpenseAccount(mappedCostAccount.get());
+                supplierContraAccount = null;
+            } else {
+                log.warnf("No intercompany cost-account mapping for debtor %s / issuer %s — "
+                                + "falling back to invoice-account-number %d",
+                        targetCompany.getUuid(), issuerCompanyUuid, integrationKeyValue.invoiceAccountNumber());
+                supplierAccount = account;
+                supplierContraAccount = contraAccount;
+            }
+
             SupplierInvoice supplierInvoice = new SupplierInvoice(
-                    account,
+                    supplierAccount,
                     StringUtils.convertInvoiceNumberToString(invoice.getInvoicenumber()),
                     text,
                     invoice.getGrandTotal() != null ? invoice.getGrandTotal() : 0.0,
-                    contraAccount,
+                    supplierContraAccount,
                     date);
 
             String issuerCvr = invoice.getCompany() != null ? invoice.getCompany().getCvr() : null;
@@ -182,7 +208,7 @@ public class EconomicsInvoiceService {
 
             log.debugf("SupplierInvoice text=%s, contraAccount=%s, supplier=%s, contraVatAccount=%s",
                     supplierInvoice.text,
-                    contraAccount.getAccountNumber(),
+                    supplierInvoice.getContraAccount(),
                     supplierInvoice.getSupplier(),
                     supplierInvoice.getContraVatAccount());
             List<SupplierInvoice> supplierInvoices = new ArrayList<>();

--- a/src/main/resources/db/migration/V375__Intercompany_account_mapping.sql
+++ b/src/main/resources/db/migration/V375__Intercompany_account_mapping.sql
@@ -1,0 +1,34 @@
+-- =============================================================================
+-- Migration V375: intercompany_account_mapping
+-- =============================================================================
+-- Spec: docs/superpowers/specs/2026-06-15-internal-invoice-debtor-cost-account-mapping-design.md
+--
+-- Maps a (debtor company, issuer company) pair to the e-conomic cost account in
+-- the DEBTOR's chart of accounts for an inter-company purchase. Used by the
+-- debtor-side SupplierInvoice voucher so the issuer's cost lands on the correct
+-- account (Technology -> 3050, Cyber -> 3055) instead of the debtor's own
+-- invoice-account-number (2101).
+--
+-- Seeds exactly the two in-scope pairs. Unmapped pairs keep today's behaviour
+-- (the application falls back to invoice-account-number and logs a warning).
+-- UUID provenance: companies.uuid values verified in AgreementDefaultsRegistry
+-- (A/S, Trustworks Technology ApS, Trustworks Cyber Security ApS).
+-- =============================================================================
+
+CREATE TABLE intercompany_account_mapping (
+    uuid                            VARCHAR(36)  NOT NULL,
+    debtor_company_uuid             VARCHAR(36)  NOT NULL,
+    issuer_company_uuid             VARCHAR(36)  NOT NULL,
+    economics_cost_account_number   INT          NOT NULL,
+    economics_cost_account_name     VARCHAR(100) NULL,
+    PRIMARY KEY (uuid),
+    UNIQUE KEY uq_intercompany_account_mapping_debtor_issuer (debtor_company_uuid, issuer_company_uuid),
+    CONSTRAINT fk_intercompany_account_mapping_debtor FOREIGN KEY (debtor_company_uuid) REFERENCES companies(uuid),
+    CONSTRAINT fk_intercompany_account_mapping_issuer FOREIGN KEY (issuer_company_uuid) REFERENCES companies(uuid)
+);
+
+INSERT INTO intercompany_account_mapping
+    (uuid, debtor_company_uuid, issuer_company_uuid, economics_cost_account_number, economics_cost_account_name)
+VALUES
+    (UUID(), 'd8894494-2fb4-4f72-9e05-e6032e6dd691', '44592d3b-2be5-4b29-bfaf-4fafc60b0fa3', 3050, 'Koeb hos Trustworks Technology'),
+    (UUID(), 'd8894494-2fb4-4f72-9e05-e6032e6dd691', 'e4b0a2a4-0963-4153-b0a2-a409637153a2', 3055, 'Koeb hos Trustworks Cyber Security');

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/economics/IntercompanyAccountMappingRepositoryTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/economics/IntercompanyAccountMappingRepositoryTest.java
@@ -1,0 +1,48 @@
+package dk.trustworks.intranet.aggregates.invoice.economics;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * DB-backed test for the seeded intercompany_account_mapping rows (V375) — AC8.
+ *
+ * Requires a database. DEFERRED in CI (the CI runner has no DB); run locally
+ * against a freshly-migrated dev DB with:
+ *   ./mvnw test -Dtest=IntercompanyAccountMappingRepositoryTest
+ * The mandatory staging e-conomic verification is the production gate.
+ */
+@QuarkusTest
+class IntercompanyAccountMappingRepositoryTest {
+
+    private static final String AS_UUID    = "d8894494-2fb4-4f72-9e05-e6032e6dd691";
+    private static final String TECH_UUID  = "44592d3b-2be5-4b29-bfaf-4fafc60b0fa3";
+    private static final String CYBER_UUID = "e4b0a2a4-0963-4153-b0a2-a409637153a2";
+
+    @Inject
+    IntercompanyAccountMappingRepository repository;
+
+    @Test
+    void seeded_technology_pair_resolves_to_3050() {
+        Optional<IntercompanyAccountMapping> m = repository.findByDebtorAndIssuer(AS_UUID, TECH_UUID);
+        assertTrue(m.isPresent(), "Technology->A/S mapping must be seeded");
+        assertEquals(3050, m.get().getEconomicsCostAccountNumber());
+    }
+
+    @Test
+    void seeded_cyber_pair_resolves_to_3055() {
+        Optional<IntercompanyAccountMapping> m = repository.findByDebtorAndIssuer(AS_UUID, CYBER_UUID);
+        assertTrue(m.isPresent(), "Cyber->A/S mapping must be seeded");
+        assertEquals(3055, m.get().getEconomicsCostAccountNumber());
+    }
+
+    @Test
+    void exactly_two_rows_are_seeded_on_a_freshly_migrated_db() {
+        // AC8 — on a freshly-migrated DB the migration seeds exactly two rows.
+        assertEquals(2, repository.count());
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/EconomicsAgreementResolverIntercompanyTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/EconomicsAgreementResolverIntercompanyTest.java
@@ -1,0 +1,58 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.economics.IntercompanyAccountMapping;
+import dk.trustworks.intranet.aggregates.invoice.economics.IntercompanyAccountMappingRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Pure Mockito unit test for EconomicsAgreementResolver#intercompanyCostAccount.
+ * No DB / no Quarkus container. The resolver's other @Inject fields
+ * (paymentTermsRepo, vatZoneRepo, em) are left null — this method uses only
+ * intercompanyAccountRepo.
+ */
+@ExtendWith(MockitoExtension.class)
+class EconomicsAgreementResolverIntercompanyTest {
+
+    private static final String DEBTOR = "d8894494-2fb4-4f72-9e05-e6032e6dd691"; // A/S
+    private static final String ISSUER = "44592d3b-2be5-4b29-bfaf-4fafc60b0fa3"; // Technology
+
+    @InjectMocks
+    EconomicsAgreementResolver resolver;
+
+    @Mock
+    IntercompanyAccountMappingRepository intercompanyAccountRepo;
+
+    @Test
+    void returns_mapped_account_when_pair_is_mapped() {
+        IntercompanyAccountMapping m = new IntercompanyAccountMapping();
+        m.setEconomicsCostAccountNumber(3050);
+        when(intercompanyAccountRepo.findByDebtorAndIssuer(DEBTOR, ISSUER))
+                .thenReturn(Optional.of(m));
+
+        assertEquals(Optional.of(3050), resolver.intercompanyCostAccount(DEBTOR, ISSUER));
+    }
+
+    @Test
+    void returns_empty_when_pair_is_unmapped() {
+        when(intercompanyAccountRepo.findByDebtorAndIssuer(DEBTOR, ISSUER))
+                .thenReturn(Optional.empty());
+
+        assertTrue(resolver.intercompanyCostAccount(DEBTOR, ISSUER).isEmpty());
+    }
+
+    @Test
+    void returns_empty_and_skips_repo_when_either_uuid_is_null() {
+        assertTrue(resolver.intercompanyCostAccount(null, ISSUER).isEmpty());
+        assertTrue(resolver.intercompanyCostAccount(DEBTOR, null).isEmpty());
+        verifyNoInteractions(intercompanyAccountRepo);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
@@ -1,0 +1,140 @@
+package dk.trustworks.intranet.expenseservice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.EconomicsSupplierResolver;
+import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
+import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver;
+import dk.trustworks.intranet.expenseservice.remote.dto.economics.Journal;
+import dk.trustworks.intranet.expenseservice.remote.dto.economics.SupplierInvoice;
+import dk.trustworks.intranet.expenseservice.remote.dto.economics.Voucher;
+import dk.trustworks.intranet.financeservice.model.IntegrationKey;
+import dk.trustworks.intranet.model.Company;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Pure Mockito unit test for EconomicsInvoiceService#buildJSONRequest (debtor-side
+ * supplier-invoice branch). No DB / no Quarkus container: the two DateUtils calls
+ * are pure and IntegrationKey.IntegrationKeyValue is a directly-constructable record.
+ * Only agreementResolver + supplierResolver are used by buildJSONRequest; the other
+ * @Inject fields (invoicePdfS3Service, bookingApi) are left null.
+ *
+ * Covers AC1 (3050), AC2 (3055), AC3 (creditor + no contra), AC4 (I25),
+ * AC5 (unmapped fallback keeps today's behaviour), AC7 (manual branch untouched).
+ */
+@ExtendWith(MockitoExtension.class)
+class EconomicsInvoiceServiceVoucherTest {
+
+    private static final String AS_UUID    = "d8894494-2fb4-4f72-9e05-e6032e6dd691"; // debtor A/S
+    private static final String TECH_UUID  = "44592d3b-2be5-4b29-bfaf-4fafc60b0fa3"; // issuer Technology
+    private static final String CYBER_UUID = "e4b0a2a4-0963-4153-b0a2-a409637153a2"; // issuer Cyber
+    private static final String TECH_CVR   = "39913708";
+    private static final int INTERNAL_JOURNAL = 77;
+    private static final int INVOICE_ACCOUNT  = 2101; // debtor invoice-account-number (fallback / contra)
+
+    @InjectMocks
+    EconomicsInvoiceService service;
+
+    @Mock EconomicsAgreementResolver agreementResolver;
+    @Mock EconomicsSupplierResolver supplierResolver;
+
+    // Canonical record order: (url, appSecretToken, agreementGrantToken,
+    // expenseJournalNumber, invoiceJournalNumber, invoiceAccountNumber,
+    // internalJournalNumber, invoiceProductNumber)
+    private IntegrationKey.IntegrationKeyValue keys() {
+        return new IntegrationKey.IntegrationKeyValue(
+                "https://restapi.e-conomic.com", "APP", "GRANT",
+                10, 20, INVOICE_ACCOUNT, INTERNAL_JOURNAL, 1);
+    }
+
+    private Company debtorAS() {
+        Company c = new Company();
+        c.setUuid(AS_UUID);
+        c.setName("Trustworks A/S");
+        return c;
+    }
+
+    private Invoice internalInvoice(String issuerUuid, String issuerCvr) {
+        Invoice inv = new Invoice();
+        inv.setUuid("inv-001");
+        inv.setInvoicenumber(91001);
+        inv.setInvoicedate(LocalDate.of(2026, 4, 15));
+        inv.setGrandTotal(50_000.0);
+        Company issuer = new Company();
+        issuer.setUuid(issuerUuid);
+        issuer.setCvr(issuerCvr);
+        issuer.setName("Issuer ApS");
+        inv.setCompany(issuer);
+        return inv;
+    }
+
+    @Test
+    void technology_to_AS_books_cost_on_3050_with_no_contra_account() {
+        Invoice inv = internalInvoice(TECH_UUID, TECH_CVR);
+        Journal journal = new Journal(INTERNAL_JOURNAL); // == internalJournalNumber -> supplier branch
+        when(agreementResolver.intercompanyCostAccount(AS_UUID, TECH_UUID)).thenReturn(Optional.of(3050));
+        when(supplierResolver.resolveByCvr(AS_UUID, TECH_CVR)).thenReturn(Optional.of(700));
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "Client, Faktura 91001", keys(), debtorAS());
+
+        SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
+        assertEquals(3050, si.getAccount().getAccountNumber());        // AC1
+        assertNull(si.getContraAccount());                            // AC3 — no contra
+        assertNotNull(si.getSupplier());                              // AC3 — creditor present
+        assertEquals(700, si.getSupplier().supplierNumber);
+        assertEquals("I25", si.getContraVatAccount().vatCode);        // AC4
+        assertNull(voucher.getEntries().getManualCustomerInvoices()); // supplier branch only
+    }
+
+    @Test
+    void cyber_to_AS_books_cost_on_3055() {
+        Invoice inv = internalInvoice(CYBER_UUID, "12345678");
+        Journal journal = new Journal(INTERNAL_JOURNAL);
+        when(agreementResolver.intercompanyCostAccount(AS_UUID, CYBER_UUID)).thenReturn(Optional.of(3055));
+        when(supplierResolver.resolveByCvr(AS_UUID, "12345678")).thenReturn(Optional.of(701));
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "txt", keys(), debtorAS());
+
+        SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
+        assertEquals(3055, si.getAccount().getAccountNumber());        // AC2
+        assertNull(si.getContraAccount());
+    }
+
+    @Test
+    void unmapped_pair_keeps_todays_behaviour_account_and_contra_both_2101() {
+        Invoice inv = internalInvoice(TECH_UUID, TECH_CVR);
+        Journal journal = new Journal(INTERNAL_JOURNAL);
+        when(agreementResolver.intercompanyCostAccount(AS_UUID, TECH_UUID)).thenReturn(Optional.empty()); // unmapped
+        when(supplierResolver.resolveByCvr(AS_UUID, TECH_CVR)).thenReturn(Optional.empty());
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "txt", keys(), debtorAS());
+
+        SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
+        assertEquals(INVOICE_ACCOUNT, si.getAccount().getAccountNumber());            // AC5 — fallback 2101
+        assertNotNull(si.getContraAccount());                                        // today's behaviour kept
+        assertEquals(INVOICE_ACCOUNT, si.getContraAccount().getAccountNumber());      // contra still 2101
+    }
+
+    @Test
+    void regular_journal_still_builds_manual_customer_invoice_unchanged() {
+        Invoice inv = internalInvoice(TECH_UUID, TECH_CVR);
+        Journal journal = new Journal(20); // != internalJournalNumber(77) -> manual branch
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "txt", keys(), debtorAS());
+
+        assertNull(voucher.getEntries().getSupplierInvoices());          // AC7 — not the supplier path
+        assertNotNull(voucher.getEntries().getManualCustomerInvoices()); // manual branch produced
+        assertEquals(1, voucher.getEntries().getManualCustomerInvoices().size());
+        // The manual branch is untouched: the issuer-aware resolver is never consulted.
+        verifyNoInteractions(agreementResolver);
+        verifyNoInteractions(supplierResolver);
+    }
+}


### PR DESCRIPTION
## Summary
- When Trustworks Technology / Cyber book an **INTERNAL** invoice to Trustworks A/S, the debtor-side e-conomic `SupplierInvoice` voucher now books the cost on the issuer-specific account (**Technology → 3050**, **Cyber → 3055**) instead of the debtor's own `invoice-account-number` (2101), and **omits the contra account** so the sender posts correctly as a creditor (kreditor) with I25 input VAT.
- New configurable mapping: `intercompany_account_mapping` table (Flyway **V375**) + `IntercompanyAccountMapping` entity + `IntercompanyAccountMappingRepository`, resolved via new `EconomicsAgreementResolver.intercompanyCostAccount(debtorUuid, issuerUuid)`.
- **Unmapped** `(debtor, issuer)` pairs keep today's behaviour **exactly** (account + contra both = `invoice-account-number`) and log a warning — only the two seeded pairs change. The fix lives in the single shared `buildJSONRequest`, so it covers both the initial debtor post and the `PARTIALLY_UPLOADED` retry.
- Spec: `docs/superpowers/specs/2026-06-15-internal-invoice-debtor-cost-account-mapping-design.md`. Docs updated: `invoicing/external-integrations.md` §1.3, `infrastructure/economics-config.md`.

## Changed files (8)
- `db/migration/V375__Intercompany_account_mapping.sql` (new — table + 2 seed rows)
- `aggregates/invoice/economics/IntercompanyAccountMapping.java` (new entity)
- `aggregates/invoice/economics/IntercompanyAccountMappingRepository.java` (new repo)
- `aggregates/invoice/services/EconomicsAgreementResolver.java` (+`intercompanyCostAccount`)
- `expenseservice/services/EconomicsInvoiceService.java` (supplier-branch fix + 2 comment fixes)
- 3 test files (resolver, voucher builder — pure Mockito; repository — `@QuarkusTest`, DB-gated)

## Test Plan
- [x] `mvn clean test-compile` — clean (exit 0)
- [x] `mvn test -Dtest=EconomicsAgreementResolverIntercompanyTest,EconomicsInvoiceServiceVoucherTest` — **7/7 pass** (3050/3055/no-contra/I25, unmapped fallback, manual branch untouched)
- [ ] `IntercompanyAccountMappingRepositoryTest` (`@QuarkusTest`, AC8) — DB-gated, **deferred in CI** (no DB on the runner); run locally against a migrated dev DB
- [ ] **MANDATORY staging e-conomic verification (gate before prod):** post a real Technology→A/S and a Cyber→A/S internal invoice in staging; in A/S's e-conomic confirm the voucher books **debit 3050/3055 (net)**, **I25 input VAT**, **credit the sender as kreditor (gross)**, balanced with no contra. Confirm the retry path uses the same mapped account.

## Notes / caveats
- **Security:** no new endpoint or external input; repository uses a parameterized Panache query; the new warn log emits only company UUIDs + an account number (no secrets); no new dependencies. (0 Critical / 0 High.)
- **Staging sequencing:** until V375 reaches prod, the nightly prod→staging refresh drops the staging `intercompany_account_mapping` table — run the e-conomic verification the same day as the staging deploy, or re-seed.
- **Known follow-up (non-blocking):** a *mapped* pair whose issuer is not found as a kreditor (CVR lookup empty) would produce a debit-only voucher that e-conomic rejects (fails closed → `PARTIALLY_UPLOADED`). Both seeded issuers are confirmed kreditorer; harden (refuse to post with no resolved supplier) when a 3rd, unverified mapping is added. See spec §11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)