### PR TITLE
fix(invoicing): internal settlement invoices lift VAT from net (vat=0)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceService.java
@@ -1391,7 +1391,11 @@ public class InvoiceService {
                 description,
                 debtorCompanyUuid);
         internal.setBillingClientUuid(intercompanyClient.getUuid());
-        internal.setVat(source.getVat());
+        // The PHANTOM source carries vat=0 (it stores the gross figure as a single sumNoTax line),
+        // so its rate must NOT be copied onto this INTERNAL invoice, whose items are net deltas.
+        // Set the rate from the currency like the INTERNAL_SERVICE path (DKK = 25%) so grandTotal
+        // becomes the VAT-inclusive gross and the debtor-side e-conomic voucher lifts VAT correctly.
+        internal.setVat("DKK".equals(source.getCurrency()) ? 25.0 : 0.0);
 
         // Stamp the settlement-group key so the group can find this document.
         internal.setSettlementBillingClientUuid(settlementClientUuid);

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -41,6 +41,12 @@ public class EconomicsInvoiceService {
      *  intercompany cost account (e.g. 3050/3055) on INTERNAL invoices. */
     private static final String INTERCOMPANY_VAT_CODE = "I25";
 
+    /** VAT rate (percent) that {@link #INTERCOMPANY_VAT_CODE} lifts out. e-conomic treats a
+     *  VAT-coded supplier-invoice amount as the VAT-inclusive gross, so the posted amount is only
+     *  correct when the invoice carries this rate (grandTotal = net × 1.25). See the guard in
+     *  {@link #buildJSONRequest}. */
+    private static final double INTERCOMPANY_VAT_RATE = 25.0;
+
     @Inject
     InvoicePdfS3Service invoicePdfS3Service;
 
@@ -195,6 +201,23 @@ public class EconomicsInvoiceService {
                     targetCompany.getUuid(), issuerCvr);
             if (resolvedSupplier.isPresent()) {
                 supplierInvoice.setSupplier(new Supplier(resolvedSupplier.get()));
+                // Guard: e-conomic treats a VAT-coded supplier-invoice amount as the VAT-inclusive
+                // GROSS and lifts the VAT out of it. That is only correct when the posted amount
+                // (grandTotal) carries the matching 25% rate. A net amount (vat=0) tagged with I25
+                // makes e-conomic lift VAT out of the net — the 2026-06 intercompany mis-posting.
+                // Fail closed rather than mis-state VAT; the invoice's VAT rate must be corrected.
+                double vatRate = invoice.getVat();
+                if (Math.abs(vatRate - INTERCOMPANY_VAT_RATE) > 0.01) {
+                    String msg = String.format(
+                            "Refusing to post INTERNAL invoice %s to debtor %s with VAT code %s: invoice VAT "
+                                    + "rate is %.2f%%, not %.0f%%, so the posted amount is not the VAT-inclusive "
+                                    + "gross and e-conomic would lift VAT out of a net amount. Correct the invoice "
+                                    + "VAT rate and retry.",
+                            invoice.getUuid(), targetCompany.getName(), INTERCOMPANY_VAT_CODE,
+                            vatRate, INTERCOMPANY_VAT_RATE);
+                    log.error(msg);
+                    throw new IllegalStateException(msg);
+                }
                 supplierInvoice.setContraVatAccount(new VatAccount(INTERCOMPANY_VAT_CODE));
                 log.infof("Enriched SupplierInvoice for invoice %s with supplier %d and vatCode %s",
                         invoice.getUuid(), resolvedSupplier.get(), INTERCOMPANY_VAT_CODE);

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceTest.java
@@ -147,6 +147,7 @@ class EconomicsInvoiceServiceTest {
         inv.setInvoicenumber(20240315);
         inv.setClientname("Trustworks A/S");
         inv.setGrandTotal(12500.00);
+        inv.setVat(25.0); // DKK intercompany invoice — required for the I25 enrichment guard
         inv.setInvoicedate(java.time.LocalDate.of(2025, 2, 14));
 
         Company issuer = new Company();

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
@@ -68,6 +68,7 @@ class EconomicsInvoiceServiceVoucherTest {
         inv.setInvoicenumber(91001);
         inv.setInvoicedate(LocalDate.of(2026, 4, 15));
         inv.setGrandTotal(50_000.0);
+        inv.setVat(25.0); // DKK intercompany invoices carry 25% — grandTotal is the VAT-inclusive gross
         Company issuer = new Company();
         issuer.setUuid(issuerUuid);
         issuer.setCvr(issuerCvr);
@@ -106,6 +107,23 @@ class EconomicsInvoiceServiceVoucherTest {
         SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
         assertEquals(3055, si.getAccount().getAccountNumber());        // AC2
         assertNull(si.getContraAccount());
+    }
+
+    @Test
+    void mapped_pair_with_non_25_vat_rate_is_refused_to_avoid_lifting_vat_from_net() {
+        // Guard: the invoice carries vat=0 (its grandTotal is the NET, not the gross), yet the
+        // supplier resolves so I25 would be applied. e-conomic would then lift VAT out of the net.
+        // The voucher build must fail closed rather than mis-state VAT.
+        Invoice inv = internalInvoice(TECH_UUID, TECH_CVR);
+        inv.setVat(0.0);
+        Journal journal = new Journal(INTERNAL_JOURNAL);
+        when(agreementResolver.intercompanyCostAccount(AS_UUID, TECH_UUID)).thenReturn(Optional.of(3050));
+        when(supplierResolver.resolveByCvr(AS_UUID, TECH_CVR)).thenReturn(Optional.of(700));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> service.buildJSONRequest(inv, journal, "txt", keys(), debtorAS()));
+        assertTrue(ex.getMessage().contains("VAT rate"),
+                "guard message should explain the VAT-rate mismatch, was: " + ex.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Problem
Self-billed settlement INTERNAL invoices (Trustworks Technology/Cyber → A/S, created after the self-billed workbench went live 2026-06-10) booked the debtor-side e-conomic voucher with **VAT lifted out of the ex-VAT (net) amount** — e.g. Faktura 70-349: posted 195.500 with I25, e-conomic lifted `195.500 × 25/125 = 39.100`, booking expense 156.400 + VAT 39.100 instead of expense 195.500 + VAT 48.875 on a gross of 244.375.

## Root cause
These invoices carry **`vat = 0.0`** while every other internal invoice carries `vat = 25.0` (verified on prod: only the 5 flagged invoices are `vat=0` BOOKED; ~250 others are `vat=25` and post correctly). `grandTotal = net × (1 + vat/100)`, so `vat=0` collapses `grandTotal` to the **net**. The debtor voucher posts `amount = grandTotal` tagged with the **I25** purchase-VAT code, and e-conomic treats that amount as the VAT-inclusive **gross** and lifts 25% out of it — so VAT is pulled out of a net figure.

`InvoiceService.createSettlementInternal` copied `vat` from its PHANTOM source, which is intentionally `vat=0` (the e-conomic import stores the gross figure as a single `sumNoTax` line). Copied onto a settlement invoice whose line items are *net* deltas, that rate is wrong.

## Fix
- **Fix A (root cause)** — `createSettlementInternal` sets the VAT rate from the currency (`"DKK" → 25`, else 0), mirroring the existing `INTERNAL_SERVICE` path, instead of copying the source's 0. `grandTotal` then recomputes to the VAT-inclusive gross downstream (`createDraft → recalc → PricingEngine`), so the existing I25 posting is correct — identical to the ~250 working invoices.
- **Fix B (defensive guard)** — `EconomicsInvoiceService.buildJSONRequest` refuses (fail-closed) to apply I25 when the invoice's VAT rate is not 25%, so a net amount can never again be posted with a VAT-lifting code. A mis-rated invoice now fails to `PARTIALLY_UPLOADED` for correction rather than silently mis-stating VAT.

## Test plan
- [x] `mvn test -Dtest=EconomicsInvoiceServiceTest,EconomicsInvoiceServiceVoucherTest,InternalInvoiceOrchestratorTest` → **17/17 pass** (incl. a new guard test asserting `vat=0` is refused; existing voucher + supplier-enrichment tests updated to the realistic `vat=25`)
- [x] `mvn clean test-compile` clean
- [ ] `createSettlementInternal` is `@QuarkusTest`-only (DB-gated, deferred in CI). Verified by Fix B's CI guard test (enforces the 25% invariant at the posting boundary, so a Fix-A regression fails closed) + the staging e-conomic gate below.
- [ ] **Staging e-conomic gate:** finalize a real Tech→A/S and Cyber→A/S settlement; confirm the debtor voucher books **gross** (net × 1.25), I25 lifts the correct 25% VAT, expense lands at net, sender credited gross as kreditor.

## Coordination / notes
- **Stacked on #114** (base = `feature/intercompany-cost-account`) because Fix B touches the same `buildJSONRequest` method #114 changed. Merge #114 first (or together); GitHub retargets this to `staging` once #114 lands.
- **Not caused by #114** — pre-existing; the I25 stamping (commit `7fe15425`, 2026-05-11) + the `vat=0` data jointly cause it.
- **Already-booked vouchers** are being corrected in e-conomic by the accountant (out of scope here).
- **Heads-up — 1 unbooked `vat=0` invoice** (TECH, status NA) remains; the new guard will refuse to post it until its VAT rate is corrected (intended fail-closed behaviour).
- **Product question for finance:** a *legitimately* zero-rated EU reverse-charge intercompany invoice (`vat=0`) would also be refused by the guard. Not reachable today (all live intercompany is DKK), but worth confirming the intended treatment if cross-border intercompany is ever added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)