### PR TITLE
fix(invoice): guard internal-invoice e-conomic writes (stop staging booking)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -93,6 +93,7 @@ jobs:
               {"name":"JOURNALNUMBER","value":"7"},
               {"name":"EXPENSEJOURNALNUMBER","value":"16"},
               {"name":"EXPENSE_ECONOMICS_UPLOAD_ENABLED","value":"true"},
+              {"name":"INVOICE_ECONOMICS_UPLOAD_ENABLED","value":"true"},
               {"name":"ENVIRONMENT_ID","value":"production"},
               {"name":"INVOICE_S3","value":"invoicefiles-new"},
               {"name":"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT","value":"http://localhost:4317"},

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,7 @@ jobs:
               {"name":"JOURNALNUMBER","value":"7"},
               {"name":"EXPENSEJOURNALNUMBER","value":"16"},
               {"name":"EXPENSE_ECONOMICS_UPLOAD_ENABLED","value":"false"},
+              {"name":"INVOICE_ECONOMICS_UPLOAD_ENABLED","value":"false"},
               {"name":"ENVIRONMENT_ID","value":"staging"},
               {"name":"INVOICE_S3","value":"invoicefiles-test"},
               {"name":"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT","value":"http://localhost:4317"},

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestrator.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestrator.java
@@ -95,6 +95,16 @@ public class InvoiceFinalizationOrchestrator {
     EanPrerequisiteChecker eanChecker;
 
     /**
+     * Kill switch for internal-invoice e-conomic writes. Staging sets this {@code false}
+     * so it can never create drafts or book invoices in the shared production e-conomic
+     * (2026-06-16 duplicate incident). Covers every booking path: nightly batch first &
+     * settlement passes, manual force-create-queued, and the upload retry job.
+     */
+    @org.eclipse.microprofile.config.inject.ConfigProperty(
+            name = "dk.trustworks.invoice.economics-upload.enabled", defaultValue = "true")
+    boolean invoiceUploadEnabled;
+
+    /**
      * Step 1: Creates the e-conomic draft invoice.
      *
      * <p>Preconditions: invoice must be DRAFT or QUEUED; PHANTOM invoices are rejected.
@@ -112,6 +122,10 @@ public class InvoiceFinalizationOrchestrator {
      */
     @Transactional
     public Invoice createDraft(String invoiceUuid) {
+        if (!invoiceUploadEnabled) {
+            throw new BadRequestException(
+                    "Invoice e-conomic upload is disabled (dk.trustworks.invoice.economics-upload.enabled=false)");
+        }
         Invoice inv = requireEditableInvoice(invoiceUuid);
 
         if (inv.getType() == InvoiceType.PHANTOM) {
@@ -242,6 +256,10 @@ public class InvoiceFinalizationOrchestrator {
      */
     @Transactional
     public Invoice bookDraft(String invoiceUuid, String sendBy) {
+        if (!invoiceUploadEnabled) {
+            throw new BadRequestException(
+                    "Invoice e-conomic upload is disabled (dk.trustworks.invoice.economics-upload.enabled=false)");
+        }
         Invoice inv = invoices.findByUuid(invoiceUuid)
                 .orElseThrow(() -> new NotFoundException(
                         "Invoice not found: " + invoiceUuid));

--- a/src/main/java/dk/trustworks/intranet/batch/BatchScheduler.java
+++ b/src/main/java/dk/trustworks/intranet/batch/BatchScheduler.java
@@ -30,6 +30,15 @@ public class BatchScheduler {
     @ConfigProperty(name = "dk.trustworks.expense.economics-upload.enabled", defaultValue = "true")
     boolean expenseUploadEnabled;
 
+    /**
+     * Kill switch for internal-invoice e-conomic booking — the queued-internal-invoice
+     * processor and the economics-upload retry both POST to the shared e-conomic. Staging's
+     * deploy sets this to {@code false} so a staging-sync-polluted DB can never book real
+     * internal invoices (2026-06-16 duplicate incident).
+     */
+    @ConfigProperty(name = "dk.trustworks.invoice.economics-upload.enabled", defaultValue = "true")
+    boolean invoiceUploadEnabled;
+
     // Observability heartbeat. The actual nightly BI refresh is run by the
     // MariaDB event ev_bi_nightly_refresh at 03:00 UTC; it runs longer than
     // any reasonable Quarkus JTA transaction timeout.
@@ -204,6 +213,10 @@ public class BatchScheduler {
     // Queued internal invoice processor - runs daily at 2 AM
     @Scheduled(cron = "0 0 2 * * ?")
     void scheduleQueuedInternalInvoiceProcessor() {
+        if (!invoiceUploadEnabled) {
+            log.debug("queued-internal-invoice-processor skipped: dk.trustworks.invoice.economics-upload.enabled=false");
+            return;
+        }
         try {
             if (jobOperator.getJobNames().contains("queued-internal-invoice-processor")) {
                 if (!jobOperator.getRunningExecutions("queued-internal-invoice-processor").isEmpty()) {
@@ -226,6 +239,10 @@ public class BatchScheduler {
     // Economics upload processing - runs every 1 minute to process pending/failed uploads
     @Scheduled(cron = "0 * * * * ?")
     void scheduleEconomicsUploadRetry() {
+        if (!invoiceUploadEnabled) {
+            log.debug("economics-upload-retry skipped: dk.trustworks.invoice.economics-upload.enabled=false");
+            return;
+        }
         try {
             if (jobOperator.getJobNames().contains("economics-upload-retry")) {
                 if (!jobOperator.getRunningExecutions("economics-upload-retry").isEmpty()) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -355,7 +355,7 @@ openai:
   # their output budget on thinking and frequently emit empty structured output for
   # image+schema requests, so vision is routed through a proven vision model.
   vision-model: ${OPENAI_VISION_MODEL:gpt-4o-mini}
-# Staging must set EXPENSE_ECONOMICS_UPLOAD_ENABLED=false and ENVIRONMENT_ID=staging
+# Staging must set EXPENSE_ECONOMICS_UPLOAD_ENABLED=false, INVOICE_ECONOMICS_UPLOAD_ENABLED=false and ENVIRONMENT_ID=staging
 # so a staging-sync-polluted DB cannot POST vouchers to e-conomics and, if it ever
 # does, cannot reuse production's idempotency keys.
 # IMPORTANT: keep this single `dk:` block — SnakeYAML silently lets a later
@@ -367,6 +367,9 @@ dk:
     expense:
       economics-upload:
         enabled: ${EXPENSE_ECONOMICS_UPLOAD_ENABLED:true}
+    invoice:
+      economics-upload:
+        enabled: ${INVOICE_ECONOMICS_UPLOAD_ENABLED:true}
     environment:
       id: ${ENVIRONMENT_ID:production}
     intranet:

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InternalInvoiceOrchestratorTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InternalInvoiceOrchestratorTest.java
@@ -12,6 +12,7 @@ import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceType;
 import dk.trustworks.intranet.expenseservice.services.EconomicsInvoiceService;
 import dk.trustworks.intranet.model.Company;
 import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -63,6 +64,11 @@ class InternalInvoiceOrchestratorTest {
     @Mock InvoiceWorkService                 work;
     @Mock EconomicsInvoiceService            economicsInvoiceService;
     @Mock DebtorCompanyLookup               debtorCompanyLookup;
+
+    @BeforeEach
+    void enableInvoiceUpload() {
+        orchestrator.invoiceUploadEnabled = true;
+    }
 
     // ── shared fixtures ───────────────────────────────────────────────────────
 

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestratorInternalTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestratorInternalTest.java
@@ -13,6 +13,7 @@ import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceType;
 import dk.trustworks.intranet.contracts.model.Contract;
 import dk.trustworks.intranet.dao.crm.model.Client;
 import dk.trustworks.intranet.model.Company;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -55,6 +56,11 @@ class InvoiceFinalizationOrchestratorInternalTest {
     @Mock dk.trustworks.intranet.expenseservice.services.EconomicsInvoiceService economicsInvoiceService;
     @Mock DebtorCompanyLookup               debtorCompanyLookup;
     @Mock EanPrerequisiteChecker            eanChecker;
+
+    @BeforeEach
+    void enableInvoiceUpload() {
+        orchestrator.invoiceUploadEnabled = true;
+    }
 
     // ── AC-14: INTERNAL finalize → mapper receives intercompany billingClient ─
 

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestratorSendByTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestratorSendByTest.java
@@ -62,6 +62,7 @@ class InvoiceFinalizationOrchestratorSendByTest {
      */
     @org.junit.jupiter.api.BeforeEach
     void stubDraftInvoiceNumberResolution() {
+        orchestrator.invoiceUploadEnabled = true;
         EconomicsDraftInvoice fetched = new EconomicsDraftInvoice();
         fetched.setDraftInvoiceNumber(4521);
         lenient().when(draftApi.getByNumber(anyString(), anyString(), anyInt()))

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestratorTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestratorTest.java
@@ -16,6 +16,7 @@ import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceType;
 import dk.trustworks.intranet.contracts.model.Contract;
 import dk.trustworks.intranet.dao.crm.model.Client;
 import dk.trustworks.intranet.model.Company;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -52,6 +53,11 @@ class InvoiceFinalizationOrchestratorTest {
     @Mock InvoiceWorkService                work;
     @Mock dk.trustworks.intranet.expenseservice.services.EconomicsInvoiceService economicsInvoiceService;
     @Mock DebtorCompanyLookup               debtorCompanyLookup;
+
+    @BeforeEach
+    void enableInvoiceUpload() {
+        orchestrator.invoiceUploadEnabled = true;
+    }
 
     // ── test 1: createDraft happy path ────────────────────────────────────────
 

--- a/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestratorUploadGuardTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestratorUploadGuardTest.java
@@ -1,0 +1,36 @@
+package dk.trustworks.intranet.aggregates.invoice.services;
+
+import dk.trustworks.intranet.aggregates.invoice.economics.book.EconomicsBookingApiClient;
+import dk.trustworks.intranet.aggregates.invoice.economics.draft.EconomicsDraftInvoiceApiClient;
+import jakarta.ws.rs.BadRequestException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class InvoiceFinalizationOrchestratorUploadGuardTest {
+
+    @InjectMocks InvoiceFinalizationOrchestrator orchestrator;
+    @Mock InvoiceRepository invoices;
+    @Mock EconomicsDraftInvoiceApiClient draftApi;
+    @Mock EconomicsBookingApiClient bookApi;
+
+    @Test
+    void createDraft_throws_and_calls_nothing_when_upload_disabled() {
+        orchestrator.invoiceUploadEnabled = false;
+        assertThrows(BadRequestException.class, () -> orchestrator.createDraft("any"));
+        verifyNoInteractions(invoices, draftApi, bookApi);
+    }
+
+    @Test
+    void bookDraft_throws_and_calls_nothing_when_upload_disabled() {
+        orchestrator.invoiceUploadEnabled = false;
+        assertThrows(BadRequestException.class, () -> orchestrator.bookDraft("any", null));
+        verifyNoInteractions(invoices, draftApi, bookApi);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/batch/BatchSchedulerInvoiceUploadGateTest.java
+++ b/src/test/java/dk/trustworks/intranet/batch/BatchSchedulerInvoiceUploadGateTest.java
@@ -1,0 +1,51 @@
+package dk.trustworks.intranet.batch;
+
+import jakarta.batch.operations.JobOperator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BatchSchedulerInvoiceUploadGateTest {
+
+    @Mock JobOperator jobOperator;
+    @InjectMocks BatchScheduler scheduler;
+
+    @Test
+    void queuedInternalInvoiceProcessor_skips_when_invoice_upload_disabled() {
+        scheduler.invoiceUploadEnabled = false;
+        scheduler.scheduleQueuedInternalInvoiceProcessor();
+        verifyNoInteractions(jobOperator);
+    }
+
+    @Test
+    void economicsUploadRetry_skips_when_invoice_upload_disabled() {
+        scheduler.invoiceUploadEnabled = false;
+        scheduler.scheduleEconomicsUploadRetry();
+        verifyNoInteractions(jobOperator);
+    }
+
+    @Test
+    void queuedInternalInvoiceProcessor_starts_when_enabled() {
+        scheduler.invoiceUploadEnabled = true;
+        Set<String> jobs = new HashSet<>();
+        jobs.add("queued-internal-invoice-processor");
+        when(jobOperator.getJobNames()).thenReturn(jobs);
+        when(jobOperator.getRunningExecutions("queued-internal-invoice-processor")).thenReturn(List.of());
+        scheduler.scheduleQueuedInternalInvoiceProcessor();
+        verify(jobOperator).start(eq("queued-internal-invoice-processor"), any(Properties.class));
+    }
+}


### PR DESCRIPTION
## Why
2026-06-16 incident: staging and prod share one e-conomic account and both run the nightly invoice batch, so staging was booking real internal invoices (duplicate/orphan risk). Adds a kill-switch mirroring the proven expense flag.

## What
- New config `dk.trustworks.invoice.economics-upload.enabled` (env `INVOICE_ECONOMICS_UPLOAD_ENABLED`, default `true`).
- Guard in `BatchScheduler` (both invoice schedulers) **and** at the booking chokepoint `InvoiceFinalizationOrchestrator.createDraft`/`bookDraft` — covers batch, settlement, manual force-create, retry.
- Staging deploy sets it `false`; prod `true`.

## Tests
`BatchSchedulerInvoiceUploadGateTest` (3), `InvoiceFinalizationOrchestratorUploadGuardTest` (2), existing orchestrator suites green (Mockito-default-false handled via `@BeforeEach`). `ApplicationYamlNoDuplicateKeysTest` green.

Spec/plan: `docs/superpowers/specs|plans/2026-06-16-internal-invoice-economic-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)