### PR TITLE
Production release: enable nightly perf digest (dedicated PERF_LOG_GROUP)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -95,6 +95,8 @@ jobs:
               {"name":"EXPENSE_ECONOMICS_UPLOAD_ENABLED","value":"true"},
               {"name":"INVOICE_ECONOMICS_UPLOAD_ENABLED","value":"true"},
               {"name":"ENVIRONMENT_ID","value":"production"},
+              {"name":"PERF_LOG_GROUP","value":"/aws/ecs/default/tw-quarkus-production-4cbe"},
+              {"name":"PERF_DIGEST_ENABLED","value":"true"},
               {"name":"INVOICE_S3","value":"invoicefiles-new"},
               {"name":"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT","value":"http://localhost:4317"},
               {"name":"OTEL_EXPORTER_OTLP_TRACES_ENABLED","value":"false"},

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -410,7 +410,7 @@ dk:
       env: ${PERF_ENV:production}
       digest:
         enabled: ${PERF_DIGEST_ENABLED:false}   # nightly analyzer off by default; enable per-env
-      log-group: ${CLOUDWATCH_LOG_GROUP_BACKEND:/ecs/tw-quarkus-unknown}
+      log-group: ${PERF_LOG_GROUP:${CLOUDWATCH_LOG_GROUP_BACKEND:/ecs/tw-quarkus-unknown}}
 pricingEngine:
   enabled: true
 cvtool:


### PR DESCRIPTION
Promotes the dedicated `PERF_LOG_GROUP` change to prod. `deploy-production.yml` now sets `PERF_LOG_GROUP=/aws/ecs/default/tw-quarkus-production-4cbe` + `PERF_DIGEST_ENABLED=true`, enabling the 06:30 UTC digest to query the real prod log group. The shared `CLOUDWATCH_LOG_GROUP_BACKEND` is untouched (bug-report log feature unaffected). Validated on staging: app boots clean, config resolves, 0 startup errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)