### PR TITLE
feat(perf): backend performance observability (CloudWatch EMF)

### DIFF
--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/book/EconomicsBookingApiClient.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/book/EconomicsBookingApiClient.java
@@ -2,11 +2,13 @@ package dk.trustworks.intranet.aggregates.invoice.economics.book;
 
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import java.io.InputStream;
 
 @RegisterRestClient(configKey = "economics-legacy-rest")
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public interface EconomicsBookingApiClient {

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/customer/EconomicsContactApiClient.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/customer/EconomicsContactApiClient.java
@@ -3,6 +3,7 @@ package dk.trustworks.intranet.aggregates.invoice.economics.customer;
 import dk.trustworks.intranet.aggregates.invoice.economics.CreatedResult;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 /**
@@ -22,6 +23,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
  * SPEC-INV-001 §3.3.2, §6.1, §6.4.
  */
 @RegisterRestClient(configKey = "economics-customers-api")
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public interface EconomicsContactApiClient {

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/customer/EconomicsCustomerApiClient.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/customer/EconomicsCustomerApiClient.java
@@ -3,6 +3,7 @@ package dk.trustworks.intranet.aggregates.invoice.economics.customer;
 import dk.trustworks.intranet.aggregates.invoice.economics.CustomerCreatedResult;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 /**
@@ -18,6 +19,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
  * SPEC-INV-001 §6.1, §6.3.
  */
 @RegisterRestClient(configKey = "economics-customers-api")
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public interface EconomicsCustomerApiClient {

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/draft/EconomicsDraftInvoiceApiClient.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/draft/EconomicsDraftInvoiceApiClient.java
@@ -19,6 +19,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
  */
 @RegisterRestClient(configKey = "economics-q2c-api")
 @RegisterProvider(EconomicsDraftErrorMapper.class)
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public interface EconomicsDraftInvoiceApiClient {

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSuppliersApiClient.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/economics/supplier/EconomicsSuppliersApiClient.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 /**
@@ -19,6 +20,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
  * supplier number in a debtor company's e-conomic agreement by CVR.
  */
 @RegisterRestClient(configKey = "economics-legacy-rest")
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 @Produces(MediaType.APPLICATION_JSON)
 public interface EconomicsSuppliersApiClient {
 

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/network/CurrencyAPI.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/network/CurrencyAPI.java
@@ -5,12 +5,14 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("")
 @RegisterRestClient
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 public interface CurrencyAPI {
 
     @GET

--- a/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestrator.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/invoice/services/InvoiceFinalizationOrchestrator.java
@@ -16,6 +16,8 @@ import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceStatus;
 import dk.trustworks.intranet.aggregates.invoice.model.enums.InvoiceType;
 import dk.trustworks.intranet.expenseservice.services.EconomicsInvoiceService;
 import dk.trustworks.intranet.model.Company;
+import dk.trustworks.intranet.perf.PerfMetrics;
+import dk.trustworks.intranet.perf.PerfTimed;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -94,6 +96,9 @@ public class InvoiceFinalizationOrchestrator {
     @Inject
     EanPrerequisiteChecker eanChecker;
 
+    @Inject
+    PerfMetrics perfMetrics;
+
     /**
      * Kill switch for internal-invoice e-conomic writes. Staging sets this {@code false}
      * so it can never create drafts or book invoices in the shared production e-conomic
@@ -120,6 +125,7 @@ public class InvoiceFinalizationOrchestrator {
      * @param invoiceUuid the invoice to create a draft for.
      * @return the updated invoice entity.
      */
+    @PerfTimed("invoice.createDraft")
     @Transactional
     public Invoice createDraft(String invoiceUuid) {
         if (!invoiceUploadEnabled) {
@@ -254,6 +260,7 @@ public class InvoiceFinalizationOrchestrator {
      * @param sendBy      optional delivery method — null | "ean" | "Email".
      * @return the updated invoice entity.
      */
+    @PerfTimed("invoice.book")
     @Transactional
     public Invoice bookDraft(String invoiceUuid, String sendBy) {
         if (!invoiceUploadEnabled) {
@@ -402,6 +409,8 @@ public class InvoiceFinalizationOrchestrator {
                     + "setting PARTIALLY_UPLOADED for retry", inv.getUuid());
             inv.setEconomicsStatus(EconomicsInvoiceStatus.PARTIALLY_UPLOADED);
             invoices.persist(inv);
+            perfMetrics.emitCount("InvoiceFinalizePartialUpload", 1,
+                    java.util.Map.of(), java.util.Map.of());
         }
     }
 

--- a/src/main/java/dk/trustworks/intranet/apis/openai/OpenAIClient.java
+++ b/src/main/java/dk/trustworks/intranet/apis/openai/OpenAIClient.java
@@ -7,10 +7,12 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 @Path("/v1")
 @RegisterRestClient(configKey = "openai-api")
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 public interface OpenAIClient {
 
     @POST

--- a/src/main/java/dk/trustworks/intranet/batch/monitoring/JobMonitoringListener.java
+++ b/src/main/java/dk/trustworks/intranet/batch/monitoring/JobMonitoringListener.java
@@ -1,6 +1,7 @@
 package dk.trustworks.intranet.batch.monitoring;
 
 import dk.trustworks.intranet.aggregates.users.services.UserService;
+import dk.trustworks.intranet.perf.PerfMetrics;
 import jakarta.batch.api.listener.JobListener;
 import jakarta.batch.operations.JobOperator;
 import jakarta.batch.runtime.BatchStatus;
@@ -14,8 +15,10 @@ import lombok.extern.jbosslog.JBossLog;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 @JBossLog
 @Dependent
@@ -28,10 +31,15 @@ public class JobMonitoringListener implements JobListener {
     @Inject BatchJobTrackingService trackingService;
     @Inject UserService userService;
     @Inject BatchExceptionRegistry exceptionRegistry;
+    @Inject PerfMetrics perfMetrics;
+
+    /** executionId -> start nanos, used to compute job duration for perf metrics. */
+    private static final Map<Long, Long> PERF_START_NANOS = new ConcurrentHashMap<>();
 
     @Override
     @Transactional(Transactional.TxType.REQUIRES_NEW)
     public void beforeJob() {
+        PERF_START_NANOS.put(jobContext.getExecutionId(), System.nanoTime());
         long executionId = jobContext.getExecutionId();
         String jobName = jobContext.getJobName();
         log.infof("[JOB-MONITOR] beforeJob() called for job '%s' (execution %d)", jobName, executionId);
@@ -129,8 +137,18 @@ public class JobMonitoringListener implements JobListener {
             exceptionRegistry.clearException(executionId);
             log.debugf("[JOB-MONITOR] Cleared exception registry for execution %d", executionId);
         } catch (Exception e) {
-            log.warnf("[JOB-MONITOR] Failed to clear exception registry for execution %d: %s", 
+            log.warnf("[JOB-MONITOR] Failed to clear exception registry for execution %d: %s",
                      executionId, e.getMessage());
+        }
+
+        try {
+            Long startNanos = PERF_START_NANOS.remove(executionId);
+            if (startNanos != null) {
+                double durationMs = (System.nanoTime() - startNanos) / 1_000_000.0;
+                emitJobPerf(jobName, status, executionId, durationMs);
+            }
+        } catch (Exception e) {
+            log.warnf("perf emit failed for job %s: %s", jobName, e.getMessage());
         }
     }
 
@@ -144,5 +162,24 @@ public class JobMonitoringListener implements JobListener {
             log.warnf("[JOB-MONITOR] Failed to get user count: %s", e.getMessage());
             return 0;
         }
+    }
+
+    void emitJobPerf(String jobName, BatchStatus status,
+                     long executionId, double durationMs) {
+        String outcome;
+        if (status == null) {
+            outcome = "other";
+        } else {
+            switch (status) {
+                case COMPLETED -> outcome = "success";
+                case FAILED -> outcome = "failed";
+                case STOPPED -> outcome = "stopped";
+                default -> outcome = "other";
+            }
+        }
+        perfMetrics.emitTimer("BatchJobDurationMs", durationMs,
+                Map.of("job", jobName), Map.of("executionId", executionId));
+        perfMetrics.emitCount("BatchJobRuns", 1,
+                Map.of("job", jobName, "outcome", outcome), Map.of("executionId", executionId));
     }
 }

--- a/src/main/java/dk/trustworks/intranet/cvtool/client/CvToolAuthClient.java
+++ b/src/main/java/dk/trustworks/intranet/cvtool/client/CvToolAuthClient.java
@@ -18,6 +18,7 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 @Path("/auth")
 @RegisterRestClient(configKey = "cvtool")
 @RegisterProvider(ResteasyJackson2Provider.class)
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 public interface CvToolAuthClient {
 
     @POST

--- a/src/main/java/dk/trustworks/intranet/cvtool/client/CvToolClient.java
+++ b/src/main/java/dk/trustworks/intranet/cvtool/client/CvToolClient.java
@@ -21,6 +21,7 @@ import java.util.List;
 @Path("/cv")
 @RegisterRestClient(configKey = "cvtool")
 @RegisterProvider(ResteasyJackson2Provider.class)
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 public interface CvToolClient {
 
     @GET

--- a/src/main/java/dk/trustworks/intranet/dao/crm/client/CvrApiClient.java
+++ b/src/main/java/dk/trustworks/intranet/dao/crm/client/CvrApiClient.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 /**
@@ -23,6 +24,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 @Path("/api")
 @RegisterRestClient(configKey = "virkdata")
 @RegisterClientHeaders(VirkdataHeadersFactory.class)
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 public interface CvrApiClient {
 
     /**

--- a/src/main/java/dk/trustworks/intranet/expenseservice/remote/EconomicsAPI.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/remote/EconomicsAPI.java
@@ -12,6 +12,7 @@ import static jakarta.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
 
 @RegisterRestClient
 @RegisterProvider(EconomicsErrorMapper.class)
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 @Produces("application/json")
 @Path("/")
 public interface EconomicsAPI extends AutoCloseable {

--- a/src/main/java/dk/trustworks/intranet/expenseservice/remote/EconomicsAPIAccount.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/remote/EconomicsAPIAccount.java
@@ -9,6 +9,7 @@ import dk.trustworks.intranet.expenseservice.remote.EconomicsErrorMapper;
 @Path("/accounts")
 @RegisterRestClient
 @RegisterProvider(EconomicsErrorMapper.class)
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 @Produces("application/json")
 @Consumes("application/json")
 public interface EconomicsAPIAccount extends AutoCloseable {

--- a/src/main/java/dk/trustworks/intranet/expenseservice/remote/EconomicsJournalsAPI.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/remote/EconomicsJournalsAPI.java
@@ -17,6 +17,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
  */
 @RegisterRestClient(configKey = "economics-journals-api")
 @RegisterProvider(EconomicsErrorMapper.class)
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/")
 public interface EconomicsJournalsAPI extends AutoCloseable {

--- a/src/main/java/dk/trustworks/intranet/financeservice/remote/EconomicsPagingAPI.java
+++ b/src/main/java/dk/trustworks/intranet/financeservice/remote/EconomicsPagingAPI.java
@@ -1,11 +1,13 @@
 package dk.trustworks.intranet.financeservice.remote;
 
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Response;
 
 @RegisterRestClient
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 @Produces("application/json")
 @Consumes("application/json")
 public interface EconomicsPagingAPI extends AutoCloseable {

--- a/src/main/java/dk/trustworks/intranet/perf/InfraMetricsEmitter.java
+++ b/src/main/java/dk/trustworks/intranet/perf/InfraMetricsEmitter.java
@@ -1,0 +1,70 @@
+package dk.trustworks.intranet.perf;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import lombok.extern.jbosslog.JBossLog;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Emits a single EMF snapshot of DB-pool + JVM-heap gauges every 60s. Avoids
+ * per-request logging while still giving live infrastructure health.
+ */
+@JBossLog
+@ApplicationScoped
+public class InfraMetricsEmitter {
+
+    /** Agroal Micrometer gauge name -> our metric name. Verify names via /q/metrics in dev. */
+    private static final Map<String, String> POOL_GAUGES = Map.of(
+            "agroal.active.count", "DbPoolActive",
+            "agroal.available.count", "DbPoolAvailable",
+            "agroal.awaiting.count", "DbPoolAwaiting",
+            "agroal.max.used.count", "DbPoolMaxUsed");
+
+    @Inject
+    MeterRegistry registry;
+
+    @Inject
+    PerfMetrics perfMetrics;
+
+    @Scheduled(every = "60s", identity = "perf-infra-metrics",
+            concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
+    void emit() {
+        try {
+            long heapUsed = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+            List<PerfMetrics.Metric> metrics = toMetrics(heapUsed, readPoolGauges());
+            perfMetrics.emit(metrics, Map.of(), Map.of());
+        } catch (Exception e) {
+            log.warnf("perf-infra-metrics emit failed: %s", e.getMessage());
+        }
+    }
+
+    /** Reads the live Agroal gauges from the registry (integration path). */
+    private Map<String, Double> readPoolGauges() {
+        Map<String, Double> out = new LinkedHashMap<>();
+        POOL_GAUGES.forEach((meterName, metricName) -> {
+            Gauge g = registry.find(meterName).gauge();
+            out.put(metricName, g != null ? g.value() : Double.NaN);
+        });
+        return out;
+    }
+
+    /** Pure builder — unit tested. */
+    List<PerfMetrics.Metric> toMetrics(long heapUsedBytes, Map<String, Double> poolGauges) {
+        List<PerfMetrics.Metric> out = new ArrayList<>();
+        out.add(new PerfMetrics.Metric("JvmHeapUsedBytes", "Bytes", heapUsedBytes));
+        poolGauges.forEach((name, value) -> {
+            if (value != null && !Double.isNaN(value)) {
+                out.add(new PerfMetrics.Metric(name, "Count", value));
+            }
+        });
+        return out;
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/perf/PerfMetrics.java
+++ b/src/main/java/dk/trustworks/intranet/perf/PerfMetrics.java
@@ -1,0 +1,94 @@
+package dk.trustworks.intranet.perf;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Emits CloudWatch Embedded Metric Format (EMF) lines on a dedicated raw-format
+ * logger. One emission feeds both CloudWatch Metrics (auto-extracted) and Logs
+ * Insights. Carries only metadata — never tokens, payloads, or PII as dimensions.
+ */
+@ApplicationScoped
+public class PerfMetrics {
+
+    public static final String NAMESPACE = "Trustworks/Perf";
+
+    /** EMF lines go here; application.yml binds this category to a raw %m%n handler. */
+    static final Logger PERF_LOG = Logger.getLogger("dk.trustworks.perf");
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @ConfigProperty(name = "dk.trustworks.perf.metrics.enabled", defaultValue = "true")
+    boolean enabled;
+
+    @ConfigProperty(name = "dk.trustworks.perf.env", defaultValue = "production")
+    String env;
+
+    public record Metric(String name, String unit, double value) {}
+
+    public void emitTimer(String metricName, double valueMs,
+                          Map<String, String> dimensions, Map<String, Object> fields) {
+        emit(List.of(new Metric(metricName, "Milliseconds", valueMs)), dimensions, fields);
+    }
+
+    public void emitCount(String metricName, double count,
+                          Map<String, String> dimensions, Map<String, Object> fields) {
+        emit(List.of(new Metric(metricName, "Count", count)), dimensions, fields);
+    }
+
+    /** Emit several metrics sharing one dimension set as a single EMF line. */
+    public void emit(List<Metric> metrics, Map<String, String> dimensions, Map<String, Object> fields) {
+        if (!enabled || metrics == null || metrics.isEmpty()) return;
+        Map<String, String> dims = new LinkedHashMap<>();
+        dims.put("env", env);
+        if (dimensions != null) dims.putAll(dimensions);
+        write(buildEmf(NAMESPACE, metrics, dims, fields, System.currentTimeMillis()));
+    }
+
+    /** Package-private seam so unit tests can verify emission without parsing logs. */
+    void write(String emfLine) {
+        PERF_LOG.info(emfLine);
+    }
+
+    /** Pure, deterministic EMF serializer — the unit-tested core. */
+    String buildEmf(String namespace, List<Metric> metrics,
+                    Map<String, String> dimensions, Map<String, Object> fields, long timestampMs) {
+        ObjectNode root = MAPPER.createObjectNode();
+        ObjectNode aws = root.putObject("_aws");
+        aws.put("Timestamp", timestampMs);
+        ArrayNode cwMetrics = aws.putArray("CloudWatchMetrics");
+        ObjectNode directive = cwMetrics.addObject();
+        directive.put("Namespace", namespace);
+        ArrayNode dimsArray = directive.putArray("Dimensions");
+        ArrayNode dimSet = dimsArray.addArray();
+        for (String key : dimensions.keySet()) dimSet.add(key);
+        ArrayNode metricDefs = directive.putArray("Metrics");
+        for (Metric m : metrics) {
+            ObjectNode md = metricDefs.addObject();
+            md.put("Name", m.name());
+            md.put("Unit", m.unit());
+        }
+        dimensions.forEach(root::put);
+        for (Metric m : metrics) root.put(m.name(), m.value());
+        if (fields != null) fields.forEach((k, v) -> putField(root, k, v));
+        try {
+            return MAPPER.writeValueAsString(root);
+        } catch (Exception e) {
+            return "{\"_perfError\":\"emf-serialize-failed\"}";
+        }
+    }
+
+    private static void putField(ObjectNode node, String key, Object value) {
+        if (value == null) { node.putNull(key); return; }
+        if (value instanceof Number n) node.put(key, n.doubleValue());
+        else if (value instanceof Boolean b) node.put(key, b);
+        else node.put(key, String.valueOf(value));
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/perf/PerfRestClientFilter.java
+++ b/src/main/java/dk/trustworks/intranet/perf/PerfRestClientFilter.java
@@ -1,0 +1,89 @@
+package dk.trustworks.intranet.perf;
+
+import io.quarkus.arc.Arc;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.client.ClientResponseContext;
+import jakarta.ws.rs.client.ClientResponseFilter;
+
+import java.net.URI;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Times outbound REST-client calls and emits ExternalApiDurationMs / ExternalApiCount.
+ * Registered per-client via @RegisterProvider (no global @Provider client filters exist
+ * in this codebase). Emits only metadata — never headers, bodies, or tokens.
+ */
+public class PerfRestClientFilter implements ClientRequestFilter, ClientResponseFilter {
+
+    private static final String START_PROP = "dk.trustworks.perf.start-nanos";
+
+    @Override
+    public void filter(ClientRequestContext requestContext) {
+        requestContext.setProperty(START_PROP, System.nanoTime());
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
+        Object start = requestContext.getProperty(START_PROP);
+        if (!(start instanceof Long startNanos)) return;
+        double ms = (System.nanoTime() - startNanos) / 1_000_000.0;
+
+        URI uri = requestContext.getUri();
+        String api = apiLabel(uri);
+        String operation = operationLabel(requestContext.getMethod(), uri);
+        int status = responseContext.getStatus();
+
+        Map<String, String> durDims = new HashMap<>();
+        durDims.put("api", api);
+        durDims.put("operation", operation);
+        Map<String, String> countDims = new HashMap<>();
+        countDims.put("api", api);
+        countDims.put("httpStatusClass", statusClass(status));
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("method", requestContext.getMethod());
+        fields.put("httpStatus", status);
+
+        PerfMetrics perf = perfMetrics();
+        if (perf == null) return; // CDI not available (e.g. unit-test path)
+        perf.emitTimer("ExternalApiDurationMs", ms, durDims, fields);
+        perf.emitCount("ExternalApiCount", 1, countDims, fields);
+    }
+
+    private PerfMetrics perfMetrics() {
+        var handle = Arc.container() != null ? Arc.container().instance(PerfMetrics.class) : null;
+        return handle != null ? handle.get() : null;
+    }
+
+    static String apiLabel(URI uri) {
+        String host = uri.getHost() == null ? "unknown" : uri.getHost();
+        if (host.contains("e-conomic")) return "economic";
+        if (host.contains("graph.microsoft")) return "graph";
+        if (host.contains("openai")) return "openai";
+        if (host.contains("nextsign")) return "nextsign";
+        if (host.contains("virkdata")) return "cvr";
+        if (host.contains("cvtool")) return "cvtool";
+        return host;
+    }
+
+    /** Last up-to-3 path segments, numeric/long ids collapsed to {id}, bounded for cardinality. */
+    static String operationLabel(String method, URI uri) {
+        String path = uri.getPath() == null ? "" : uri.getPath();
+        Deque<String> tail = new ArrayDeque<>();
+        String[] segs = path.split("/");
+        for (int i = segs.length - 1; i >= 0 && tail.size() < 3; i--) {
+            String s = segs[i];
+            if (s.isBlank()) continue;
+            String norm = (s.matches("\\d+") || s.length() > 24) ? "{id}" : s;
+            tail.addFirst(norm);
+        }
+        return method + (tail.isEmpty() ? "" : " " + String.join(" ", tail));
+    }
+
+    static String statusClass(int status) {
+        return (status / 100) + "xx";
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/perf/PerfRestClientFilter.java
+++ b/src/main/java/dk/trustworks/intranet/perf/PerfRestClientFilter.java
@@ -77,7 +77,7 @@ public class PerfRestClientFilter implements ClientRequestFilter, ClientResponse
         for (int i = segs.length - 1; i >= 0 && tail.size() < 3; i--) {
             String s = segs[i];
             if (s.isBlank()) continue;
-            String norm = (s.matches("\\d+") || s.length() > 24) ? "{id}" : s;
+            String norm = (s.matches(".*\\d.*") || s.length() > 24) ? "{id}" : s;
             tail.addFirst(norm);
         }
         return method + (tail.isEmpty() ? "" : " " + String.join(" ", tail));

--- a/src/main/java/dk/trustworks/intranet/perf/PerfRestClientFilter.java
+++ b/src/main/java/dk/trustworks/intranet/perf/PerfRestClientFilter.java
@@ -26,6 +26,8 @@ public class PerfRestClientFilter implements ClientRequestFilter, ClientResponse
         requestContext.setProperty(START_PROP, System.nanoTime());
     }
 
+    // SECURITY: emit only path + method + status. NEVER read uri.getQuery()/getRawQuery()
+    // (query strings carry secrets like ?apikey=) or request headers/body/tokens.
     @Override
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) {
         Object start = requestContext.getProperty(START_PROP);

--- a/src/main/java/dk/trustworks/intranet/perf/PerfTimed.java
+++ b/src/main/java/dk/trustworks/intranet/perf/PerfTimed.java
@@ -1,0 +1,18 @@
+package dk.trustworks.intranet.perf;
+
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Times the annotated method and emits OperationDurationMs / OperationCount. */
+@InterceptorBinding
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PerfTimed {
+    /** Phase label used as the 'phase' dimension (must be a bounded value). */
+    @Nonbinding String value();
+}

--- a/src/main/java/dk/trustworks/intranet/perf/PerfTimedInterceptor.java
+++ b/src/main/java/dk/trustworks/intranet/perf/PerfTimedInterceptor.java
@@ -1,0 +1,54 @@
+package dk.trustworks.intranet.perf;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@PerfTimed("")
+@Interceptor
+@Priority(Interceptor.Priority.APPLICATION + 50)
+public class PerfTimedInterceptor {
+
+    @Inject
+    PerfMetrics perfMetrics;
+
+    @AroundInvoke
+    Object time(InvocationContext ctx) throws Exception {
+        String phase = phaseOf(ctx);
+        long start = System.nanoTime();
+        try {
+            Object result = ctx.proceed();
+            emit(phase, start, "success", null);
+            return result;
+        } catch (Exception e) {
+            emit(phase, start, "error", e.getClass().getSimpleName());
+            throw e;
+        } catch (Error e) {
+            emit(phase, start, "error", e.getClass().getSimpleName());
+            throw e;
+        }
+    }
+
+    private String phaseOf(InvocationContext ctx) {
+        PerfTimed ann = ctx.getMethod() != null ? ctx.getMethod().getAnnotation(PerfTimed.class) : null;
+        if (ann != null && ann.value() != null && !ann.value().isBlank()) {
+            return ann.value();
+        }
+        return ctx.getMethod() != null ? ctx.getMethod().getName() : "unknown";
+    }
+
+    private void emit(String phase, long startNanos, String outcome, String errorType) {
+        double ms = (System.nanoTime() - startNanos) / 1_000_000.0;
+        Map<String, String> durDims = Map.of("phase", phase);
+        Map<String, String> countDims = Map.of("phase", phase, "outcome", outcome);
+        Map<String, Object> fields = new HashMap<>();
+        if (errorType != null) fields.put("errorType", errorType);
+        perfMetrics.emitTimer("OperationDurationMs", ms, durDims, fields);
+        perfMetrics.emitCount("OperationCount", 1, countDims, fields);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/perf/PerformanceDigestBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/perf/PerformanceDigestBatchlet.java
@@ -8,9 +8,17 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import lombok.extern.jbosslog.JBossLog;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.apache.ProxyConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.*;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +53,27 @@ public class PerformanceDigestBatchlet {
     @ConfigProperty(name = "dk.trustworks.perf.digest.regression-factor", defaultValue = "1.5")
     double regressionFactor;
 
+    @ConfigProperty(name = "dk.trustworks.perf.log-group", defaultValue = "/ecs/tw-quarkus-production")
+    String logGroup;
+
+    private volatile CloudWatchLogsClient logsClient;
+
+    private CloudWatchLogsClient logsClient() {
+        if (logsClient == null) {
+            synchronized (this) {
+                if (logsClient == null) {
+                    ProxyConfiguration.Builder proxy = ProxyConfiguration.builder();
+                    ApacheHttpClient.Builder http = ApacheHttpClient.builder().proxyConfiguration(proxy.build());
+                    logsClient = CloudWatchLogsClient.builder()
+                            .region(Region.EU_WEST_1)
+                            .httpClientBuilder(http)
+                            .build();
+                }
+            }
+        }
+        return logsClient;
+    }
+
     @Scheduled(cron = "0 30 6 * * ?", identity = "performance-digest")
     void scheduledRun() {
         if (!digestEnabled) {
@@ -63,7 +92,21 @@ public class PerformanceDigestBatchlet {
         StringBuilder msg = new StringBuilder();
         msg.append(":bar_chart: *Performance digest* — last ").append(recentWindowHours).append("h\n\n");
         msg.append(batchSection(now));
-        // Task 10 appends invoice/external/infra sections from Logs Insights here.
+
+        LocalDateTime to = now;
+        LocalDateTime from = now.minusHours(recentWindowHours);
+        String apiQuery =
+                "filter ispresent(ExternalApiDurationMs) " +
+                "| stats pct(ExternalApiDurationMs, 95) as p95 by api " +
+                "| sort p95 desc | limit 10";
+        try {
+            List<Map<String, String>> apiRows = runInsightsQuery(apiQuery, from, to);
+            msg.append('\n').append(formatInsightsSection(
+                    ":satellite_antenna: *External API p95 (ms)*", apiRows, "api", "p95", "ms"));
+        } catch (Exception e) {
+            log.warnf("perf digest: external-API Logs Insights query failed: %s", e.getMessage());
+        }
+
         slackService.sendMessage(opsAlertChannel, msg.toString(), "mother");
     }
 
@@ -105,5 +148,54 @@ public class PerformanceDigestBatchlet {
         }
         if (!any) sb.append("• no batch-job regressions\n");
         return sb.toString();
+    }
+
+    /** Pure Slack-section formatter — unit tested. Sorts rows by numeric value desc. */
+    String formatInsightsSection(String title, List<Map<String, String>> rows,
+                                 String labelField, String valueField, String unit) {
+        StringBuilder sb = new StringBuilder(title).append('\n');
+        if (rows == null || rows.isEmpty()) {
+            sb.append("• no data\n");
+            return sb.toString();
+        }
+        rows.stream()
+                .sorted(Comparator.comparingDouble(
+                        (Map<String, String> r) -> parseDouble(r.get(valueField))).reversed())
+                .limit(10)
+                .forEach(r -> sb.append(String.format("• %s — %s %s%n",
+                        r.getOrDefault(labelField, "?"), r.getOrDefault(valueField, "?"), unit)));
+        return sb.toString();
+    }
+
+    private static double parseDouble(String s) {
+        try { return s == null ? 0 : Double.parseDouble(s); } catch (NumberFormatException e) { return 0; }
+    }
+
+    /** Runs a Logs Insights query and returns each result row as field->value. */
+    List<Map<String, String>> runInsightsQuery(String query, LocalDateTime from, LocalDateTime to) {
+        CloudWatchLogsClient c = logsClient();
+        StartQueryResponse started = c.startQuery(StartQueryRequest.builder()
+                .logGroupName(logGroup)
+                .startTime(from.toEpochSecond(ZoneOffset.UTC))
+                .endTime(to.toEpochSecond(ZoneOffset.UTC))
+                .queryString(query)
+                .build());
+        String queryId = started.queryId();
+        for (int i = 0; i < 30; i++) {
+            GetQueryResultsResponse res = c.getQueryResults(
+                    GetQueryResultsRequest.builder().queryId(queryId).build());
+            if (res.status() == QueryStatus.COMPLETE) {
+                List<Map<String, String>> out = new ArrayList<>();
+                res.results().forEach(row -> {
+                    Map<String, String> m = new LinkedHashMap<>();
+                    row.forEach(f -> m.put(f.field(), f.value()));
+                    out.add(m);
+                });
+                return out;
+            }
+            if (res.status() == QueryStatus.FAILED || res.status() == QueryStatus.CANCELLED) break;
+            try { Thread.sleep(1000); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); break; }
+        }
+        return List.of();
     }
 }

--- a/src/main/java/dk/trustworks/intranet/perf/PerformanceDigestBatchlet.java
+++ b/src/main/java/dk/trustworks/intranet/perf/PerformanceDigestBatchlet.java
@@ -1,0 +1,109 @@
+package dk.trustworks.intranet.perf;
+
+import dk.trustworks.intranet.batch.monitoring.BatchJobExecutionTracking;
+import dk.trustworks.intranet.communicationsservice.services.SlackService;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import lombok.extern.jbosslog.JBossLog;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Nightly performance digest. Batch-job regressions come from the existing
+ * batch_job_execution_tracking table; invoice/external/infra come from CloudWatch
+ * Logs Insights (Task 10). Posts to Slack #ops-alert. Off by default; enable per env.
+ */
+@JBossLog
+@ApplicationScoped
+public class PerformanceDigestBatchlet {
+
+    @Inject
+    EntityManager em;
+
+    @Inject
+    SlackService slackService;
+
+    @ConfigProperty(name = "dk.trustworks.perf.digest.enabled", defaultValue = "false")
+    boolean digestEnabled;
+
+    @ConfigProperty(name = "slack.opsAlertChannel", defaultValue = "C0B2VQ2CFU1")
+    String opsAlertChannel;
+
+    @ConfigProperty(name = "dk.trustworks.perf.digest.recent-window-hours", defaultValue = "24")
+    int recentWindowHours;
+
+    @ConfigProperty(name = "dk.trustworks.perf.digest.baseline-days", defaultValue = "7")
+    int baselineDays;
+
+    @ConfigProperty(name = "dk.trustworks.perf.digest.regression-factor", defaultValue = "1.5")
+    double regressionFactor;
+
+    @Scheduled(cron = "0 30 6 * * ?", identity = "performance-digest")
+    void scheduledRun() {
+        if (!digestEnabled) {
+            log.debug("performance-digest skipped: dk.trustworks.perf.digest.enabled=false");
+            return;
+        }
+        try {
+            runOnce();
+        } catch (Exception e) {
+            log.errorf(e, "performance-digest failed");
+        }
+    }
+
+    void runOnce() {
+        LocalDateTime now = LocalDateTime.now();
+        StringBuilder msg = new StringBuilder();
+        msg.append(":bar_chart: *Performance digest* — last ").append(recentWindowHours).append("h\n\n");
+        msg.append(batchSection(now));
+        // Task 10 appends invoice/external/infra sections from Logs Insights here.
+        slackService.sendMessage(opsAlertChannel, msg.toString(), "mother");
+    }
+
+    String batchSection(LocalDateTime now) {
+        LocalDateTime since = now.minusDays(baselineDays);
+        List<BatchJobExecutionTracking> rows = em.createQuery(
+                        "SELECT e FROM BatchJobExecutionTracking e " +
+                                "WHERE e.endTime IS NOT NULL AND e.startTime >= :since " +
+                                "ORDER BY e.startTime", BatchJobExecutionTracking.class)
+                .setParameter("since", since)
+                .getResultList();
+        return buildBatchDigest(rows, now, recentWindowHours, regressionFactor);
+    }
+
+    /** Pure regression detector — unit tested. */
+    String buildBatchDigest(List<BatchJobExecutionTracking> rows, LocalDateTime now,
+                            int recentWindowHours, double regressionFactor) {
+        LocalDateTime recentCutoff = now.minusHours(recentWindowHours);
+        Map<String, double[]> agg = new LinkedHashMap<>(); // job -> [recentSum, recentN, baseSum, baseN]
+        for (BatchJobExecutionTracking e : rows) {
+            if (e.getStartTime() == null || e.getEndTime() == null) continue;
+            double durSec = Duration.between(e.getStartTime(), e.getEndTime()).toMillis() / 1000.0;
+            double[] a = agg.computeIfAbsent(e.getJobName(), k -> new double[4]);
+            if (e.getStartTime().isAfter(recentCutoff)) { a[0] += durSec; a[1] += 1; }
+            else { a[2] += durSec; a[3] += 1; }
+        }
+        StringBuilder sb = new StringBuilder(":hourglass: *Batch jobs*\n");
+        boolean any = false;
+        for (Map.Entry<String, double[]> en : agg.entrySet()) {
+            double[] a = en.getValue();
+            if (a[1] == 0 || a[3] == 0) continue; // need both windows
+            double recentAvg = a[0] / a[1];
+            double baseAvg = a[2] / a[3];
+            if (baseAvg > 0 && recentAvg > baseAvg * regressionFactor) {
+                any = true;
+                sb.append(String.format("• *%s* — %.0fs vs %.0fs baseline (%.1f× slower)%n",
+                        en.getKey(), recentAvg, baseAvg, recentAvg / baseAvg));
+            }
+        }
+        if (!any) sb.append("• no batch-job regressions\n");
+        return sb.toString();
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/sharepoint/client/GraphApiClient.java
+++ b/src/main/java/dk/trustworks/intranet/sharepoint/client/GraphApiClient.java
@@ -35,6 +35,7 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 @OidcClientFilter("graph")
 @RegisterProvider(GraphResponseExceptionMapper.class)
 @RegisterProvider(GraphApiLoggingFilter.class)
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 public interface GraphApiClient {
 
     @GET

--- a/src/main/java/dk/trustworks/intranet/userservice/network/MailAPI.java
+++ b/src/main/java/dk/trustworks/intranet/userservice/network/MailAPI.java
@@ -1,6 +1,7 @@
 package dk.trustworks.intranet.userservice.network;
 
 import dk.trustworks.intranet.communicationsservice.model.TrustworksMail;
+import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 import jakarta.ws.rs.Consumes;
@@ -9,6 +10,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 
 @RegisterRestClient
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 @Produces("application/json")
 @Consumes("application/json")
 @Path("/communications/mails")

--- a/src/main/java/dk/trustworks/intranet/utils/client/NextsignClient.java
+++ b/src/main/java/dk/trustworks/intranet/utils/client/NextsignClient.java
@@ -21,6 +21,7 @@ import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 @RegisterProvider(ResteasyJackson2Provider.class)
 @RegisterProvider(NextsignResponseExceptionMapper.class)
 @RegisterProvider(NextsignLoggingFilter.class)
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 public interface NextsignClient {
 
     /**

--- a/src/main/java/dk/trustworks/intranet/utils/client/NextsignConvertClient.java
+++ b/src/main/java/dk/trustworks/intranet/utils/client/NextsignConvertClient.java
@@ -39,6 +39,7 @@ import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 @RegisterProvider(ResteasyJackson2Provider.class)
 @RegisterProvider(NextsignResponseExceptionMapper.class)
 @RegisterProvider(NextsignLoggingFilter.class)
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 public interface NextsignConvertClient {
 
     /**

--- a/src/main/java/dk/trustworks/intranet/utils/client/NextsignDocumentClient.java
+++ b/src/main/java/dk/trustworks/intranet/utils/client/NextsignDocumentClient.java
@@ -26,6 +26,7 @@ import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 @RegisterProvider(ResteasyJackson2Provider.class)
 @RegisterProvider(NextsignResponseExceptionMapper.class)
 @RegisterProvider(NextsignLoggingFilter.class)
+@RegisterProvider(dk.trustworks.intranet.perf.PerfRestClientFilter.class)
 public interface NextsignDocumentClient {
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,8 @@ quarkus:
       statement-batch-size: 32
     second-level-caching-enabled: true
     statistics: true
+    log:
+      queries-slower-than-ms: ${PERF_SLOW_QUERY_MS:500}
     unsupported-properties:
       "hibernate.order_inserts": "true"
       "hibernate.order_updates": "true"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -410,7 +410,7 @@ dk:
       env: ${PERF_ENV:production}
       digest:
         enabled: ${PERF_DIGEST_ENABLED:false}   # nightly analyzer off by default; enable per-env
-      log-group: ${CLOUDWATCH_LOG_GROUP_BACKEND:/ecs/tw-quarkus-production}
+      log-group: ${CLOUDWATCH_LOG_GROUP_BACKEND:/ecs/tw-quarkus-unknown}
 pricingEngine:
   enabled: true
 cvtool:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -184,9 +184,19 @@ quarkus:
     max-threads: 30
   log:
     level: INFO
+    handler:
+      console:
+        "perf":
+          enable: true
+          format: "%m%n"
     category:
       "dk.trustworks":
         level: INFO
+      "dk.trustworks.perf":
+        level: INFO
+        handlers:
+          - perf
+        use-parent-handlers: false
       "io.quarkus.http":
         level: INFO
       "org.jboss.resteasy.resteasy_client":
@@ -392,6 +402,13 @@ dk:
       # close to the 24h cron cadence; +1h grace covers clock skew + retry.
       economic-revenue-import:
         max-staleness-hours: 25
+    perf:
+      metrics:
+        enabled: ${PERF_METRICS_ENABLED:true}
+      env: ${PERF_ENV:production}
+      digest:
+        enabled: ${PERF_DIGEST_ENABLED:false}   # nightly analyzer off by default; enable per-env
+      log-group: ${CLOUDWATCH_LOG_GROUP_BACKEND:/ecs/tw-quarkus-production}
 pricingEngine:
   enabled: true
 cvtool:

--- a/src/test/java/dk/trustworks/intranet/batch/monitoring/JobMonitoringPerfTest.java
+++ b/src/test/java/dk/trustworks/intranet/batch/monitoring/JobMonitoringPerfTest.java
@@ -1,0 +1,44 @@
+package dk.trustworks.intranet.batch.monitoring;
+
+import dk.trustworks.intranet.perf.PerfMetrics;
+import jakarta.batch.runtime.BatchStatus;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class JobMonitoringPerfTest {
+
+    @Test
+    void emitJobPerf_mapsCompletedToSuccess_andEmitsDurationAndCount() {
+        PerfMetrics perf = mock(PerfMetrics.class);
+        JobMonitoringListener listener = new JobMonitoringListener();
+        listener.perfMetrics = perf;
+
+        listener.emitJobPerf("finance-load-economics", BatchStatus.COMPLETED, 42L, 16432.0);
+
+        verify(perf).emitTimer(eq("BatchJobDurationMs"), eq(16432.0),
+                eq(Map.of("job", "finance-load-economics")), anyMap());
+
+        ArgumentCaptor<Map<String, String>> dims = ArgumentCaptor.forClass(Map.class);
+        verify(perf).emitCount(eq("BatchJobRuns"), eq(1.0), dims.capture(), anyMap());
+        assertEquals("success", dims.getValue().get("outcome"));
+        assertEquals("finance-load-economics", dims.getValue().get("job"));
+    }
+
+    @Test
+    void emitJobPerf_mapsFailedToFailed() {
+        PerfMetrics perf = mock(PerfMetrics.class);
+        JobMonitoringListener listener = new JobMonitoringListener();
+        listener.perfMetrics = perf;
+
+        listener.emitJobPerf("expense-sync", BatchStatus.FAILED, 7L, 100.0);
+
+        ArgumentCaptor<Map<String, String>> dims = ArgumentCaptor.forClass(Map.class);
+        verify(perf).emitCount(eq("BatchJobRuns"), eq(1.0), dims.capture(), anyMap());
+        assertEquals("failed", dims.getValue().get("outcome"));
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/perf/InfraMetricsEmitterTest.java
+++ b/src/test/java/dk/trustworks/intranet/perf/InfraMetricsEmitterTest.java
@@ -1,0 +1,35 @@
+package dk.trustworks.intranet.perf;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InfraMetricsEmitterTest {
+
+    private final InfraMetricsEmitter emitter = new InfraMetricsEmitter();
+
+    @Test
+    void toMetrics_includesHeapAndPresentPoolGauges() {
+        Map<String, Double> pool = new LinkedHashMap<>();
+        pool.put("DbPoolActive", 3.0);
+        pool.put("DbPoolAwaiting", 0.0);
+
+        List<PerfMetrics.Metric> metrics = emitter.toMetrics(536_870_912L, pool);
+
+        assertTrue(metrics.stream().anyMatch(m -> m.name().equals("JvmHeapUsedBytes") && m.value() == 536_870_912L));
+        assertTrue(metrics.stream().anyMatch(m -> m.name().equals("DbPoolActive") && m.value() == 3.0));
+        assertTrue(metrics.stream().anyMatch(m -> m.name().equals("DbPoolAwaiting")));
+    }
+
+    @Test
+    void toMetrics_skipsNaNGauges() {
+        Map<String, Double> pool = new LinkedHashMap<>();
+        pool.put("DbPoolActive", Double.NaN);
+        List<PerfMetrics.Metric> metrics = emitter.toMetrics(1L, pool);
+        assertTrue(metrics.stream().noneMatch(m -> m.name().equals("DbPoolActive")));
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/perf/PerfMetricsTest.java
+++ b/src/test/java/dk/trustworks/intranet/perf/PerfMetricsTest.java
@@ -3,6 +3,7 @@ package dk.trustworks.intranet.perf;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -60,5 +61,24 @@ class PerfMetricsTest {
                 List.of(new PerfMetrics.Metric("X", "Count", 1.0)),
                 Map.of("env", "staging"), Map.of(), 1L);
         assertFalse(line.contains("\n"), "EMF must be a single JSON line");
+    }
+
+    @Test
+    void emit_doesNothing_whenDisabled() {
+        PerfMetrics spy = Mockito.spy(new PerfMetrics());
+        spy.enabled = false;
+        spy.env = "production";
+        spy.emitCount("X", 1, Map.of(), Map.of());
+        Mockito.verify(spy, Mockito.never()).write(Mockito.anyString());
+    }
+
+    @Test
+    void emit_writesOnce_whenEnabled_andPrependsEnvDimension() {
+        PerfMetrics spy = Mockito.spy(new PerfMetrics());
+        spy.enabled = true;
+        spy.env = "staging";
+        Mockito.doNothing().when(spy).write(Mockito.anyString());
+        spy.emitCount("ExternalApiCount", 1, Map.of("api", "economic"), Map.of());
+        Mockito.verify(spy, Mockito.times(1)).write(Mockito.contains("\"env\":\"staging\""));
     }
 }

--- a/src/test/java/dk/trustworks/intranet/perf/PerfMetricsTest.java
+++ b/src/test/java/dk/trustworks/intranet/perf/PerfMetricsTest.java
@@ -1,0 +1,64 @@
+package dk.trustworks.intranet.perf;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PerfMetricsTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final PerfMetrics perf = new PerfMetrics();
+
+    @Test
+    void buildEmf_producesValidEnvelope_withDimensionsAndMetricValues() throws Exception {
+        Map<String, String> dims = new LinkedHashMap<>();
+        dims.put("env", "production");
+        dims.put("job", "finance-load-economics");
+
+        Map<String, Object> fields = new LinkedHashMap<>();
+        fields.put("executionId", 42L);
+        fields.put("traceId", "abc123");
+
+        String line = perf.buildEmf(
+                "Trustworks/Perf",
+                List.of(new PerfMetrics.Metric("BatchJobDurationMs", "Milliseconds", 16432.0)),
+                dims, fields, 1718700000000L);
+
+        JsonNode root = mapper.readTree(line);
+
+        // EMF envelope
+        JsonNode directive = root.path("_aws").path("CloudWatchMetrics").get(0);
+        assertEquals("Trustworks/Perf", directive.path("Namespace").asText());
+        assertEquals(1718700000000L, root.path("_aws").path("Timestamp").asLong());
+        // dimension set lists the dimension KEYS
+        JsonNode dimSet = directive.path("Dimensions").get(0);
+        assertEquals("env", dimSet.get(0).asText());
+        assertEquals("job", dimSet.get(1).asText());
+        // metric definition
+        JsonNode metricDef = directive.path("Metrics").get(0);
+        assertEquals("BatchJobDurationMs", metricDef.path("Name").asText());
+        assertEquals("Milliseconds", metricDef.path("Unit").asText());
+        // top-level dimension VALUES present
+        assertEquals("production", root.path("env").asText());
+        assertEquals("finance-load-economics", root.path("job").asText());
+        // top-level metric VALUE present
+        assertEquals(16432.0, root.path("BatchJobDurationMs").asDouble(), 0.0001);
+        // fields present for drill-down
+        assertEquals("abc123", root.path("traceId").asText());
+        assertEquals(42.0, root.path("executionId").asDouble(), 0.0001);
+    }
+
+    @Test
+    void buildEmf_isSingleLineJson() {
+        String line = perf.buildEmf("Trustworks/Perf",
+                List.of(new PerfMetrics.Metric("X", "Count", 1.0)),
+                Map.of("env", "staging"), Map.of(), 1L);
+        assertFalse(line.contains("\n"), "EMF must be a single JSON line");
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/perf/PerfRestClientFilterTest.java
+++ b/src/test/java/dk/trustworks/intranet/perf/PerfRestClientFilterTest.java
@@ -1,0 +1,32 @@
+package dk.trustworks.intranet.perf;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PerfRestClientFilterTest {
+
+    @Test
+    void apiLabel_mapsKnownHostsToBoundedLabels() {
+        assertEquals("economic", PerfRestClientFilter.apiLabel(URI.create("https://apis.e-conomic.com/q2capi/v5.1.0/invoices/drafts")));
+        assertEquals("graph", PerfRestClientFilter.apiLabel(URI.create("https://graph.microsoft.com/v1.0/me")));
+        assertEquals("openai", PerfRestClientFilter.apiLabel(URI.create("https://api.openai.com/v1/responses")));
+        assertEquals("nextsign", PerfRestClientFilter.apiLabel(URI.create("https://api.nextsign.dk/api/v1/foo")));
+        assertEquals("cvr", PerfRestClientFilter.apiLabel(URI.create("https://virkdata.dk/cvr/123")));
+    }
+
+    @Test
+    void operationLabel_collapsesNumericIdsToBoundIt() {
+        assertEquals("GET invoices drafts {id}",
+                PerfRestClientFilter.operationLabel("GET", URI.create("https://apis.e-conomic.com/q2capi/v5.1.0/invoices/drafts/123456")));
+    }
+
+    @Test
+    void statusClass_bucketsByHundreds() {
+        assertEquals("2xx", PerfRestClientFilter.statusClass(204));
+        assertEquals("4xx", PerfRestClientFilter.statusClass(404));
+        assertEquals("5xx", PerfRestClientFilter.statusClass(503));
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/perf/PerfRestClientFilterTest.java
+++ b/src/test/java/dk/trustworks/intranet/perf/PerfRestClientFilterTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class PerfRestClientFilterTest {
 
@@ -35,5 +36,16 @@ class PerfRestClientFilterTest {
         assertEquals("2xx", PerfRestClientFilter.statusClass(204));
         assertEquals("4xx", PerfRestClientFilter.statusClass(404));
         assertEquals("5xx", PerfRestClientFilter.statusClass(503));
+    }
+
+    @Test
+    void operationLabel_neverIncludesQueryStringSecrets() {
+        String op = PerfRestClientFilter.operationLabel("POST",
+                URI.create("https://api.nextsign.dk/auth/login?password=hunter2&apikey=SECRET"));
+        assertEquals("POST auth login", op);
+        assertFalse(op.contains("password"));
+        assertFalse(op.contains("hunter2"));
+        assertFalse(op.contains("apikey"));
+        assertFalse(op.contains("SECRET"));
     }
 }

--- a/src/test/java/dk/trustworks/intranet/perf/PerfRestClientFilterTest.java
+++ b/src/test/java/dk/trustworks/intranet/perf/PerfRestClientFilterTest.java
@@ -24,6 +24,13 @@ class PerfRestClientFilterTest {
     }
 
     @Test
+    void operationLabel_collapsesDateSegmentsToBoundId() {
+        assertEquals("GET accounting-years {id} entries",
+                PerfRestClientFilter.operationLabel("GET",
+                        URI.create("https://apis.e-conomic.com/q2capi/v5.1.0/accounting-years/2025-07-01/entries")));
+    }
+
+    @Test
     void statusClass_bucketsByHundreds() {
         assertEquals("2xx", PerfRestClientFilter.statusClass(204));
         assertEquals("4xx", PerfRestClientFilter.statusClass(404));

--- a/src/test/java/dk/trustworks/intranet/perf/PerfTimedInterceptorTest.java
+++ b/src/test/java/dk/trustworks/intranet/perf/PerfTimedInterceptorTest.java
@@ -1,0 +1,61 @@
+package dk.trustworks.intranet.perf;
+
+import jakarta.interceptor.InvocationContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PerfTimedInterceptorTest {
+
+    @PerfTimed("invoice.createDraft")
+    public Object sampleSuccess() { return "ok"; }
+
+    @PerfTimed("invoice.book")
+    public Object sampleFailure() { throw new IllegalStateException("boom"); }
+
+    @Test
+    void success_emitsDurationAndSuccessCount() throws Exception {
+        PerfMetrics perf = mock(PerfMetrics.class);
+        PerfTimedInterceptor interceptor = new PerfTimedInterceptor();
+        interceptor.perfMetrics = perf;
+
+        Method m = getClass().getMethod("sampleSuccess");
+        InvocationContext ctx = mock(InvocationContext.class);
+        when(ctx.getMethod()).thenReturn(m);
+        when(ctx.getTarget()).thenReturn(this);
+        when(ctx.proceed()).thenReturn("ok");
+
+        Object result = interceptor.time(ctx);
+
+        assertEquals("ok", result);
+        verify(perf).emitTimer(eq("OperationDurationMs"), anyDouble(),
+                eq(Map.of("phase", "invoice.createDraft")), anyMap());
+        ArgumentCaptor<Map<String, String>> dims = ArgumentCaptor.forClass(Map.class);
+        verify(perf).emitCount(eq("OperationCount"), eq(1.0), dims.capture(), anyMap());
+        assertEquals("success", dims.getValue().get("outcome"));
+    }
+
+    @Test
+    void failure_emitsErrorCount_andRethrows() throws Exception {
+        PerfMetrics perf = mock(PerfMetrics.class);
+        PerfTimedInterceptor interceptor = new PerfTimedInterceptor();
+        interceptor.perfMetrics = perf;
+
+        Method m = getClass().getMethod("sampleFailure");
+        InvocationContext ctx = mock(InvocationContext.class);
+        when(ctx.getMethod()).thenReturn(m);
+        when(ctx.getTarget()).thenReturn(this);
+        when(ctx.proceed()).thenThrow(new IllegalStateException("boom"));
+
+        assertThrows(IllegalStateException.class, () -> interceptor.time(ctx));
+
+        ArgumentCaptor<Map<String, String>> dims = ArgumentCaptor.forClass(Map.class);
+        verify(perf).emitCount(eq("OperationCount"), eq(1.0), dims.capture(), anyMap());
+        assertEquals("error", dims.getValue().get("outcome"));
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/perf/PerfTimedInterceptorTest.java
+++ b/src/test/java/dk/trustworks/intranet/perf/PerfTimedInterceptorTest.java
@@ -54,6 +54,8 @@ class PerfTimedInterceptorTest {
 
         assertThrows(IllegalStateException.class, () -> interceptor.time(ctx));
 
+        verify(perf).emitTimer(eq("OperationDurationMs"), anyDouble(),
+                eq(Map.of("phase", "invoice.book")), anyMap());
         ArgumentCaptor<Map<String, String>> dims = ArgumentCaptor.forClass(Map.class);
         verify(perf).emitCount(eq("OperationCount"), eq(1.0), dims.capture(), anyMap());
         assertEquals("error", dims.getValue().get("outcome"));

--- a/src/test/java/dk/trustworks/intranet/perf/PerformanceDigestBatchletTest.java
+++ b/src/test/java/dk/trustworks/intranet/perf/PerformanceDigestBatchletTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+
 class PerformanceDigestBatchletTest {
 
     private final PerformanceDigestBatchlet batchlet = new PerformanceDigestBatchlet();
@@ -49,5 +50,25 @@ class PerformanceDigestBatchletTest {
         String digest = batchlet.buildBatchDigest(rows, now, 24, 1.5);
 
         assertFalse(digest.contains("slack-user-sync"), "stable job must not be flagged");
+    }
+
+    @Test
+    void formatInsightsSection_rendersRowsSortedByValueDesc() {
+        List<java.util.Map<String, String>> rows = List.of(
+                java.util.Map.of("api", "economic", "p95", "820"),
+                java.util.Map.of("api", "graph", "p95", "1300"));
+        String section = batchlet.formatInsightsSection(
+                ":satellite: External API p95 (ms)", rows, "api", "p95", "ms");
+        // higher value first
+        assertTrue(section.indexOf("graph") < section.indexOf("economic"),
+                "rows should be sorted by value descending");
+        assertTrue(section.contains("1300"));
+    }
+
+    @Test
+    void formatInsightsSection_handlesEmpty() {
+        String section = batchlet.formatInsightsSection(
+                ":satellite: x", List.of(), "api", "p95", "ms");
+        assertTrue(section.toLowerCase().contains("no data"));
     }
 }

--- a/src/test/java/dk/trustworks/intranet/perf/PerformanceDigestBatchletTest.java
+++ b/src/test/java/dk/trustworks/intranet/perf/PerformanceDigestBatchletTest.java
@@ -1,0 +1,53 @@
+package dk.trustworks.intranet.perf;
+
+import dk.trustworks.intranet.batch.monitoring.BatchJobExecutionTracking;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PerformanceDigestBatchletTest {
+
+    private final PerformanceDigestBatchlet batchlet = new PerformanceDigestBatchlet();
+
+    private BatchJobExecutionTracking row(String job, LocalDateTime start, long durationSeconds) {
+        BatchJobExecutionTracking e = new BatchJobExecutionTracking();
+        e.setJobName(job);
+        e.setStartTime(start);
+        e.setEndTime(start.plusSeconds(durationSeconds));
+        e.setStatus("COMPLETED");
+        e.setResult("COMPLETED");
+        return e;
+    }
+
+    @Test
+    void buildBatchDigest_flagsRegressedJob() {
+        LocalDateTime now = LocalDateTime.of(2026, 6, 18, 7, 0);
+        List<BatchJobExecutionTracking> rows = new ArrayList<>();
+        // baseline (2-7 days ago): ~10s
+        for (int d = 2; d <= 7; d++) rows.add(row("opex-refresh", now.minusDays(d), 10));
+        // recent (last 24h): ~60s -> regression
+        rows.add(row("opex-refresh", now.minusHours(3), 60));
+
+        String digest = batchlet.buildBatchDigest(rows, now, 24, 1.5);
+
+        assertTrue(digest.contains("opex-refresh"), "regressed job should appear");
+        assertTrue(digest.contains("60") || digest.toLowerCase().contains("slower"),
+                "should report the regression");
+    }
+
+    @Test
+    void buildBatchDigest_omitsStableJob() {
+        LocalDateTime now = LocalDateTime.of(2026, 6, 18, 7, 0);
+        List<BatchJobExecutionTracking> rows = new ArrayList<>();
+        for (int d = 2; d <= 7; d++) rows.add(row("slack-user-sync", now.minusDays(d), 5));
+        rows.add(row("slack-user-sync", now.minusHours(2), 5));
+
+        String digest = batchlet.buildBatchDigest(rows, now, 24, 1.5);
+
+        assertFalse(digest.contains("slack-user-sync"), "stable job must not be flagged");
+    }
+}


### PR DESCRIPTION
## Backend performance observability (CloudWatch EMF)

Instruments the Quarkus backend with CloudWatch Embedded Metric Format (EMF) metrics under namespace `Trustworks/Perf`, emitted as JSON log lines via a dedicated `dk.trustworks.perf` raw logger → stdout → CloudWatch Logs (auto-extracted). **No new dependencies, no Flyway migration, no new runtime IAM for emission.** Backend-only, staging-first.

### Four instrumented targets
- **Batch jobs** — one hook in the existing `JobMonitoringListener.afterJob()` covers all ~20 jobs → `BatchJobDurationMs`/`BatchJobRuns` (dims `env,job[,outcome]`).
- **Invoice finalization** — `@PerfTimed` CDI interceptor on `createDraft`/`bookDraft` → `OperationDurationMs`/`OperationCount`; inline `InvoiceFinalizePartialUpload` counter.
- **External REST clients** — `PerfRestClientFilter` registered on all 19 `@RegisterRestClient` interfaces → `ExternalApiDurationMs`/`ExternalApiCount` (`api` = bounded host label; `operation` = method + last ≤3 path segments, ids/dates collapsed to `{id}`).
- **DB / JVM** — `InfraMetricsEmitter` `@Scheduled(60s)` (Agroal pool + JVM heap) + Hibernate slow-query log (`quarkus.hibernate-orm.log.queries-slower-than-ms`).

Plus a nightly `PerformanceDigestBatchlet` (`@Scheduled` 06:30, **off by default**) that reads batch regressions from the existing `batch_job_execution_tracking` table + the rest via CloudWatch Logs Insights → Slack `#ops-alert`.

### Cardinality & security discipline
- Dimensions are a bounded set only (`env, job, api, operation, phase, outcome, httpStatusClass`); high-cardinality values (UUIDs, `traceId`, `executionId`, SQL) are log fields only.
- EMF lines / logs / Logs-Insights queries / Slack text carry **only metadata** — never tokens, headers, request/response bodies, or e-conomic payloads (security review: all 5 emission points PASS).

### Verification
- **19/19** feature unit tests pass (plain JUnit 5 + Mockito, no `@QuarkusTest`/DB); full `clean compile` BUILD SUCCESS.
- Per-task spec+quality reviews; final whole-branch review (READY TO MERGE, no code blockers); validation PASS (config-key/metric-name consistency, EMF envelope, JPQL, no API/DB regression); security review LOW risk, 0 Critical/High.
- Hardening applied: fail-safe `log-group` default (sentinel, so a missing `CLOUDWATCH_LOG_GROUP_BACKEND` can't make staging query prod logs); cardinality bound on `operation` (collapse id/date segments); REST-filter query-string guard + regression test.

> CI note: run the feature tests by explicit class name — the package wildcard `-Dtest=dk.trustworks.intranet.perf.*` matches 0 classes in this Surefire version.

### NOT in this branch / required before "live"
- **Untracked artifacts** (parent monorepo dir is not a git repo): `infra/observability/cloudwatch-dashboard.yaml` and the `docs/finalized/shared/architecture.md` subsection — need a home in a version-controlled infra/docs repo.
- **Admin actions (read-only profile can't):** apply read-only Logs-Insights IAM (`logs:StartQuery`/`GetQueryResults`/`StopQuery`/`DescribeLogGroups` on `/ecs/tw-quarkus-*`); deploy the dashboard stack `tw-perf-observability-<env>` (`cloudwatch:PutDashboard`). Keep `PERF_DIGEST_ENABLED=false` until IAM is applied.
- **Staging validation runbook:** confirm EMF lines flow (`filter-pattern '{ $._aws.CloudWatchMetrics IS TRUE }'`), metrics extracted (`list-metrics --namespace Trustworks/Perf`), confirm Agroal meter names via `/q/metrics`, then enable the digest and confirm a Slack post.

### Follow-ups (non-blocking)
- Pre-existing (NOT this branch): a committed Nextsign bearer-token literal in `application.yml` — rotate + replace with an empty default.
- Minor hardening deferred: `PERF_START_NANOS` cap/TTL; digest baseline window robustness if `recentWindowHours` reconfigured; `%n`→`\n` in the digest format; broader outcome-mapping test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
