### PR TITLE
Release: credit kreditor on payer-side internal invoice voucher (sign fix)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceService.java
@@ -194,11 +194,22 @@ public class EconomicsInvoiceService {
                 supplierContraAccount = contraAccount;
             }
 
+            // e-conomic's supplierInvoices entry posts `amount` from the SUPPLIER (kreditor)
+            // perspective: a POSITIVE amount DEBITS the creditor (reduces accounts payable — a
+            // supplier credit note), a NEGATIVE amount CREDITS it (increases payable — a normal
+            // purchase invoice). For an intercompany INTERNAL invoice the debtor (e.g. A/S) OWES
+            // the issuer, so the creditor must be CREDITED: we post the negated gross. e-conomic
+            // then books the balancing debit on the contra (cost) account net, lifting the I25
+            // input VAT out of the gross. Without the negation every payer-side voucher booked as
+            // a DEBIT on the creditor and the accountant had to flip the sign by hand on each one.
+            // Negating getGrandTotal() also keeps credit notes correct: a negative gross flips back
+            // to a positive amount (debit the creditor), reducing payable as intended.
+            double grandTotal = invoice.getGrandTotal() != null ? invoice.getGrandTotal() : 0.0;
             SupplierInvoice supplierInvoice = new SupplierInvoice(
                     supplierAccount,
                     StringUtils.convertInvoiceNumberToString(invoice.getInvoicenumber()),
                     text,
-                    invoice.getGrandTotal() != null ? invoice.getGrandTotal() : 0.0,
+                    -grandTotal,
                     supplierContraAccount,
                     date);
 

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsInvoiceServiceVoucherTest.java
@@ -94,6 +94,9 @@ class EconomicsInvoiceServiceVoucherTest {
         assertNotNull(si.getSupplier());                              // AC3 — creditor present
         assertEquals(700, si.getSupplier().supplierNumber);
         assertEquals("I25", si.getContraVatAccount().vatCode);        // AC4
+        // The debtor OWES the issuer, so the creditor must be CREDITED — e-conomic credits the
+        // supplier only for a NEGATIVE amount; a positive amount debits it (the reported bug).
+        assertEquals(-50_000.0, si.getAmount(), 0.001);
         assertNull(voucher.getEntries().getManualCustomerInvoices()); // supplier branch only
     }
 
@@ -109,6 +112,7 @@ class EconomicsInvoiceServiceVoucherTest {
         SupplierInvoice si = voucher.getEntries().getSupplierInvoices().get(0);
         assertEquals(3055, si.getContraAccount().getAccountNumber()); // AC2 — cost lands on 3055 (contra)
         assertEquals(3055, si.getAccount().getAccountNumber());
+        assertEquals(-50_000.0, si.getAmount(), 0.001);               // creditor credited (negative)
     }
 
     @Test


### PR DESCRIPTION
## Release Summary
- Fix #124: payer-side internal-invoice voucher now posts `-getGrandTotal()` so e-conomic **credits** the issuer's kreditor (was booking a **debit**; the accountant had been flipping every sign by hand). Cost account debited (net) + I25 input VAT.
- Scoped to the supplier-invoice (debtor) branch of `EconomicsInvoiceService.buildJSONRequest`; customer/issuer branch untouched. Sits on top of the 2026-06-16 contraAccount fix.

## Pre-merge checklist
- [x] Local tests green: `EconomicsInvoiceServiceVoucherTest` + `EconomicsInvoiceServiceTest` 14/14, BUILD SUCCESS
- [x] Staging carries the change (`INVOICE_ECONOMICS_UPLOAD_ENABLED=false` there, so no staging e-conomic post — verification is the next real prod posting, per product owner)

## Verify after deploy
- Next Tech/Cyber→A/S internal invoice posts the payer side as a **credit** with no manual correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)