### PR TITLE
Promote to production: internal-invoice cost-account + VAT fixes (staging→master)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/IntercompanyAccountMapping.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/IntercompanyAccountMapping.java
@@ -1,0 +1,43 @@
+package dk.trustworks.intranet.aggregates.invoice.economics;
+
+import dk.trustworks.intranet.model.Company;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Maps a (debtor company x issuer company) pair to the e-conomic cost account in
+ * the DEBTOR's chart of accounts for an inter-company purchase (the debtor-side
+ * SupplierInvoice voucher). E.g. debtor A/S + issuer Technology -> 3050,
+ * debtor A/S + issuer Cyber -> 3055.
+ *
+ * Spec: 2026-06-15-internal-invoice-debtor-cost-account-mapping-design.md §4.2.
+ */
+@Getter
+@Setter
+@Entity
+@Table(name = "intercompany_account_mapping")
+public class IntercompanyAccountMapping extends PanacheEntityBase {
+
+    @Id
+    private String uuid;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "debtor_company_uuid", nullable = false)
+    private Company debtorCompany;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "issuer_company_uuid", nullable = false)
+    private Company issuerCompany;
+
+    @NotNull
+    @Column(name = "economics_cost_account_number", nullable = false)
+    private Integer economicsCostAccountNumber;
+
+    @Column(name = "economics_cost_account_name", length = 100)
+    private String economicsCostAccountName;
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/IntercompanyAccountMappingRepository.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/IntercompanyAccountMappingRepository.java
@@ -1,0 +1,23 @@
+package dk.trustworks.intranet.aggregates.invoice.economics;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Optional;
+
+/**
+ * Panache repository for IntercompanyAccountMapping. Lookups are by the
+ * (debtor, issuer) company pair, which is unique (see V375 UNIQUE KEY).
+ */
+@ApplicationScoped
+public class IntercompanyAccountMappingRepository
+        implements PanacheRepositoryBase<IntercompanyAccountMapping, String> {
+
+    public Optional<IntercompanyAccountMapping> findByDebtorAndIssuer(
+            String debtorCompanyUuid, String issuerCompanyUuid) {
+        if (debtorCompanyUuid == null) throw new IllegalArgumentException("debtorCompanyUuid is required");
+        if (issuerCompanyUuid == null) throw new IllegalArgumentException("issuerCompanyUuid is required");
+        return find("debtorCompany.uuid = ?1 and issuerCompany.uuid = ?2",
+                debtorCompanyUuid, issuerCompanyUuid).firstResultOptional();
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/EconomicsAgreementResolver.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/EconomicsAgreementResolver.java
@@ -1,5 +1,7 @@
 package dk.trustworks.intranet.aggregates.invoice.services;
 
+import dk.trustworks.intranet.aggregates.invoice.economics.IntercompanyAccountMapping;
+import dk.trustworks.intranet.aggregates.invoice.economics.IntercompanyAccountMappingRepository;
 import dk.trustworks.intranet.aggregates.invoice.economics.PaymentTermsMapping;
 import dk.trustworks.intranet.aggregates.invoice.economics.PaymentTermsMappingRepository;
 import dk.trustworks.intranet.aggregates.invoice.economics.VatZoneMapping;
@@ -13,6 +15,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.ws.rs.BadRequestException;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 /**
  * Thin wrapper that resolves e-conomic agreement-level configuration for a given
@@ -31,6 +34,9 @@ public class EconomicsAgreementResolver {
 
     @Inject
     VatZoneMappingRepository vatZoneRepo;
+
+    @Inject
+    IntercompanyAccountMappingRepository intercompanyAccountRepo;
 
     @Inject
     EntityManager em;
@@ -169,6 +175,22 @@ public class EconomicsAgreementResolver {
         }
         IntegrationKey.IntegrationKeyValue kv = IntegrationKey.getIntegrationKeyValue(company);
         return kv.internalJournalNumber();
+    }
+
+    /**
+     * Cost account in the DEBTOR's chart of accounts for an inter-company purchase
+     * from the ISSUER (e.g. debtor A/S + issuer Technology = 3050, Cyber = 3055).
+     *
+     * <p>Returns {@link Optional#empty()} when the (debtor, issuer) pair is not
+     * mapped — or when either UUID is null — so the caller can fall back gracefully
+     * without an exception (see EconomicsInvoiceService.buildJSONRequest).
+     */
+    public Optional<Integer> intercompanyCostAccount(String debtorCompanyUuid, String issuerCompanyUuid) {
+        if (debtorCompanyUuid == null || issuerCompanyUuid == null) {
+            return Optional.empty();
+        }
+        return intercompanyAccountRepo.findByDebtorAndIssuer(debtorCompanyUuid, issuerCompanyUuid)
+                .map(IntercompanyAccountMapping::getEconomicsCostAccountNumber);
     }
 
     /**

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceService.java
@@ -1391,7 +1391,11 @@ public class InvoiceService {
                 description,
                 debtorCompanyUuid);
         internal.setBillingClientUuid(intercompanyClient.getUuid());
-        internal.setVat(source.getVat());
+        // The PHANTOM source carries vat=0 (it stores the gross figure as a single sumNoTax line),
+        // so its rate must NOT be copied onto this INTERNAL invoice, whose items are net deltas.
+        // Set the rate from the currency like the INTERNAL_SERVICE path (DKK = 25%) so grandTotal
+        // becomes the VAT-inclusive gross and the debtor-side e-conomic voucher lifts VAT correctly.
+        internal.setVat("DKK".equals(source.getCurrency()) ? 25.0 : 0.0);
 
         // Stamp the settlement-group key so the group can find this document.
         internal.setSettlementBillingClientUuid(settlementClientUuid);

--- a/src/main/java/dk/trustworks/intranet/exceptions/DatabaseConstraintViolationExceptionMapper.java
+++ b/src/main/java/dk/trustworks/intranet/exceptions/DatabaseConstraintViolationExceptionMapper.java
@@ -1,11 +1,14 @@
 package dk.trustworks.intranet.exceptions;
 
+import jakarta.persistence.PersistenceException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import lombok.extern.jbosslog.JBossLog;
 import org.hibernate.exception.ConstraintViolationException;
+
+import java.sql.SQLIntegrityConstraintViolationException;
 
 /**
  * Maps a database-level integrity-constraint violation (e.g. a duplicate unique key such as
@@ -17,25 +20,55 @@ import org.hibernate.exception.ConstraintViolationException;
  * Validation, mapped to 400 by {@link ConstraintViolationExceptionMapper}). Without this mapper
  * such failures fall through to {@link GenericExceptionMapper} and surface as 500.
  * <p>
- * The constraint name and SQL state are logged server-side; the client gets a clean, generic
- * message that does not leak schema details.
+ * Quarkus/Hibernate may throw the Hibernate exception directly or wrap it inside a
+ * {@link PersistenceException}; this mapper handles both shapes. The constraint name and SQL state
+ * are logged server-side; the client gets a clean, generic message that does not leak schema details.
  */
 @Provider
 @JBossLog
-public class DatabaseConstraintViolationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
+public class DatabaseConstraintViolationExceptionMapper implements ExceptionMapper<PersistenceException> {
 
     static final String MESSAGE =
             "The request conflicts with existing data — a database uniqueness constraint was violated "
                     + "(a matching record may already exist).";
 
     @Override
-    public Response toResponse(ConstraintViolationException exception) {
-        String sqlState = exception.getSQLException() != null ? exception.getSQLException().getSQLState() : "?";
-        log.warnf("DB constraint violation → 409: constraint=%s sqlState=%s — %s",
-                exception.getConstraintName(), sqlState, exception.getMessage());
+    public Response toResponse(PersistenceException exception) {
+        ConstraintViolationException constraintViolation = findCause(exception, ConstraintViolationException.class);
+        SQLIntegrityConstraintViolationException sqlIntegrity = findCause(exception, SQLIntegrityConstraintViolationException.class);
+
+        if (constraintViolation == null && sqlIntegrity == null) {
+            log.error("Unhandled persistence exception in REST resource", exception);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(new ErrorResponse("Internal server error", 500))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
+        }
+
+        String constraintName = constraintViolation != null ? constraintViolation.getConstraintName() : "?";
+        String sqlState = "?";
+        if (constraintViolation != null && constraintViolation.getSQLException() != null) {
+            sqlState = constraintViolation.getSQLException().getSQLState();
+        } else if (sqlIntegrity != null) {
+            sqlState = sqlIntegrity.getSQLState();
+        }
+
+        log.warnf("DB constraint violation -> 409: constraint=%s sqlState=%s - %s",
+                constraintName, sqlState, exception.getMessage());
         return Response.status(Response.Status.CONFLICT)
                 .entity(new ErrorResponse(MESSAGE, Response.Status.CONFLICT.getStatusCode()))
                 .type(MediaType.APPLICATION_JSON)
                 .build();
+    }
+
+    private static <T extends Throwable> T findCause(Throwable throwable, Class<T> type) {
+        Throwable current = throwable;
+        for (int depth = 0; current != null && depth < 8; depth++) {
+            if (type.isInstance(current)) {
+                return type.cast(current);
+            }
+            current = current.getCause();
+        }
+        return null;
     }
 }

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -41,6 +41,12 @@ public class EconomicsInvoiceService {
      *  intercompany cost account (e.g. 3050/3055) on INTERNAL invoices. */
     private static final String INTERCOMPANY_VAT_CODE = "I25";
 
+    /** VAT rate (percent) that {@link #INTERCOMPANY_VAT_CODE} lifts out. e-conomic treats a
+     *  VAT-coded supplier-invoice amount as the VAT-inclusive gross, so the posted amount is only
+     *  correct when the invoice carries this rate (grandTotal = net × 1.25). See the guard in
+     *  {@link #buildJSONRequest}. */
+    private static final double INTERCOMPANY_VAT_RATE = 25.0;
+
     @Inject
     InvoicePdfS3Service invoicePdfS3Service;
 
@@ -195,6 +201,23 @@ public class EconomicsInvoiceService {
                     targetCompany.getUuid(), issuerCvr);
             if (resolvedSupplier.isPresent()) {
                 supplierInvoice.setSupplier(new Supplier(resolvedSupplier.get()));
+                // Guard: e-conomic treats a VAT-coded supplier-invoice amount as the VAT-inclusive
+                // GROSS and lifts the VAT out of it. That is only correct when the posted amount
+                // (grandTotal) carries the matching 25% rate. A net amount (vat=0) tagged with I25
+                // makes e-conomic lift VAT out of the net — the 2026-06 intercompany mis-posting.
+                // Fail closed rather than mis-state VAT; the invoice's VAT rate must be corrected.
+                double vatRate = invoice.getVat();
+                if (Math.abs(vatRate - INTERCOMPANY_VAT_RATE) > 0.01) {
+                    String msg = String.format(
+                            "Refusing to post INTERNAL invoice %s to debtor %s with VAT code %s: invoice VAT "
+                                    + "rate is %.2f%%, not %.0f%%, so the posted amount is not the VAT-inclusive "
+                                    + "gross and e-conomic would lift VAT out of a net amount. Correct the invoice "
+                                    + "VAT rate and retry.",
+                            invoice.getUuid(), targetCompany.getName(), INTERCOMPANY_VAT_CODE,
+                            vatRate, INTERCOMPANY_VAT_RATE);
+                    log.error(msg);
+                    throw new IllegalStateException(msg);
+                }
                 supplierInvoice.setContraVatAccount(new VatAccount(INTERCOMPANY_VAT_CODE));
                 log.infof("Enriched SupplierInvoice for invoice %s with supplier %d and vatCode %s",
                         invoice.getUuid(), resolvedSupplier.get(), INTERCOMPANY_VAT_CODE);

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -37,7 +37,8 @@ import java.util.Optional;
 @ApplicationScoped
 public class EconomicsInvoiceService {
 
-    /** Hardcoded Danish 25% purchase VAT code applied to account 2101 on INTERNAL invoices. */
+    /** Hardcoded Danish 25% purchase (input) VAT code (I25), applied to the issuer-aware
+     *  intercompany cost account (e.g. 3050/3055) on INTERNAL invoices. */
     private static final String INTERCOMPANY_VAT_CODE = "I25";
 
     @Inject
@@ -156,12 +157,37 @@ public class EconomicsInvoiceService {
         // Check if this is an internal journal (supplier invoice) or regular journal (customer invoice)
         if (journal.getJournalNumber() == integrationKeyValue.internalJournalNumber()) {
             log.info("Creating supplier invoice for number " + invoice.getInvoicenumber());
+
+            // Resolve the issuer-aware intercompany cost account in the DEBTOR's chart of accounts.
+            // issuer = invoice.getCompany(); debtor = targetCompany. When the pair is mapped
+            // (e.g. Technology -> A/S = 3050, Cyber -> A/S = 3055) the cost lands on that account and
+            // NO contra account is set: the CVR-resolved supplier (kreditor) drives the AP credit.
+            // When the pair is unmapped, keep today's behaviour EXACTLY (invoice-account-number for
+            // both the cost account and the contra account) so out-of-scope intercompany flows are
+            // untouched. See spec 2026-06-15-internal-invoice-debtor-cost-account-mapping-design.md §4.5.
+            String issuerCompanyUuid = invoice.getCompany() != null ? invoice.getCompany().getUuid() : null;
+            Optional<Integer> mappedCostAccount =
+                    agreementResolver.intercompanyCostAccount(targetCompany.getUuid(), issuerCompanyUuid);
+
+            ExpenseAccount supplierAccount;
+            ContraAccount supplierContraAccount;
+            if (mappedCostAccount.isPresent()) {
+                supplierAccount = new ExpenseAccount(mappedCostAccount.get());
+                supplierContraAccount = null;
+            } else {
+                log.warnf("No intercompany cost-account mapping for debtor %s / issuer %s — "
+                                + "falling back to invoice-account-number %d",
+                        targetCompany.getUuid(), issuerCompanyUuid, integrationKeyValue.invoiceAccountNumber());
+                supplierAccount = account;
+                supplierContraAccount = contraAccount;
+            }
+
             SupplierInvoice supplierInvoice = new SupplierInvoice(
-                    account,
+                    supplierAccount,
                     StringUtils.convertInvoiceNumberToString(invoice.getInvoicenumber()),
                     text,
                     invoice.getGrandTotal() != null ? invoice.getGrandTotal() : 0.0,
-                    contraAccount,
+                    supplierContraAccount,
                     date);
 
             String issuerCvr = invoice.getCompany() != null ? invoice.getCompany().getCvr() : null;
@@ -182,7 +208,7 @@ public class EconomicsInvoiceService {
 
             log.debugf("SupplierInvoice text=%s, contraAccount=%s, supplier=%s, contraVatAccount=%s",
                     supplierInvoice.text,
-                    contraAccount.getAccountNumber(),
+                    supplierInvoice.getContraAccount(),
                     supplierInvoice.getSupplier(),
                     supplierInvoice.getContraVatAccount());
             List<SupplierInvoice> supplierInvoices = new ArrayList<>();

--- a/src/main/resources/db/migration/V375__Intercompany_account_mapping.sql
+++ b/src/main/resources/db/migration/V375__Intercompany_account_mapping.sql
@@ -1,0 +1,34 @@
+-- =============================================================================
+-- Migration V375: intercompany_account_mapping
+-- =============================================================================
+-- Spec: docs/superpowers/specs/2026-06-15-internal-invoice-debtor-cost-account-mapping-design.md
+--
+-- Maps a (debtor company, issuer company) pair to the e-conomic cost account in
+-- the DEBTOR's chart of accounts for an inter-company purchase. Used by the
+-- debtor-side SupplierInvoice voucher so the issuer's cost lands on the correct
+-- account (Technology -> 3050, Cyber -> 3055) instead of the debtor's own
+-- invoice-account-number (2101).
+--
+-- Seeds exactly the two in-scope pairs. Unmapped pairs keep today's behaviour
+-- (the application falls back to invoice-account-number and logs a warning).
+-- UUID provenance: companies.uuid values verified in AgreementDefaultsRegistry
+-- (A/S, Trustworks Technology ApS, Trustworks Cyber Security ApS).
+-- =============================================================================
+
+CREATE TABLE intercompany_account_mapping (
+    uuid                            VARCHAR(36)  NOT NULL,
+    debtor_company_uuid             VARCHAR(36)  NOT NULL,
+    issuer_company_uuid             VARCHAR(36)  NOT NULL,
+    economics_cost_account_number   INT          NOT NULL,
+    economics_cost_account_name     VARCHAR(100) NULL,
+    PRIMARY KEY (uuid),
+    UNIQUE KEY uq_intercompany_account_mapping_debtor_issuer (debtor_company_uuid, issuer_company_uuid),
+    CONSTRAINT fk_intercompany_account_mapping_debtor FOREIGN KEY (debtor_company_uuid) REFERENCES companies(uuid),
+    CONSTRAINT fk_intercompany_account_mapping_issuer FOREIGN KEY (issuer_company_uuid) REFERENCES companies(uuid)
+);
+
+INSERT INTO intercompany_account_mapping
+    (uuid, debtor_company_uuid, issuer_company_uuid, economics_cost_account_number, economics_cost_account_name)
+VALUES
+    (UUID(), 'd8894494-2fb4-4f72-9e05-e6032e6dd691', '44592d3b-2be5-4b29-bfaf-4fafc60b0fa3', 3050, 'Koeb hos Trustworks Technology'),
+    (UUID(), 'd8894494-2fb4-4f72-9e05-e6032e6dd691', 'e4b0a2a4-0963-4153-b0a2-a409637153a2', 3055, 'Koeb hos Trustworks Cyber Security');

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/economics/IntercompanyAccountMappingRepositoryTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/economics/IntercompanyAccountMappingRepositoryTest.java
@@ -1,0 +1,48 @@
+package dk.trustworks.intranet.aggregates.invoice.economics;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * DB-backed test for the seeded intercompany_account_mapping rows (V375) — AC8.
+ *
+ * Requires a database. DEFERRED in CI (the CI runner has no DB); run locally
+ * against a freshly-migrated dev DB with:
+ *   ./mvnw test -Dtest=IntercompanyAccountMappingRepositoryTest
+ * The mandatory staging e-conomic verification is the production gate.
+ */
+@QuarkusTest
+class IntercompanyAccountMappingRepositoryTest {
+
+    private static final String AS_UUID    = "d8894494-2fb4-4f72-9e05-e6032e6dd691";
+    private static final String TECH_UUID  = "44592d3b-2be5-4b29-bfaf-4fafc60b0fa3";
+    private static final String CYBER_UUID = "e4b0a2a4-0963-4153-b0a2-a409637153a2";
+
+    @Inject
+    IntercompanyAccountMappingRepository repository;
+
+    @Test
+    void seeded_technology_pair_resolves_to_3050() {
+        Optional<IntercompanyAccountMapping> m = repository.findByDebtorAndIssuer(AS_UUID, TECH_UUID);
+        assertTrue(m.isPresent(), "Technology->A/S mapping must be seeded");
+        assertEquals(3050, m.get().getEconomicsCostAccountNumber());
+    }
+
+    @Test
+    void seeded_cyber_pair_resolves_to_3055() {
+        Optional<IntercompanyAccountMapping> m = repository.findByDebtorAndIssuer(AS_UUID, CYBER_UUID);
+        assertTrue(m.isPresent(), "Cyber->A/S mapping must be seeded");
+        assertEquals(3055, m.get().getEconomicsCostAccountNumber());
+    }
+
+    @Test
+    void exactly_two_rows_are_seeded_on_a_freshly_migrated_db() {
+        // AC8 — on a freshly-migrated DB the migration seeds exactly two rows.
+        assertEquals(2, repository.count());
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/EconomicsAgreementResolverIntercompanyTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/EconomicsAgreementResolverIntercompanyTest.java
@@ -1,0 +1,58 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.economics.IntercompanyAccountMapping;
+import dk.trustworks.intranet.aggregates.invoice.economics.IntercompanyAccountMappingRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Pure Mockito unit test for EconomicsAgreementResolver#intercompanyCostAccount.
+ * No DB / no Quarkus container. The resolver's other @Inject fields
+ * (paymentTermsRepo, vatZoneRepo, em) are left null — this method uses only
+ * intercompanyAccountRepo.
+ */
+@ExtendWith(MockitoExtension.class)
+class EconomicsAgreementResolverIntercompanyTest {
+
+    private static final String DEBTOR = "d8894494-2fb4-4f72-9e05-e6032e6dd691"; // A/S
+    private static final String ISSUER = "44592d3b-2be5-4b29-bfaf-4fafc60b0fa3"; // Technology
+
+    @InjectMocks
+    EconomicsAgreementResolver resolver;
+
+    @Mock
+    IntercompanyAccountMappingRepository intercompanyAccountRepo;
+
+    @Test
+    void returns_mapped_account_when_pair_is_mapped() {
+        IntercompanyAccountMapping m = new IntercompanyAccountMapping();
+        m.setEconomicsCostAccountNumber(3050);
+        when(intercompanyAccountRepo.findByDebtorAndIssuer(DEBTOR, ISSUER))
+                .thenReturn(Optional.of(m));
+
+        assertEquals(Optional.of(3050), resolver.intercompanyCostAccount(DEBTOR, ISSUER));
+    }
+
+    @Test
+    void returns_empty_when_pair_is_unmapped() {
+        when(intercompanyAccountRepo.findByDebtorAndIssuer(DEBTOR, ISSUER))
+                .thenReturn(Optional.empty());
+
+        assertTrue(resolver.intercompanyCostAccount(DEBTOR, ISSUER).isEmpty());
+    }
+
+    @Test
+    void returns_empty_and_skips_repo_when_either_uuid_is_null() {
+        assertTrue(resolver.intercompanyCostAccount(null, ISSUER).isEmpty());
+        assertTrue(resolver.intercompanyCostAccount(DEBTOR, null).isEmpty());
+        verifyNoInteractions(intercompanyAccountRepo);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/exceptions/DatabaseConstraintViolationExceptionMapperTest.java
+++ b/src/test/java/dk/trustworks/intranet/exceptions/DatabaseConstraintViolationExceptionMapperTest.java
@@ -1,5 +1,6 @@
 package dk.trustworks.intranet.exceptions;
 
+import jakarta.persistence.PersistenceException;
 import jakarta.ws.rs.core.Response;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,21 @@ class DatabaseConstraintViolationExceptionMapperTest {
     }
 
     @Test
+    void wrappedDuplicateKeyConstraintViolationMapsTo409() {
+        ConstraintViolationException constraint = mock(ConstraintViolationException.class);
+        when(constraint.getConstraintName()).thenReturn("uq_userstatus_user_date");
+        when(constraint.getSQLException()).thenReturn(
+                new SQLException("Duplicate entry 'u-2026-06-01' for key 'uq_userstatus_user_date'", "23000", 1062));
+        when(constraint.getMessage()).thenReturn("could not execute statement");
+
+        Response r = new DatabaseConstraintViolationExceptionMapper()
+                .toResponse(new PersistenceException("flush failed", constraint));
+
+        assertEquals(Response.Status.CONFLICT.getStatusCode(), r.getStatus(),
+                "Wrapped DB constraint violations must still map to 409");
+    }
+
+    @Test
     void nullSqlExceptionDoesNotNpe() {
         ConstraintViolationException ex = mock(ConstraintViolationException.class);
         when(ex.getSQLException()).thenReturn(null);
@@ -44,5 +60,17 @@ class DatabaseConstraintViolationExceptionMapperTest {
 
         Response r = new DatabaseConstraintViolationExceptionMapper().toResponse(ex);
         assertEquals(409, r.getStatus());
+    }
+
+    @Test
+    void unrelatedPersistenceExceptionKeepsGeneric500Shape() {
+        Response r = new DatabaseConstraintViolationExceptionMapper()
+                .toResponse(new PersistenceException("database unavailable"));
+
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), r.getStatus());
+        assertInstanceOf(ErrorResponse.class, r.getEntity());
+        ErrorResponse body = (ErrorResponse) r.getEntity();
+        assertEquals("Internal server error", body.error());
+        assertEquals(500, body.status());
     }
 }

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceTest.java
@@ -147,6 +147,7 @@ class EconomicsInvoiceServiceTest {
         inv.setInvoicenumber(20240315);
         inv.setClientname("Trustworks A/S");
         inv.setGrandTotal(12500.00);
+        inv.setVat(25.0); // DKK intercompany invoice — required for the I25 enrichment guard
         inv.setInvoicedate(java.time.LocalDate.of(2025, 2, 14));
 
         Company issuer = new Company();

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
@@ -68,6 +68,7 @@ class EconomicsInvoiceServiceVoucherTest {
         inv.setInvoicenumber(91001);
         inv.setInvoicedate(LocalDate.of(2026, 4, 15));
         inv.setGrandTotal(50_000.0);
+        inv.setVat(25.0); // DKK intercompany invoices carry 25% — grandTotal is the VAT-inclusive gross
         Company issuer = new Company();
         issuer.setUuid(issuerUuid);
         issuer.setCvr(issuerCvr);
@@ -106,6 +107,23 @@ class EconomicsInvoiceServiceVoucherTest {
         SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
         assertEquals(3055, si.getAccount().getAccountNumber());        // AC2
         assertNull(si.getContraAccount());
+    }
+
+    @Test
+    void mapped_pair_with_non_25_vat_rate_is_refused_to_avoid_lifting_vat_from_net() {
+        // Guard: the invoice carries vat=0 (its grandTotal is the NET, not the gross), yet the
+        // supplier resolves so I25 would be applied. e-conomic would then lift VAT out of the net.
+        // The voucher build must fail closed rather than mis-state VAT.
+        Invoice inv = internalInvoice(TECH_UUID, TECH_CVR);
+        inv.setVat(0.0);
+        Journal journal = new Journal(INTERNAL_JOURNAL);
+        when(agreementResolver.intercompanyCostAccount(AS_UUID, TECH_UUID)).thenReturn(Optional.of(3050));
+        when(supplierResolver.resolveByCvr(AS_UUID, TECH_CVR)).thenReturn(Optional.of(700));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> service.buildJSONRequest(inv, journal, "txt", keys(), debtorAS()));
+        assertTrue(ex.getMessage().contains("VAT rate"),
+                "guard message should explain the VAT-rate mismatch, was: " + ex.getMessage());
     }
 
     @Test

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
@@ -1,0 +1,140 @@
+package dk.trustworks.intranet.expenseservice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.economics.supplier.EconomicsSupplierResolver;
+import dk.trustworks.intranet.aggregates.invoice.model.Invoice;
+import dk.trustworks.intranet.aggregates.invoice.services.EconomicsAgreementResolver;
+import dk.trustworks.intranet.expenseservice.remote.dto.economics.Journal;
+import dk.trustworks.intranet.expenseservice.remote.dto.economics.SupplierInvoice;
+import dk.trustworks.intranet.expenseservice.remote.dto.economics.Voucher;
+import dk.trustworks.intranet.financeservice.model.IntegrationKey;
+import dk.trustworks.intranet.model.Company;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Pure Mockito unit test for EconomicsInvoiceService#buildJSONRequest (debtor-side
+ * supplier-invoice branch). No DB / no Quarkus container: the two DateUtils calls
+ * are pure and IntegrationKey.IntegrationKeyValue is a directly-constructable record.
+ * Only agreementResolver + supplierResolver are used by buildJSONRequest; the other
+ * @Inject fields (invoicePdfS3Service, bookingApi) are left null.
+ *
+ * Covers AC1 (3050), AC2 (3055), AC3 (creditor + no contra), AC4 (I25),
+ * AC5 (unmapped fallback keeps today's behaviour), AC7 (manual branch untouched).
+ */
+@ExtendWith(MockitoExtension.class)
+class EconomicsInvoiceServiceVoucherTest {
+
+    private static final String AS_UUID    = "d8894494-2fb4-4f72-9e05-e6032e6dd691"; // debtor A/S
+    private static final String TECH_UUID  = "44592d3b-2be5-4b29-bfaf-4fafc60b0fa3"; // issuer Technology
+    private static final String CYBER_UUID = "e4b0a2a4-0963-4153-b0a2-a409637153a2"; // issuer Cyber
+    private static final String TECH_CVR   = "39913708";
+    private static final int INTERNAL_JOURNAL = 77;
+    private static final int INVOICE_ACCOUNT  = 2101; // debtor invoice-account-number (fallback / contra)
+
+    @InjectMocks
+    EconomicsInvoiceService service;
+
+    @Mock EconomicsAgreementResolver agreementResolver;
+    @Mock EconomicsSupplierResolver supplierResolver;
+
+    // Canonical record order: (url, appSecretToken, agreementGrantToken,
+    // expenseJournalNumber, invoiceJournalNumber, invoiceAccountNumber,
+    // internalJournalNumber, invoiceProductNumber)
+    private IntegrationKey.IntegrationKeyValue keys() {
+        return new IntegrationKey.IntegrationKeyValue(
+                "https://restapi.e-conomic.com", "APP", "GRANT",
+                10, 20, INVOICE_ACCOUNT, INTERNAL_JOURNAL, 1);
+    }
+
+    private Company debtorAS() {
+        Company c = new Company();
+        c.setUuid(AS_UUID);
+        c.setName("Trustworks A/S");
+        return c;
+    }
+
+    private Invoice internalInvoice(String issuerUuid, String issuerCvr) {
+        Invoice inv = new Invoice();
+        inv.setUuid("inv-001");
+        inv.setInvoicenumber(91001);
+        inv.setInvoicedate(LocalDate.of(2026, 4, 15));
+        inv.setGrandTotal(50_000.0);
+        Company issuer = new Company();
+        issuer.setUuid(issuerUuid);
+        issuer.setCvr(issuerCvr);
+        issuer.setName("Issuer ApS");
+        inv.setCompany(issuer);
+        return inv;
+    }
+
+    @Test
+    void technology_to_AS_books_cost_on_3050_with_no_contra_account() {
+        Invoice inv = internalInvoice(TECH_UUID, TECH_CVR);
+        Journal journal = new Journal(INTERNAL_JOURNAL); // == internalJournalNumber -> supplier branch
+        when(agreementResolver.intercompanyCostAccount(AS_UUID, TECH_UUID)).thenReturn(Optional.of(3050));
+        when(supplierResolver.resolveByCvr(AS_UUID, TECH_CVR)).thenReturn(Optional.of(700));
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "Client, Faktura 91001", keys(), debtorAS());
+
+        SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
+        assertEquals(3050, si.getAccount().getAccountNumber());        // AC1
+        assertNull(si.getContraAccount());                            // AC3 — no contra
+        assertNotNull(si.getSupplier());                              // AC3 — creditor present
+        assertEquals(700, si.getSupplier().supplierNumber);
+        assertEquals("I25", si.getContraVatAccount().vatCode);        // AC4
+        assertNull(voucher.getEntries().getManualCustomerInvoices()); // supplier branch only
+    }
+
+    @Test
+    void cyber_to_AS_books_cost_on_3055() {
+        Invoice inv = internalInvoice(CYBER_UUID, "12345678");
+        Journal journal = new Journal(INTERNAL_JOURNAL);
+        when(agreementResolver.intercompanyCostAccount(AS_UUID, CYBER_UUID)).thenReturn(Optional.of(3055));
+        when(supplierResolver.resolveByCvr(AS_UUID, "12345678")).thenReturn(Optional.of(701));
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "txt", keys(), debtorAS());
+
+        SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
+        assertEquals(3055, si.getAccount().getAccountNumber());        // AC2
+        assertNull(si.getContraAccount());
+    }
+
+    @Test
+    void unmapped_pair_keeps_todays_behaviour_account_and_contra_both_2101() {
+        Invoice inv = internalInvoice(TECH_UUID, TECH_CVR);
+        Journal journal = new Journal(INTERNAL_JOURNAL);
+        when(agreementResolver.intercompanyCostAccount(AS_UUID, TECH_UUID)).thenReturn(Optional.empty()); // unmapped
+        when(supplierResolver.resolveByCvr(AS_UUID, TECH_CVR)).thenReturn(Optional.empty());
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "txt", keys(), debtorAS());
+
+        SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
+        assertEquals(INVOICE_ACCOUNT, si.getAccount().getAccountNumber());            // AC5 — fallback 2101
+        assertNotNull(si.getContraAccount());                                        // today's behaviour kept
+        assertEquals(INVOICE_ACCOUNT, si.getContraAccount().getAccountNumber());      // contra still 2101
+    }
+
+    @Test
+    void regular_journal_still_builds_manual_customer_invoice_unchanged() {
+        Invoice inv = internalInvoice(TECH_UUID, TECH_CVR);
+        Journal journal = new Journal(20); // != internalJournalNumber(77) -> manual branch
+
+        Voucher voucher = service.buildJSONRequest(inv, journal, "txt", keys(), debtorAS());
+
+        assertNull(voucher.getEntries().getSupplierInvoices());          // AC7 — not the supplier path
+        assertNotNull(voucher.getEntries().getManualCustomerInvoices()); // manual branch produced
+        assertEquals(1, voucher.getEntries().getManualCustomerInvoices().size());
+        // The manual branch is untouched: the issuer-aware resolver is never consulted.
+        verifyNoInteractions(agreementResolver);
+        verifyNoInteractions(supplierResolver);
+    }
+}


### PR DESCRIPTION
Promotes staging → master (production). **Authorized directly by product owner (2026-06-15), explicitly waiving the staging e-conomic verification gate.**

## Included
- **#114** — issuer-aware intercompany cost account (Technology→A/S `3050`, Cyber→A/S `3055`) on the debtor-side voucher; removes the duplicate `2101` contra so the sender posts as a creditor (kreditor). Adds `intercompany_account_mapping` table (Flyway **V375**), entity, repository, resolver.
- **#115** — sets 25% VAT on self-billed settlement invoices (`createSettlementInternal`) + a fail-closed guard in `buildJSONRequest` (refuses to apply I25 when the invoice isn't carrying 25%), fixing VAT being lifted out of the net.
- **302825bf** — "Refactor AutoFixSettingsTab and enhance exception handling" (unrelated, pre-existing on staging; carried along by the staging→master promotion).

## ⚠️ Verification status
The mandatory staging e-conomic verification (confirm the debtor voucher books **debit 3050/3055 net, I25 lifting 25%, sender credited gross as kreditor, balanced without contra**) was **NOT performed** — direct prod promotion authorized by product owner. The contra-less supplier-invoice format is unverified against live e-conomic. **Watch the first prod internal-invoice postings**: a `PARTIALLY_UPLOADED` status would indicate e-conomic rejected the voucher format (the remedy is to set the contra to A/S's kreditor-samlekonto — a one-line change).

V375 migration runs on prod (additive: CREATE TABLE + 2 seed rows). Backend-only; no frontend coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)