### PR TITLE
Upgrade intranetservices to Quarkus 3.36.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Quarkus Backend — Quick Reference
 
-Java 21, Quarkus 3.30.x, Hibernate ORM with Panache, MariaDB 10.x, Flyway migrations.
+Java 21, Quarkus 3.36.x, Hibernate ORM with Panache, MariaDB 10.x, Flyway migrations.
 
 ## REST Resource Routing
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.4</quarkus.platform.version>
+    <quarkus.platform.version>3.36.3</quarkus.platform.version>
     <skipITs>true</skipITs>
     <!--<quarkus-amazon-services.version>2.5.1</quarkus-amazon-services.version>-->
   </properties>
@@ -159,7 +159,7 @@
       <dependency>
           <groupId>io.quarkiverse.jberet</groupId>
           <artifactId>quarkus-jberet</artifactId>
-          <version>2.9.1</version>
+          <version>2.11.0</version>
       </dependency>
 
 


### PR DESCRIPTION
## Summary

Upgrades the Quarkus platform from **3.32.4 → 3.36.3**, applied via the official `quarkus update` tool. The diff is intentionally minimal: the single `quarkus.platform.version` property plus the one Quarkiverse extension the tool flagged for stream alignment.

## Starting → target version

- **From:** Quarkus `3.32.4`
- **To:** Quarkus `3.36.3` — verified as the **latest stable 3.36.x patch** on Maven Central. The only newer publication is `3.37.0.CR1`, a candidate release (not GA), so the target is unchanged.

## Update command used

```bash
./mvnw io.quarkus.platform:quarkus-maven-plugin:3.36.3:update -N -Dstream=3.36
```

Ran on JDK 21. The tool generated `target/rewrite/rewrite.yaml`; the recipe was **reviewed before applying**. Its effective changes were: bump `quarkus.platform.version` → 3.36.3 and `quarkus-jberet` → 2.11.0. It reported **"0 specific recipes"** — no source/config OpenRewrite migrations are required for the 3.32.4 → 3.36.3 path (the project already sits past the 3.28–3.32 breaking changes).

## Changes in this PR

| File | Change |
|---|---|
| `pom.xml` | `quarkus.platform.version` `3.32.4` → `3.36.3` (drives `quarkus-bom`, `quarkus-amazon-services-bom`, `quarkus-maven-plugin`, and the panache annotation-processor path — all via the single property) |
| `pom.xml` | `io.quarkiverse.jberet:quarkus-jberet` `2.9.1` → `2.11.0` — **required stream alignment** (see below) |
| `CLAUDE.md` | Quick-reference version `Quarkus 3.30.x` → `Quarkus 3.36.x` (in-repo doc fact) |

**Why jberet moved (and jpastreamer did not):** Quarkiverse extensions are not in the platform BOM and their deployment modules compile against Quarkus internals. Verified against Maven Central: jberet `2.9.1` was built against Quarkus `3.31.3`, while `2.11.0` is built against Quarkus `3.36.2` — so `2.11.0` is the 3.36-aligned release (the update tool independently recommended exactly this). `quarkus-jpastreamer` is **kept at `3.0.3.Final`**: it is already the latest published release, already runs on the newer 3.32.4 baseline, and has no newer version to move to. The `mockito-bom 5.23.0` override is **kept** (3.36.3 still manages Mockito `5.21.0`, so the override remains valid and necessary). `commons-lang3` stays explicitly pinned at `3.20.0` (a transient OpenRewrite removal of the pin was reverted).

## Release notes / migration guides reviewed

- Official update workflow: <https://quarkus.io/guides/update-quarkus>
- Migration guides: **3.33 (LTS)**, 3.34, 3.35, 3.36 (GitHub wiki). The 3.33 LTS guide states it is a direct continuation of 3.32 with *no changes requiring manual intervention* — consistent with the tool's empty recipe set.
- 3.36.3 release post + a 3.33→3.36.3 release sweep.
- **Managed-dependency deltas verified directly against the Maven Central BOM POMs** (3.32.4 vs 3.36.3):
  - `hibernate-core` 7.2.6 → 7.3.7 (minor — already on Hibernate ORM 7.x in baseline, **not** a 6→7 jump)
  - `opentelemetry-api` 1.57.0 → 1.60.1 · `mariadb-java-client` 3.5.7 → 3.5.8 · `jackson-databind` 2.21.1 → 2.21.4 · `micrometer-core` 1.16.3 → 1.16.6 · `narayana-jta` 7.3.3 → 7.3.4 · `agroal-pool` 3.0 → 3.2 · `vertx-core` 4.5.25 → 4.5.28
  - Unchanged: `hibernate-validator` 9.1.0, `mockito-core` 5.21.0, `smallrye-jwt` 4.6.3, `flyway` 12.0.0

## Manual migration changes

None required beyond the jberet alignment. Verified by targeted grep that the breaking changes from the 3.33–3.36 range do not apply here:

- No `quarkus.https.port` / `quarkus.https.test-port` / `System.getProperty("quarkus.http.port")` usage.
- No references to the misspelled OTel `...tracing.intrumentation` package.
- No `@PermissionChecker` (the app uses `@RolesAllowed` scope-based authz), so the security-vs-transaction interceptor-ordering change is irrelevant.
- JUnit test artifacts already use the renamed `quarkus-junit` / `quarkus-junit-mockito`.
- The named `health` datasource is a datasource only (not a Hibernate ORM persistence unit), so the inactive-PU fail-fast change does not apply.
- Agroal default pool max-size (20→50) is moot — the datasources set explicit `max-size` (64 / 4).
- The deprecated `quarkus.datasource.jdbc.enable-metrics` in `application.yml` is a **pre-existing** 3.32.4 state (the app builds with it today), not introduced or changed by this upgrade; left untouched to keep the PR scoped.

## Validation (results)

Run on **JDK 21 (Corretto 21.0.10)** — matching CI (`temurin` 21) and the `Dockerfile.jvm` runtime base.

| Command | Result |
|---|---|
| `./mvnw -version` | Apache Maven 3.8.6, Java 21 |
| `./mvnw clean test` | **1225 tests run.** Failure set is identical to the pre-upgrade baseline **except** one pre-existing flaky test (see Risks). No genuine new failures. |
| `./mvnw clean package -DskipTests` | **BUILD SUCCESS** — fast-jar `target/quarkus-app/quarkus-run.jar` produced (augmentation works on 3.36.3). |
| `./mvnw dependency:tree -Dincludes=io.quarkus,io.quarkus.platform,io.quarkiverse.amazonservices,software.amazon.awssdk` | All `io.quarkus:quarkus-*` → 3.36.3; `quarkus-jberet` 2.11.0; `quarkus-jpastreamer` 3.0.3.Final; AWS SDK v2 2.44.6; `quarkus-amazon-s3` 3.19.0 |
| Build-log scan | No new deprecation/migration warnings. |

**DB blocker (documented):** `@QuarkusTest` tests that boot the application require a MariaDB on `127.0.0.1:3306`, which is unavailable in this build environment (mirroring CI, which deploys with `-DskipTests`). These error identically *before and after* the upgrade (`Failed to start quarkus`) — environmental, not upgrade-related. The 27 test **errors** and the non-flaky failures are byte-for-byte the same in the baseline and post-upgrade runs.

## Security review (OWASP-minded)

**Verdict: safe to merge.** No Critical/High/Medium findings.

- The 2-line `pom.xml` change contains no secrets/credentials.
- **Net security-positive:** moves Vert.x (4.5.25→4.5.28), Netty, Hibernate, Jackson, etc. forward — the 3.32→3.36 range carries HTTP-layer CVE fixes (HTTP/2 CONTINUATION flood, HTTP/1.1 request smuggling, a Vert.x static-handler cache issue).
- No authn/authz regression: `smallrye-jwt` unchanged (4.6.3); the Azure AD OIDC + `@RolesAllowed` scope model (`ScopeContext`, `UserScopeResponseFilter`, `AdminScopeAugmentor`) is untouched. Quarkus 3.36's OIDC/keystore additions are additive.
- Info/Low only: pre-existing standalone pinned libs are unchanged and out of scope for this PR (`aws-java-sdk-ses` 1.11.858 [AWS SDK v1, EOL], `xalan`/`xercesImpl`/`tika-core` 1.27) — flagged for separate hygiene, not addressed here.

## Remaining risks / blockers

1. **Pre-existing flaky test — `EconomicsCustomerSyncServiceStatusForTest`** (`ok_*`, `pending_*`, `abandoned_*`). It asserts on `rows.get(0)` from `statusFor()`, which iterates `AgreementDefaultsRegistry.TEMPLATES.keySet()` — a `Map.of(...)` of 3 companies whose iteration order is **randomized per JVM** (JDK behavior since 9). The test only stubs lookups for one company, so it passes only when that company sorts first (~⅓ of runs). **Not caused by this upgrade** — proven: (a) 6 reruns on the *unchanged* 3.36.3 tree flapped `1,1,1,4,4,1` failures; (b) a Quarkus-free `jshell` probe of the exact 3 keys shows `Map.of` keySet order varies per JVM. The test source and service are unchanged by this PR. Left unfixed to keep this PR scoped to the upgrade — **recommend a separate fix** (stub all three companies, or make `listConfiguredCompanies()` order deterministic).
2. **DB-backed verification deferred to staging:** `@QuarkusTest` tests need a real DB (unavailable here). Staging has one — please confirm a green app boot + Flyway migrate there.
3. **Low-risk minor bumps to eyeball on staging:** Hibernate ORM 7.2→7.3 (Panache query semantics) and OpenTelemetry 1.57→1.60 (trace attribute names on dashboards). No code changes were needed; behavior should be sanity-checked once.
4. **Out-of-repo docs:** the monorepo docs `docs/finalized/shared/architecture.md` and `docs/finalized/infrastructure/github-integration.md` still read "Quarkus 3.30.x". They live outside the `intranetservices` repo, so they cannot be updated in this PR — flagged for a separate refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
