### PR TITLE
Release: harden finance-load-economics against concurrent-peer duplicate cascade

### DIFF
--- a/src/main/java/dk/trustworks/intranet/financeservice/jobs/FinanceLoadJob.java
+++ b/src/main/java/dk/trustworks/intranet/financeservice/jobs/FinanceLoadJob.java
@@ -18,6 +18,7 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import lombok.extern.jbosslog.JBossLog;
 import org.apache.commons.lang3.Range;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import java.time.Duration;
@@ -73,13 +74,33 @@ public class FinanceLoadJob {
                 log.info("Load data from periode: "+economicsUrlYear+" for company "+company.getUuid());
                 Map<PostingStatus, Map<Range<Integer>, List<EconomicsService.FinanceEntry>>> allEntries;
                 try {
+                    // Order matters: getAllEntries persists finance_details (the
+                    // uq_fd_logical_key table) and THROWS on a 1062 collision, so a
+                    // concurrent-peer duplicate aborts this iteration BEFORE persistExpenses
+                    // writes the aggregated 'finances' rows. 'finances' has no unique key, so
+                    // this throw-before-persist ordering is the only thing keeping the two
+                    // tables consistent under a concurrent peer — do not reorder, and do not
+                    // make finance_details persistence non-throwing (e.g. INSERT IGNORE)
+                    // without first adding a 'finances' duplicate guard.
                     allEntries = economicsService.getAllEntries(company, economicsUrlYear);
                     economicsService.persistExpenses(allEntries);
                     log.info("allEntries.size() = " + allEntries.size());
                     log.info("Entries for period " + economicsUrlYear + " persisted!");
                 } catch (Exception e) {
-                    log.error("Error loading data for company "+company.getUuid(), e);
-                    fireSlackAlertIfNeeded(company, economicsUrlYear, e);
+                    if (isConcurrentDuplicate(e)) {
+                        // A concurrent peer run (e.g. the draining OLD task re-firing the
+                        // 21:00 schedule during an ECS-Express deploy bake) already loaded
+                        // this (company, period). The uq_fd_logical_key 1062 collision rolled
+                        // back ONLY this batch's own transaction (getAllEntries persists via
+                        // QuarkusTransaction.requiringNew), so the rows are present and the
+                        // rest of the run is unaffected. Skip quietly — expected during a
+                        // double-fire and self-heals; no Slack alert.
+                        log.warnf("Skipping company %s period %s: finance_details already loaded by a concurrent peer run (uq_fd_logical_key collision)",
+                                company.getUuid(), economicsUrlYear);
+                    } else {
+                        log.error("Error loading data for company "+company.getUuid(), e);
+                        fireSlackAlertIfNeeded(company, economicsUrlYear, e);
+                    }
                 }
             }
         }
@@ -124,6 +145,34 @@ public class FinanceLoadJob {
         log.info("The ExpenseLoadJob is starting...");
         //loadEconomicsData();
         //synchronizeInvoices();
+    }
+
+    /**
+     * True when {@code e} (or anything in its cause chain) is a unique-key collision on
+     * {@code uq_fd_logical_key} — i.e. a concurrent peer run already inserted these
+     * finance_details rows. The persist runs in {@code QuarkusTransaction.requiringNew()}
+     * inside {@link EconomicsService#getAllEntries}, so a commit-time violation surfaces
+     * wrapped (RollbackException / ArcUndeclaredThrowableException); the whole cause chain
+     * is inspected.
+     *
+     * <p>Detection is by message, anchored on the constraint name {@code uq_fd_logical_key}
+     * (a locale-independent DB object name) with MariaDB's "Duplicate entry" (error 1062)
+     * as a secondary signal. This is deliberately narrow: a genuine, non-duplicate
+     * integrity error (NOT NULL, FK, …) carries neither marker, so it falls through to the
+     * Slack alert instead of being silently skipped on every run. A real duplicate means
+     * the rows are already present, so the caller skips this (company, period) quietly
+     * rather than alerting and re-deriving — see {@link #loadEconomicsData()}.
+     */
+    static boolean isConcurrentDuplicate(Throwable e) {
+        for (Throwable t : ExceptionUtils.getThrowableList(e)) {
+            String msg = t.getMessage();
+            if (msg != null
+                    && (msg.contains("uq_fd_logical_key")
+                        || msg.contains("Duplicate entry"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/dk/trustworks/intranet/financeservice/services/EconomicsService.java
+++ b/src/main/java/dk/trustworks/intranet/financeservice/services/EconomicsService.java
@@ -15,6 +15,7 @@ import dk.trustworks.intranet.financeservice.remote.EconomicsPagingAPI;
 import dk.trustworks.intranet.financeservice.remote.dto.economics.Collection;
 import dk.trustworks.intranet.financeservice.remote.dto.economics.EconomicsInvoice;
 import dk.trustworks.intranet.model.Company;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import lombok.SneakyThrows;
 import lombok.extern.jbosslog.JBossLog;
 import org.apache.commons.lang3.Range;
@@ -22,8 +23,7 @@ import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-import jakarta.transaction.*;
+import jakarta.transaction.Transactional;
 import java.net.URI;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -43,9 +43,6 @@ import static dk.trustworks.intranet.financeservice.model.enums.EconomicAccountG
 @JBossLog
 @ApplicationScoped
 public class EconomicsService {
-
-    @Inject
-    TransactionManager tm;
 
     @ConfigProperty(name = "quarkus.rest-client.economics-journals-api.url", defaultValue = "https://apis.e-conomic.com/journalsapi/v13.0.1")
     URI journalsApiUri;
@@ -117,36 +114,33 @@ public class EconomicsService {
         // Deduping by the source-aware logical key keeps the persist idempotent
         // against pagination quirks. "Last write wins" matches the INSERT
         // IGNORE semantics the unique key enforces at the DB.
-        List<FinanceDetails> uniqueFinanceDetails = financeDetails;
-        if (!financeDetails.isEmpty()) {
-            Map<String, FinanceDetails> deduped = new LinkedHashMap<>();
-            for (FinanceDetails fd : financeDetails) {
-                String logicalKey = fd.getCompany().getUuid()
-                        + "|" + fd.getPostingstatus()
-                        + "|" + fd.getJournalnumber()
-                        + "|" + fd.getVouchernumber()
-                        + "|" + fd.getEntrynumber()
-                        + "|" + fd.getAccountnumber()
-                        + "|" + fd.getAmount()
-                        + "|" + fd.getExpensedate();
-                deduped.put(logicalKey, fd);
-            }
-            if (deduped.size() != financeDetails.size()) {
-                log.warnf("In-batch dedup: %d → %d FinanceDetails for company %s period %s (%d duplicate(s) from e-conomic pagination)",
-                        financeDetails.size(), deduped.size(), company.getUuid(), date,
-                        financeDetails.size() - deduped.size());
-                uniqueFinanceDetails = new ArrayList<>(deduped.values());
-            }
+        Map<String, FinanceDetails> deduped = new LinkedHashMap<>();
+        for (FinanceDetails fd : financeDetails) {
+            String logicalKey = fd.getCompany().getUuid()
+                    + "|" + fd.getPostingstatus()
+                    + "|" + fd.getJournalnumber()
+                    + "|" + fd.getVouchernumber()
+                    + "|" + fd.getEntrynumber()
+                    + "|" + fd.getAccountnumber()
+                    + "|" + fd.getAmount()
+                    + "|" + fd.getExpensedate();
+            deduped.put(logicalKey, fd);
+        }
+        if (deduped.size() != financeDetails.size()) {
+            log.warnf("In-batch dedup: %d → %d FinanceDetails for company %s period %s (%d duplicate(s) from e-conomic pagination)",
+                    financeDetails.size(), deduped.size(), company.getUuid(), date,
+                    financeDetails.size() - deduped.size());
         }
 
-        try {
-            tm.begin();
-            FinanceDetails.persist(uniqueFinanceDetails);
-            tm.commit();
-        } catch (NotSupportedException | HeuristicRollbackException | SystemException | HeuristicMixedException |
-                 RollbackException e) {
-            throw new RuntimeException(e);
-        }
+        // Persist this batch in its OWN new transaction so a uq_fd_logical_key
+        // collision (1062) rolls back ONLY this batch and Quarkus tears down its
+        // transaction-scoped persistence context. The previous manual
+        // tm.begin()/tm.commit() left the failed FinanceDetails (null identifier) in
+        // the long-lived request session, so one collision AssertionFailure-cascaded
+        // (HHH000099) across every remaining tenant (2026-04-24, 2026-06-16). The
+        // collision propagates to the caller, which skips the duplicate tenant.
+        final List<FinanceDetails> entriesToPersist = new ArrayList<>(deduped.values());
+        QuarkusTransaction.requiringNew().run(() -> FinanceDetails.persist(entriesToPersist));
         return collectionResultMap;
     }
 

--- a/src/test/java/dk/trustworks/intranet/financeservice/jobs/FinanceLoadJobConcurrentDuplicateTest.java
+++ b/src/test/java/dk/trustworks/intranet/financeservice/jobs/FinanceLoadJobConcurrentDuplicateTest.java
@@ -1,0 +1,69 @@
+package dk.trustworks.intranet.financeservice.jobs;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLIntegrityConstraintViolationException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link FinanceLoadJob#isConcurrentDuplicate(Throwable)} — the classifier that
+ * lets the nightly economics reload tolerate a concurrent peer run (e.g. the draining OLD task
+ * re-firing the 21:00 schedule during an ECS-Express deploy bake).
+ *
+ * <p>A uq_fd_logical_key 1062 collision means a peer already inserted the rows, so the job skips
+ * that (company, period) quietly instead of alerting. A genuine, non-duplicate failure must NOT
+ * be classified as a duplicate — it has to fall through to the Slack alert. Pure logic, no DB/CDI.
+ */
+class FinanceLoadJobConcurrentDuplicateTest {
+
+    /** The exact MariaDB 1062 wrapping seen in prod: a commit-time violation surfaces deeply nested. */
+    @Test
+    void wrappedUqFdLogicalKeyCollision_isConcurrentDuplicate() {
+        SQLIntegrityConstraintViolationException sql = new SQLIntegrityConstraintViolationException(
+                "Duplicate entry '44592d3b-2be5-4b29-bfaf-4fafc60b0fa3-BOOKED-0-1001-1-2250-119' "
+                        + "for key 'uq_fd_logical_key'", "23000", 1062);
+        Throwable wrapped = new RuntimeException("ARJUNA transaction rolled back",
+                new RuntimeException("could not execute statement", sql));
+
+        assertTrue(FinanceLoadJob.isConcurrentDuplicate(wrapped));
+    }
+
+    /** Constraint name alone (locale-independent) is enough, even without the English "Duplicate entry". */
+    @Test
+    void constraintNameInMessage_isConcurrentDuplicate() {
+        Throwable e = new RuntimeException("INSERT failed on constraint uq_fd_logical_key");
+        assertTrue(FinanceLoadJob.isConcurrentDuplicate(e));
+    }
+
+    /** "Duplicate entry" (MariaDB 1062 text) is the secondary signal. */
+    @Test
+    void duplicateEntryText_isConcurrentDuplicate() {
+        Throwable e = new RuntimeException("Duplicate entry 'x' for key 'PRIMARY'");
+        assertTrue(FinanceLoadJob.isConcurrentDuplicate(e));
+    }
+
+    /** An e-conomic / network failure must still alert — not be swallowed as a duplicate. */
+    @Test
+    void unrelatedFailure_isNotConcurrentDuplicate() {
+        Throwable e = new RuntimeException("e-conomic API returned 500",
+                new IllegalStateException("read timed out"));
+        assertFalse(FinanceLoadJob.isConcurrentDuplicate(e));
+    }
+
+    /** A genuine, non-duplicate integrity error has no duplicate marker and must fall through to alert. */
+    @Test
+    void nonDuplicateIntegrityError_isNotConcurrentDuplicate() {
+        Throwable e = new SQLIntegrityConstraintViolationException(
+                "Column 'amount' cannot be null", "23000", 1048);
+        assertFalse(FinanceLoadJob.isConcurrentDuplicate(e));
+    }
+
+    /** Null messages in the cause chain must not NPE. */
+    @Test
+    void nullMessageInChain_isSafeAndNotDuplicate() {
+        Throwable e = new RuntimeException((String) null, new NullPointerException());
+        assertFalse(FinanceLoadJob.isConcurrentDuplicate(e));
+    }
+}


### PR DESCRIPTION
## Release Summary
Promotes the FinanceLoadJob / EconomicsService nightly-economics-reload hardening (PR #126) to production.

- `EconomicsService.getAllEntries` persists `finance_details` via `QuarkusTransaction.requiringNew()` so a `uq_fd_logical_key` 1062 collision rolls back only that `(company, period)` batch and tears down its persistence context — a single collision can no longer `HHH000099`-cascade across all tenants and wipe the nightly reload.
- `FinanceLoadJob.loadEconomicsData` classifies a concurrent-peer duplicate (`uq_fd_logical_key` / "Duplicate entry") and skips that `(company, period)` quietly instead of alerting; all other failures still alert.
- BE-only: no API/JSON-shape change, no Flyway migration, no frontend coupling.

## Pre-merge checklist
- [x] `./mvnw clean test-compile` BUILD SUCCESS; classifier unit test 6/6
- [x] Staging deploy (PR #126) completed successfully
- [ ] Behavioral validation deferred to prod's own ~21:00 UTC nightly run (the nightly had not yet run on staging at release time — accepted; change is defensive/low-risk)

## Follow-ups (separate tickets)
- Cross-JVM single-run guard (existing `getRunningExecutions` guard is JVM-local; prod uses in-memory JBeret repo).
- Metric/alert on skip frequency; consolidate the 4 cause-chain constraint-violation detectors into a shared `DbExceptions` util.

🤖 Generated with [Claude Code](https://claude.com/claude-code)