### PR TITLE
Release: internal-invoice debtor voucher contraAccount fix (#119)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -166,11 +166,16 @@ public class EconomicsInvoiceService {
 
             // Resolve the issuer-aware intercompany cost account in the DEBTOR's chart of accounts.
             // issuer = invoice.getCompany(); debtor = targetCompany. When the pair is mapped
-            // (e.g. Technology -> A/S = 3050, Cyber -> A/S = 3055) the cost lands on that account and
-            // NO contra account is set: the CVR-resolved supplier (kreditor) drives the AP credit.
+            // (e.g. Technology -> A/S = 3050, Cyber -> A/S = 3055) the cost must land on the
+            // SupplierInvoice's CONTRA account. e-conomic's supplierInvoices voucher entry has no
+            // `account` field — it is silently ignored (see the journals-voucher schema: the only
+            // accounts on a supplierInvoice are `contraAccount` and the `supplier`). The cost account
+            // is therefore the contra (offset) leg, and the CVR-resolved supplier (kreditor) drives
+            // the AP credit. We set both account and contraAccount to the mapped number, mirroring the
+            // proven unmapped shape (account == contraAccount); only the contra is honoured.
             // When the pair is unmapped, keep today's behaviour EXACTLY (invoice-account-number for
             // both the cost account and the contra account) so out-of-scope intercompany flows are
-            // untouched. See spec 2026-06-15-internal-invoice-debtor-cost-account-mapping-design.md §4.5.
+            // untouched. See spec 2026-06-15-internal-invoice-debtor-cost-account-mapping-design.md §4.4.
             String issuerCompanyUuid = invoice.getCompany() != null ? invoice.getCompany().getUuid() : null;
             Optional<Integer> mappedCostAccount =
                     agreementResolver.intercompanyCostAccount(targetCompany.getUuid(), issuerCompanyUuid);
@@ -178,8 +183,9 @@ public class EconomicsInvoiceService {
             ExpenseAccount supplierAccount;
             ContraAccount supplierContraAccount;
             if (mappedCostAccount.isPresent()) {
-                supplierAccount = new ExpenseAccount(mappedCostAccount.get());
-                supplierContraAccount = null;
+                int costAccountNumber = mappedCostAccount.get();
+                supplierAccount = new ExpenseAccount(costAccountNumber);
+                supplierContraAccount = new ContraAccount(costAccountNumber);
             } else {
                 log.warnf("No intercompany cost-account mapping for debtor %s / issuer %s — "
                                 + "falling back to invoice-account-number %d",

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.*;
  * Only agreementResolver + supplierResolver are used by buildJSONRequest; the other
  * @Inject fields (invoicePdfS3Service, bookingApi) are left null.
  *
- * Covers AC1 (3050), AC2 (3055), AC3 (creditor + no contra), AC4 (I25),
+ * Covers AC1 (3050), AC2 (3055), AC3 (creditor + cost on contra), AC4 (I25),
  * AC5 (unmapped fallback keeps today's behaviour), AC7 (manual branch untouched).
  */
 @ExtendWith(MockitoExtension.class)
@@ -78,7 +78,7 @@ class EconomicsInvoiceServiceVoucherTest {
     }
 
     @Test
-    void technology_to_AS_books_cost_on_3050_with_no_contra_account() {
+    void technology_to_AS_books_cost_on_3050_contra_with_creditor() {
         Invoice inv = internalInvoice(TECH_UUID, TECH_CVR);
         Journal journal = new Journal(INTERNAL_JOURNAL); // == internalJournalNumber -> supplier branch
         when(agreementResolver.intercompanyCostAccount(AS_UUID, TECH_UUID)).thenReturn(Optional.of(3050));
@@ -87,8 +87,10 @@ class EconomicsInvoiceServiceVoucherTest {
         Voucher voucher = service.buildJSONRequest(inv, journal, "Client, Faktura 91001", keys(), debtorAS());
 
         SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
-        assertEquals(3050, si.getAccount().getAccountNumber());        // AC1
-        assertNull(si.getContraAccount());                            // AC3 — no contra
+        // e-conomic ignores `account` on a supplierInvoices entry; the cost account is the CONTRA
+        // (offset) leg. It must be present, else e-conomic books only the creditor with no cost.
+        assertEquals(3050, si.getContraAccount().getAccountNumber()); // AC1 — cost lands on 3050 (contra)
+        assertEquals(3050, si.getAccount().getAccountNumber());       // mirrors unmapped shape (account==contra)
         assertNotNull(si.getSupplier());                              // AC3 — creditor present
         assertEquals(700, si.getSupplier().supplierNumber);
         assertEquals("I25", si.getContraVatAccount().vatCode);        // AC4
@@ -105,8 +107,8 @@ class EconomicsInvoiceServiceVoucherTest {
         Voucher voucher = service.buildJSONRequest(inv, journal, "txt", keys(), debtorAS());
 
         SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
-        assertEquals(3055, si.getAccount().getAccountNumber());        // AC2
-        assertNull(si.getContraAccount());
+        assertEquals(3055, si.getContraAccount().getAccountNumber()); // AC2 — cost lands on 3055 (contra)
+        assertEquals(3055, si.getAccount().getAccountNumber());
     }
 
     @Test


### PR DESCRIPTION
## Release Summary

Ships the internal-invoice debtor-voucher fix (#119) to **production**. Only commit ahead of `master`: `afd5e45b` (2 files).

- `EconomicsInvoiceService.buildJSONRequest`: the intercompany cost account (Tech→**3050**, Cyber→**3055**) is now set as the `SupplierInvoice` **`contraAccount`** — e-conomic silently ignores `account` on `supplierInvoices`, so the 2026-06-15 change (cost in `account`, `contraAccount=null`) dropped the cost leg and posted only the kreditor (unbalanced debit, no Modkonto 3050). Fixes the accountant's 2026-06-16 report.

## ⛔ DO NOT MERGE until both are true (this is the gate that was waived last time)

- [ ] **Accountant confirms** the staging posting (invoice `70-362`, voucher `5001415`) books **credit kreditor (Trustworks Technology) / debit 3050 + I25, balanced** — i.e. correct posting *direction*.
- [ ] **Explicit release go-ahead** given.

Kept as a **draft** until then.

## Verified on staging

- Deploy live: image `afd5e45b`, ECS `tw-quarkus-staging` PRIMARY rollout COMPLETED (task def `:261`).
- e-conomic payload now carries `"contraAccount":{"accountNumber":3050}` (was missing).
- Voucher `5001415`: Type Lev.fakt, Leverandør Trustworks Technology, Modkonto 3050 (Konsulentbistand TW TECH), I25 (Momsbeløb 36.093,72), **Bilagsbalance DKK 0,00**.

## After this merges to production

- The ~47 QUEUED Tech/Cyber→A/S internal invoices on prod can be force-created (they'll post correctly). Keep them on hold until then.
- Delete the malformed drafts (`70-357/358/359/360/361`) from the e-conomic daybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
