### PR TITLE
Release to prod: Quarkus 3.36.3 + FinanceLoadJob duplicate-detection narrowing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Quarkus Backend — Quick Reference
 
-Java 21, Quarkus 3.30.x, Hibernate ORM with Panache, MariaDB 10.x, Flyway migrations.
+Java 21, Quarkus 3.36.x, Hibernate ORM with Panache, MariaDB 10.x, Flyway migrations.
 
 ## REST Resource Routing
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.4</quarkus.platform.version>
+    <quarkus.platform.version>3.36.3</quarkus.platform.version>
     <skipITs>true</skipITs>
     <!--<quarkus-amazon-services.version>2.5.1</quarkus-amazon-services.version>-->
   </properties>
@@ -159,7 +159,7 @@
       <dependency>
           <groupId>io.quarkiverse.jberet</groupId>
           <artifactId>quarkus-jberet</artifactId>
-          <version>2.9.1</version>
+          <version>2.11.0</version>
       </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.32.2</quarkus.platform.version>
+    <quarkus.platform.version>3.32.4</quarkus.platform.version>
     <skipITs>true</skipITs>
     <!--<quarkus-amazon-services.version>2.5.1</quarkus-amazon-services.version>-->
   </properties>

--- a/src/main/java/dk/trustworks/intranet/financeservice/jobs/FinanceLoadJob.java
+++ b/src/main/java/dk/trustworks/intranet/financeservice/jobs/FinanceLoadJob.java
@@ -156,19 +156,17 @@ public class FinanceLoadJob {
      * is inspected.
      *
      * <p>Detection is by message, anchored on the constraint name {@code uq_fd_logical_key}
-     * (a locale-independent DB object name) with MariaDB's "Duplicate entry" (error 1062)
-     * as a secondary signal. This is deliberately narrow: a genuine, non-duplicate
-     * integrity error (NOT NULL, FK, …) carries neither marker, so it falls through to the
-     * Slack alert instead of being silently skipped on every run. A real duplicate means
-     * the rows are already present, so the caller skips this (company, period) quietly
-     * rather than alerting and re-deriving — see {@link #loadEconomicsData()}.
+     * (a locale-independent DB object name). This is deliberately narrow: a genuine,
+     * unrelated integrity error (NOT NULL, FK, another unique key, …) does not carry this
+     * marker, so it falls through to the Slack alert instead of being silently skipped on
+     * every run. A real duplicate means the rows are already present, so the caller skips
+     * this (company, period) quietly rather than alerting and re-deriving — see
+     * {@link #loadEconomicsData()}.
      */
     static boolean isConcurrentDuplicate(Throwable e) {
         for (Throwable t : ExceptionUtils.getThrowableList(e)) {
             String msg = t.getMessage();
-            if (msg != null
-                    && (msg.contains("uq_fd_logical_key")
-                        || msg.contains("Duplicate entry"))) {
+            if (msg != null && msg.contains("uq_fd_logical_key")) {
                 return true;
             }
         }

--- a/src/test/java/dk/trustworks/intranet/financeservice/jobs/FinanceLoadJobConcurrentDuplicateTest.java
+++ b/src/test/java/dk/trustworks/intranet/financeservice/jobs/FinanceLoadJobConcurrentDuplicateTest.java
@@ -37,10 +37,17 @@ class FinanceLoadJobConcurrentDuplicateTest {
         assertTrue(FinanceLoadJob.isConcurrentDuplicate(e));
     }
 
-    /** "Duplicate entry" (MariaDB 1062 text) is the secondary signal. */
+    /** The duplicate must be for the finance_details logical key, not any arbitrary key. */
     @Test
-    void duplicateEntryText_isConcurrentDuplicate() {
+    void duplicateEntryForDifferentKey_isNotConcurrentDuplicate() {
         Throwable e = new RuntimeException("Duplicate entry 'x' for key 'PRIMARY'");
+        assertFalse(FinanceLoadJob.isConcurrentDuplicate(e));
+    }
+
+    /** MariaDB's 1062 text is accepted when it names the finance_details logical key. */
+    @Test
+    void duplicateEntryForLogicalKey_isConcurrentDuplicate() {
+        Throwable e = new RuntimeException("Duplicate entry 'x' for key 'uq_fd_logical_key'");
         assertTrue(FinanceLoadJob.isConcurrentDuplicate(e));
     }
 


### PR DESCRIPTION
## Promotion: `staging` → `master` (production)

Promotes the current `staging` head (`df09c6f3`) to production. The delta over `master` is two functional changes:

### 1. Quarkus 3.32.2 → 3.36.3  (`cf5581f1`, PR #128)
- `quarkus.platform.version` → **3.36.3** (drives quarkus-bom, quarkus-amazon-services-bom, quarkus-maven-plugin); `quarkus-jberet` 2.9.1 → **2.11.0** (3.36 stream alignment).
- Applied via the official `quarkus update` tool (0 source/config recipes needed). OWASP security review: **safe / net-positive** (advances Netty/Vert.x/Hibernate/Jackson past HTTP-layer CVEs; no secrets; no authz/JWT/OIDC regression). Build/test verified on JDK 21.

### 2. `FinanceLoadJob.isConcurrentDuplicate` narrowing  (`15bcbc7a`)
- Narrows concurrent-duplicate detection to match **only** the `uq_fd_logical_key` constraint name, dropping the secondary `"Duplicate entry"` message check (+ test update). Refines the PR #127 incident fix.

### Staging verification (`df09c6f3`, image-verified)
- ECS staging PRIMARY task-def `:267` image = `tw-quarkus-staging:df09c6f3…`; `rolloutState=COMPLETED`; running=desired=1 (clean cutover, not a rollback).
- App booted clean: **`started in 33.070s`** ⇒ Flyway `migrate-at-start` passed against the real staging MariaDB.
- All 33 features installed (incl. `jberet`, `jpastreamer`, `flyway`, `hibernate-orm`, full `rest` + `resteasy-client` stack); `/health` → 200; **JBeret 2.11.0 jobs running & tracking** at runtime; no boot errors.

### Notes
- No Flyway migration in this delta — no schema/frontend coupling.
- Known pre-existing flaky unit test `EconomicsCustomerSyncServiceStatusForTest` (`Map.of` iteration order; not Quarkus-related) — deploy does not gate on tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
