### PR TITLE
fix(timeregistration): make POST /weeks idempotent on unique_task collision

### DIFF
--- a/src/main/java/dk/trustworks/intranet/dao/workservice/services/WeekService.java
+++ b/src/main/java/dk/trustworks/intranet/dao/workservice/services/WeekService.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 import java.time.temporal.WeekFields;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 @JBossLog
 @ApplicationScoped
@@ -25,8 +26,37 @@ public class WeekService {
 
     @Transactional
     public Week save(Week week) {
-        week.persist();
+        // POST /weeks is an idempotent "add this task to my week". The unique_task constraint
+        // (taskuuid, useruuid, weeknumber, year) allows a task to appear on a user's week only once.
+        // The frontend mints a fresh uuid on every add and does not dedupe, so double-clicks,
+        // concurrent tabs and add-delete-readd re-submit an already-existing tuple. A blind persist()
+        // then violates unique_task and — because the flush is deferred to commit — surfaces as a 500.
+        // Reconcile to the existing row instead of inserting; the desired end state (task is on the
+        // week) is already satisfied. Sorting/workas are intentionally left untouched here: reorder is
+        // a separate PATCH flow and the add payload omits sorting (defaults to 0), so overwriting them
+        // would clobber the existing order.
+        Optional<Week> existing = findExistingWeek(week);
+        if (existing.isPresent()) {
+            log.infof("save: task already on week (task=%s user=%s week=%d/%d) — returning existing row, no insert",
+                    week.getTaskuuid(), week.getUseruuid(), week.getWeeknumber(), week.getYear());
+            return existing.get();
+        }
+        // persistAndFlush so that a genuine concurrent-insert race (two requests both past the lookup)
+        // surfaces here as a PersistenceException — mapped to a clean 409 by
+        // DatabaseConstraintViolationExceptionMapper — instead of a deferred commit-time 500.
+        week.persistAndFlush();
         return week;
+    }
+
+    /**
+     * Finds an existing week-task row by the {@code unique_task} tuple
+     * (taskuuid, useruuid, weeknumber, year). Package-private seam so the idempotency logic in
+     * {@link #save(Week)} can be unit-tested without a live database.
+     */
+    Optional<Week> findExistingWeek(Week week) {
+        return Week.find("taskuuid = ?1 AND useruuid = ?2 AND weeknumber = ?3 AND year = ?4",
+                week.getTaskuuid(), week.getUseruuid(), week.getWeeknumber(), week.getYear())
+                .firstResultOptional();
     }
 
     @Transactional

--- a/src/test/java/dk/trustworks/intranet/dao/workservice/services/WeekServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/dao/workservice/services/WeekServiceTest.java
@@ -1,0 +1,80 @@
+package dk.trustworks.intranet.dao.workservice.services;
+
+import dk.trustworks.intranet.dao.workservice.model.Week;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Plain unit test (no DB / no @QuarkusTest) for {@link WeekService#save(Week)}.
+ *
+ * <p>Reproduces the production bug where POST /weeks returned HTTP 500 on a {@code unique_task}
+ * (taskuuid, useruuid, weeknumber, year) collision: the frontend mints a fresh uuid on every
+ * "add task to week" and does not dedupe, so a double-click / concurrent tab / add-delete-readd
+ * re-submitted an already-existing tuple, the blind {@code persist()} violated the unique key, and
+ * — because the flush was deferred to commit — it surfaced as a 500 instead of an idempotent success.
+ *
+ * <p>The Panache tuple lookup is isolated behind the {@link WeekService#findExistingWeek(Week)} seam
+ * and the entity persist is stubbed, so the idempotency decision is exercised without a live database.
+ */
+class WeekServiceTest {
+
+    @Test
+    void duplicateTupleIsReconciledToExistingRow_andNothingIsInserted() {
+        // An identical (taskuuid, useruuid, weeknumber, year) already lives on the user's week,
+        // with a meaningful display order set previously via the reorder (PATCH) flow.
+        Week existing = newWeek("existing-uuid", "task-1", "user-1", 25, 2026);
+        existing.setSorting(7);
+
+        // The re-add the frontend sends: a brand-new client uuid, sorting omitted (defaults to 0).
+        Week incoming = spy(newWeek("fresh-client-uuid", "task-1", "user-1", 25, 2026));
+        incoming.setSorting(0);
+
+        WeekService service = spy(new WeekService());
+        doReturn(Optional.of(existing)).when(service).findExistingWeek(any(Week.class));
+
+        Week result = service.save(incoming);
+
+        assertSame(existing, result, "a duplicate save must return the pre-existing row, not insert a new one");
+        assertEquals("existing-uuid", result.getUuid(), "must reconcile to the existing uuid, not the client's fresh uuid");
+        assertEquals(7, existing.getSorting(), "an idempotent re-add must not clobber the existing display order");
+        // The crux of the fix: no INSERT is attempted for an already-present tuple, so unique_task never fires.
+        verify(incoming, never()).persistAndFlush();
+        verify(incoming, never()).persist();
+    }
+
+    @Test
+    void newTupleIsPersisted() {
+        // A genuinely new task on the week: no existing row for the tuple.
+        Week incoming = spy(newWeek("fresh-uuid", "task-2", "user-2", 26, 2026));
+        doNothing().when(incoming).persistAndFlush();
+
+        WeekService service = spy(new WeekService());
+        doReturn(Optional.empty()).when(service).findExistingWeek(any(Week.class));
+
+        Week result = service.save(incoming);
+
+        assertSame(incoming, result);
+        // Flushed (not a deferred commit) so a concurrent-insert race surfaces as a catchable 409.
+        verify(incoming).persistAndFlush();
+    }
+
+    private static Week newWeek(String uuid, String taskuuid, String useruuid, int weeknumber, int year) {
+        Week week = new Week();
+        week.setUuid(uuid);
+        week.setTaskuuid(taskuuid);
+        week.setUseruuid(useruuid);
+        week.setWeeknumber(weeknumber);
+        week.setYear(year);
+        return week;
+    }
+}


### PR DESCRIPTION
## Summary
- `POST /weeks` returned **HTTP 500** whenever a week-save collided with the DB unique key `unique_task` = `UNIQUE(taskuuid, useruuid, weeknumber, year)` on table `week` (recurring in prod: 8× on 2026-06-15 from multiple users). The frontend mints a fresh `crypto.randomUUID()` per "add task to week" and does not dedupe, so double-clicks / concurrent tabs / add-delete-readd / clone re-submit an already-existing tuple; the old blind `week.persist()` then violated `unique_task`.
- Because the flush was deferred to JTA commit, the violation surfaced as `ArcUndeclaredThrowableException` (a wrapped **checked** `RollbackException`), **not** a `PersistenceException` — so `DatabaseConstraintViolationExceptionMapper` (`ExceptionMapper<PersistenceException>`) never matched and it fell through to `GenericExceptionMapper` → 500.
- `WeekService.save` now looks up the existing row by the `unique_task` tuple and **returns it idempotently** (no insert; `sorting`/`workas` left untouched — reorder is a separate `PATCH /weeks/{uuid}` flow and the add payload omits `sorting`→0). Otherwise `persistAndFlush()`, so a genuine concurrent-insert race surfaces synchronously as an **unchecked** `PersistenceException` → clean **409** via the existing mapper instead of a deferred commit-time 500.
- Lookup extracted to a package-private `findExistingWeek()` seam so the idempotency decision is unit-testable without a DB.
- Adds `WeekServiceTest` (pure Mockito, no DB): duplicate tuple returns the existing row and **never** inserts; new tuple persists.

Backend-only — no Flyway/schema change, no frontend coupling, single caller (`WeekResource.saveWeek`).

## Test plan
- [x] `./mvnw clean test-compile` → BUILD SUCCESS
- [x] `./mvnw test -Dtest=WeekServiceTest` → 2/2 pass; `DatabaseConstraintViolationExceptionMapperTest` 4/4 pass
- [ ] After staging deploy: add a task already on the week (or double-click add) → expect success/no-op (no 500); verify timesheet still renders the task once

🤖 Generated with [Claude Code](https://claude.com/claude-code)