### PR TITLE
feat(perf): dedicated PERF_LOG_GROUP + enable prod digest

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -95,6 +95,8 @@ jobs:
               {"name":"EXPENSE_ECONOMICS_UPLOAD_ENABLED","value":"true"},
               {"name":"INVOICE_ECONOMICS_UPLOAD_ENABLED","value":"true"},
               {"name":"ENVIRONMENT_ID","value":"production"},
+              {"name":"PERF_LOG_GROUP","value":"/aws/ecs/default/tw-quarkus-production-4cbe"},
+              {"name":"PERF_DIGEST_ENABLED","value":"true"},
               {"name":"INVOICE_S3","value":"invoicefiles-new"},
               {"name":"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT","value":"http://localhost:4317"},
               {"name":"OTEL_EXPORTER_OTLP_TRACES_ENABLED","value":"false"},

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -410,7 +410,7 @@ dk:
       env: ${PERF_ENV:production}
       digest:
         enabled: ${PERF_DIGEST_ENABLED:false}   # nightly analyzer off by default; enable per-env
-      log-group: ${CLOUDWATCH_LOG_GROUP_BACKEND:/ecs/tw-quarkus-unknown}
+      log-group: ${PERF_LOG_GROUP:${CLOUDWATCH_LOG_GROUP_BACKEND:/ecs/tw-quarkus-unknown}}
 pricingEngine:
   enabled: true
 cvtool:


### PR DESCRIPTION
Isolates the nightly digest's log group via a dedicated `PERF_LOG_GROUP` env var (falls back to the shared `CLOUDWATCH_LOG_GROUP_BACKEND`), so the prod digest can query the real `/aws/ecs/default/tw-quarkus-production-4cbe` without changing the shared var (which the bug-report log feature reads). Enables the digest in prod via `deploy-production.yml` (`PERF_LOG_GROUP` + `PERF_DIGEST_ENABLED=true`). Inert on staging (perf disabled there). Validated: YAML + prod env JSON parse; shared var unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)