### PR TITLE
fix(invoicing): book internal-invoice debtor cost on contraAccount (3050/3055)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -166,11 +166,16 @@ public class EconomicsInvoiceService {
 
             // Resolve the issuer-aware intercompany cost account in the DEBTOR's chart of accounts.
             // issuer = invoice.getCompany(); debtor = targetCompany. When the pair is mapped
-            // (e.g. Technology -> A/S = 3050, Cyber -> A/S = 3055) the cost lands on that account and
-            // NO contra account is set: the CVR-resolved supplier (kreditor) drives the AP credit.
+            // (e.g. Technology -> A/S = 3050, Cyber -> A/S = 3055) the cost must land on the
+            // SupplierInvoice's CONTRA account. e-conomic's supplierInvoices voucher entry has no
+            // `account` field — it is silently ignored (see the journals-voucher schema: the only
+            // accounts on a supplierInvoice are `contraAccount` and the `supplier`). The cost account
+            // is therefore the contra (offset) leg, and the CVR-resolved supplier (kreditor) drives
+            // the AP credit. We set both account and contraAccount to the mapped number, mirroring the
+            // proven unmapped shape (account == contraAccount); only the contra is honoured.
             // When the pair is unmapped, keep today's behaviour EXACTLY (invoice-account-number for
             // both the cost account and the contra account) so out-of-scope intercompany flows are
-            // untouched. See spec 2026-06-15-internal-invoice-debtor-cost-account-mapping-design.md §4.5.
+            // untouched. See spec 2026-06-15-internal-invoice-debtor-cost-account-mapping-design.md §4.4.
             String issuerCompanyUuid = invoice.getCompany() != null ? invoice.getCompany().getUuid() : null;
             Optional<Integer> mappedCostAccount =
                     agreementResolver.intercompanyCostAccount(targetCompany.getUuid(), issuerCompanyUuid);
@@ -178,8 +183,9 @@ public class EconomicsInvoiceService {
             ExpenseAccount supplierAccount;
             ContraAccount supplierContraAccount;
             if (mappedCostAccount.isPresent()) {
-                supplierAccount = new ExpenseAccount(mappedCostAccount.get());
-                supplierContraAccount = null;
+                int costAccountNumber = mappedCostAccount.get();
+                supplierAccount = new ExpenseAccount(costAccountNumber);
+                supplierContraAccount = new ContraAccount(costAccountNumber);
             } else {
                 log.warnf("No intercompany cost-account mapping for debtor %s / issuer %s — "
                                 + "falling back to invoice-account-number %d",

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.*;
  * Only agreementResolver + supplierResolver are used by buildJSONRequest; the other
  * @Inject fields (invoicePdfS3Service, bookingApi) are left null.
  *
- * Covers AC1 (3050), AC2 (3055), AC3 (creditor + no contra), AC4 (I25),
+ * Covers AC1 (3050), AC2 (3055), AC3 (creditor + cost on contra), AC4 (I25),
  * AC5 (unmapped fallback keeps today's behaviour), AC7 (manual branch untouched).
  */
 @ExtendWith(MockitoExtension.class)
@@ -78,7 +78,7 @@ class EconomicsInvoiceServiceVoucherTest {
     }
 
     @Test
-    void technology_to_AS_books_cost_on_3050_with_no_contra_account() {
+    void technology_to_AS_books_cost_on_3050_contra_with_creditor() {
         Invoice inv = internalInvoice(TECH_UUID, TECH_CVR);
         Journal journal = new Journal(INTERNAL_JOURNAL); // == internalJournalNumber -> supplier branch
         when(agreementResolver.intercompanyCostAccount(AS_UUID, TECH_UUID)).thenReturn(Optional.of(3050));
@@ -87,8 +87,10 @@ class EconomicsInvoiceServiceVoucherTest {
         Voucher voucher = service.buildJSONRequest(inv, journal, "Client, Faktura 91001", keys(), debtorAS());
 
         SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
-        assertEquals(3050, si.getAccount().getAccountNumber());        // AC1
-        assertNull(si.getContraAccount());                            // AC3 — no contra
+        // e-conomic ignores `account` on a supplierInvoices entry; the cost account is the CONTRA
+        // (offset) leg. It must be present, else e-conomic books only the creditor with no cost.
+        assertEquals(3050, si.getContraAccount().getAccountNumber()); // AC1 — cost lands on 3050 (contra)
+        assertEquals(3050, si.getAccount().getAccountNumber());       // mirrors unmapped shape (account==contra)
         assertNotNull(si.getSupplier());                              // AC3 — creditor present
         assertEquals(700, si.getSupplier().supplierNumber);
         assertEquals("I25", si.getContraVatAccount().vatCode);        // AC4
@@ -105,8 +107,8 @@ class EconomicsInvoiceServiceVoucherTest {
         Voucher voucher = service.buildJSONRequest(inv, journal, "txt", keys(), debtorAS());
 
         SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
-        assertEquals(3055, si.getAccount().getAccountNumber());        // AC2
-        assertNull(si.getContraAccount());
+        assertEquals(3055, si.getContraAccount().getAccountNumber()); // AC2 — cost lands on 3055 (contra)
+        assertEquals(3055, si.getAccount().getAccountNumber());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes the intercompany internal-invoice debtor voucher: the issuer-specific cost account (Technology→**3050**, Cyber→**3055**) was being sent in the `SupplierInvoice.account` field — which **e-conomic silently ignores for `supplierInvoices` entries** — while `contraAccount` was set to `null`. e-conomic therefore booked only the kreditor leg with no cost account, posting an **unbalanced debit on the kreditor (Trustworks Technology) with no Modkonto 3050**.

Reported by the accountant on 2026-06-16 (3 internal invoices "came into A/S from Tech … uden konto 3050 og beløbet står i debet").

## Root cause (verified)

- e-conomic's journals-voucher schema: a `supplierInvoices` entry has **no `account` field** — only `supplier` and `contraAccount` ("Either 'supplier' or 'contraAccount' is required").
- The pre-2026-06-15 code worked because it set `contraAccount = invoice-account-number` (2101) → cost on 2101 (wrong account, but a balanced kreditor posting).
- Commit `53fe2253` (2026-06-15) moved the cost number into the ignored `account` and nulled `contraAccount` → dropped the cost leg.
- Confirmed by the **actual posted payload** in staging CloudWatch:
  `{"supplierInvoices":[{"account":{"accountNumber":3050},"supplier":{"supplierNumber":44232855},"amount":32312.5,"contraVatAccount":{"vatCode":"I25"}}]}` — note **no `contraAccount`**.

## Fix

`EconomicsInvoiceService.buildJSONRequest` (mapped supplier-invoice branch): set the cost account as the **`contraAccount`** (the honoured offset leg) and `account` to the same number (mirrors the proven unmapped shape; only contra posts). Supplier (kreditor) + I25 VAT logic unchanged.

Resulting posting = **credit kreditor (gross), debit 3050/3055 (net) + I25 VAT lifted from gross** — i.e. the correct reference entry (`70-350`).

## Test plan

- [x] `EconomicsInvoiceServiceVoucherTest` updated to assert `contraAccount == 3050/3055` — 5/5 pass
- [x] `EconomicsInvoiceServiceTest` (unmapped/manual paths) — 9/9 pass, unchanged
- [ ] **MANDATORY before promoting `staging → master`:** post a real Technology→A/S and Cyber→A/S internal invoice on staging and confirm in A/S's e-conomic it books **credit kreditor (gross) / debit 3050/3055 (net) + I25, balanced**. This is the verification that was waived for the original change and is how the regression reached prod-bound code — **do not waive it again.**

## Notes / guards (not code, for the reviewer)

- Prod's real A/S internal journal (17) is clean — prod backend posted zero internal supplier-invoices in the last 9 days; the affected invoices are still QUEUED.
- **Hold the ~47 QUEUED Tech/Cyber→A/S internal invoices on prod** — do not force-create until this fix is live on prod.
- The malformed drafts the accountant sees are unbooked entries in the "TW app test journal" — they should be deleted and re-posted after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
