### PR TITLE
fix(invoice): credit kreditor on payer-side internal voucher (negate amount)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -194,11 +194,22 @@ public class EconomicsInvoiceService {
                 supplierContraAccount = contraAccount;
             }
 
+            // e-conomic's supplierInvoices entry posts `amount` from the SUPPLIER (kreditor)
+            // perspective: a POSITIVE amount DEBITS the creditor (reduces accounts payable — a
+            // supplier credit note), a NEGATIVE amount CREDITS it (increases payable — a normal
+            // purchase invoice). For an intercompany INTERNAL invoice the debtor (e.g. A/S) OWES
+            // the issuer, so the creditor must be CREDITED: we post the negated gross. e-conomic
+            // then books the balancing debit on the contra (cost) account net, lifting the I25
+            // input VAT out of the gross. Without the negation every payer-side voucher booked as
+            // a DEBIT on the creditor and the accountant had to flip the sign by hand on each one.
+            // Negating getGrandTotal() also keeps credit notes correct: a negative gross flips back
+            // to a positive amount (debit the creditor), reducing payable as intended.
+            double grandTotal = invoice.getGrandTotal() != null ? invoice.getGrandTotal() : 0.0;
             SupplierInvoice supplierInvoice = new SupplierInvoice(
                     supplierAccount,
                     StringUtils.convertInvoiceNumberToString(invoice.getInvoicenumber()),
                     text,
-                    invoice.getGrandTotal() != null ? invoice.getGrandTotal() : 0.0,
+                    -grandTotal,
                     supplierContraAccount,
                     date);
 

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
@@ -94,6 +94,9 @@ class EconomicsInvoiceServiceVoucherTest {
         assertNotNull(si.getSupplier());                              // AC3 — creditor present
         assertEquals(700, si.getSupplier().supplierNumber);
         assertEquals("I25", si.getContraVatAccount().vatCode);        // AC4
+        // The debtor OWES the issuer, so the creditor must be CREDITED — e-conomic credits the
+        // supplier only for a NEGATIVE amount; a positive amount debits it (the reported bug).
+        assertEquals(-50_000.0, si.getAmount(), 0.001);
         assertNull(voucher.getEntries().getManualCustomerInvoices()); // supplier branch only
     }
 
@@ -109,6 +112,7 @@ class EconomicsInvoiceServiceVoucherTest {
         SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
         assertEquals(3055, si.getContraAccount().getAccountNumber()); // AC2 — cost lands on 3055 (contra)
         assertEquals(3055, si.getAccount().getAccountNumber());
+        assertEquals(-50_000.0, si.getAmount(), 0.001);               // creditor credited (negative)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- e-conomic's `supplierInvoices` entry posts `amount` from the **creditor's** perspective: a positive amount **debits** the kreditor (supplier credit-note direction), a negative amount **credits** it (normal purchase, payable up).
- `EconomicsInvoiceService.buildJSONRequest` sent the positive gross (`getGrandTotal()`), so every payer-side internal invoice booked as a **debit** on the issuer's kreditor — the accountant had to flip each sign by hand. Confirmed on prod via the 50088 payload (`amount:5716.8`, `contraAccount:3055`).
- Fix: post `-getGrandTotal()` so the kreditor is **credited** (gross) and the cost account debited (net) + I25 input VAT. Also keeps credit notes correct (negative gross → positive → debit kreditor).

## Notes
- Independent of and on top of the 2026-06-16 contraAccount fix (that fixed the cost leg; this fixes the sign).
- Behaviour change is scoped to the supplier-invoice (debtor) branch only; the customer/issuer branch is untouched.

## Test plan
- [x] `./mvnw test -Dtest=EconomicsInvoiceServiceVoucherTest,EconomicsInvoiceServiceTest` → 14/14, BUILD SUCCESS (added `assertEquals(-50_000.0, si.getAmount())` for Tech & Cyber branches)
- [ ] Verify on the next real Tech/Cyber→A/S prod posting that the payer side books as a **credit** with no manual flip (staging e-conomic upload stays OFF via `INVOICE_ECONOMICS_UPLOAD_ENABLED=false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)