### PR TITLE
Release: expenses date-range + e-conomic re-send

### DIFF
--- a/src/main/java/dk/trustworks/intranet/expenseservice/dto/ExpenseResendPrecheckDTO.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/dto/ExpenseResendPrecheckDTO.java
@@ -1,0 +1,9 @@
+package dk.trustworks.intranet.expenseservice.dto;
+
+/** Per-expense pre-check: whether it can be re-sent and whether its voucher still exists. */
+public record ExpenseResendPrecheckDTO(
+        String uuid,
+        boolean eligible,
+        String reason,        // null when eligible; else the skip reason
+        boolean voucherExists,
+        String location) {}   // "DRAFT" | "BOOKED" | "MISSING"

--- a/src/main/java/dk/trustworks/intranet/expenseservice/dto/ExpenseResendRequestDTO.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/dto/ExpenseResendRequestDTO.java
@@ -1,0 +1,10 @@
+package dk.trustworks.intranet.expenseservice.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+/** Selected expenses to re-send to / pre-check against e-conomic. */
+public record ExpenseResendRequestDTO(
+        @NotEmpty @Size(max = 500) List<@NotBlank String> uuids) {}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/dto/ExpenseResendResultDTO.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/dto/ExpenseResendResultDTO.java
@@ -1,0 +1,9 @@
+package dk.trustworks.intranet.expenseservice.dto;
+
+import java.util.List;
+
+/** Outcome of a bulk re-send: applied count, skipped (ineligible) and failed (post error) rows. */
+public record ExpenseResendResultDTO(int updated, List<Skipped> skipped, List<Failed> failed) {
+    public record Skipped(String uuid, String reason) {}
+    public record Failed(String uuid, String error) {}
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/resources/ExpenseEconomicsResendResource.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/resources/ExpenseEconomicsResendResource.java
@@ -1,0 +1,69 @@
+package dk.trustworks.intranet.expenseservice.resources;
+
+import dk.trustworks.intranet.expenseservice.dto.ExpenseResendPrecheckDTO;
+import dk.trustworks.intranet.expenseservice.dto.ExpenseResendRequestDTO;
+import dk.trustworks.intranet.expenseservice.dto.ExpenseResendResultDTO;
+import dk.trustworks.intranet.expenseservice.services.ExpenseEconomicResendService;
+import dk.trustworks.intranet.security.RequestHeaderHolder;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manual e-conomic re-send (spec §4). Mirrors {@link ExpenseBatchDecisionResource}: each uuid is
+ * processed in its own transaction by the service; ineligible rows are skipped (with a reason) and
+ * e-conomic post errors are reported as failed — neither changes the expense's status.
+ */
+@Path("/expenses/economics")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ExpenseEconomicsResendResource {
+
+    @Inject ExpenseEconomicResendService resend;
+    @Inject RequestHeaderHolder header;
+
+    @POST
+    @Path("/resend/precheck")
+    @RolesAllowed({"expenses:review"})
+    public List<ExpenseResendPrecheckDTO> precheck(@Valid ExpenseResendRequestDTO body) {
+        List<ExpenseResendPrecheckDTO> out = new ArrayList<>();
+        for (String uuid : body.uuids()) {
+            out.add(resend.precheckOne(uuid));
+        }
+        return out;
+    }
+
+    @POST
+    @Path("/resend")
+    @RolesAllowed({"expenses:review"})
+    public ExpenseResendResultDTO resend(@Valid ExpenseResendRequestDTO body) {
+        String actor = header.getUserUuid();
+        int updated = 0;
+        List<ExpenseResendResultDTO.Skipped> skipped = new ArrayList<>();
+        List<ExpenseResendResultDTO.Failed> failed = new ArrayList<>();
+        for (String uuid : body.uuids()) {
+            try {
+                resend.resendOne(uuid, actor);
+                updated++;
+            } catch (NotFoundException ex) {
+                skipped.add(new ExpenseResendResultDTO.Skipped(uuid, "not found"));
+            } catch (BadRequestException ex) {
+                skipped.add(new ExpenseResendResultDTO.Skipped(uuid, ex.getMessage()));
+            } catch (Exception ex) {
+                failed.add(new ExpenseResendResultDTO.Failed(uuid,
+                        ex.getMessage() != null ? ex.getMessage() : ex.getClass().getSimpleName()));
+            }
+        }
+        return new ExpenseResendResultDTO(updated, skipped, failed);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/EconomicsService.java
@@ -649,6 +649,43 @@ public class  EconomicsService {
     }
 
     /**
+     * True if the stored voucher is present in the booked accounting-year ledger.
+     * Complements {@link #verifyVoucherExists(Expense)} (draft journal) so a BOOKED
+     * voucher is not mistaken for "missing". Returns false on missing triple / error.
+     */
+    public boolean voucherBookedInLedger(Expense expense) {
+        if (expense.getVouchernumber() <= 0 || expense.getJournalnumber() == null || expense.getAccountingyear() == null) {
+            return false;
+        }
+        String yearId = DateUtils.toEconomicsUrlYear(expense.getAccountingyear());
+        String filter = "voucherNumber$eq:" + expense.getVouchernumber();
+        try (EconomicsAPI api = getApiForExpense(expense)) {
+            Response yr = api.getYearEntries(yearId, filter, 1000, 0);
+            int status = yr != null ? yr.getStatus() : -1;
+            String body = null;
+            try { if (yr != null) body = yr.readEntity(String.class); }
+            finally { if (yr != null) yr.close(); }
+            return status >= 200 && status < 300 && hasAnyLedgerEntries(body);
+        } catch (Exception e) {
+            log.warn("voucherBookedInLedger lookup failed for expense " + expense.getUuid() + ": " + e.getMessage());
+            return false;
+        }
+    }
+
+    /** e-conomic list responses wrap items in a "collection" array. True when non-empty. */
+    private boolean hasAnyLedgerEntries(String json) {
+        if (json == null || json.isBlank()) return false;
+        try {
+            com.fasterxml.jackson.databind.JsonNode root = new com.fasterxml.jackson.databind.ObjectMapper().readTree(json);
+            com.fasterxml.jackson.databind.JsonNode coll = root.get("collection");
+            if (coll != null && coll.isArray()) return coll.size() > 0;
+            return root.isArray() && root.size() > 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
      * Delete voucher from e-conomic using NEW Journals API.
      * <p>
      * Uses GET-then-DELETE pattern: first fetches entry details to obtain

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseDecisionLogService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseDecisionLogService.java
@@ -66,6 +66,13 @@ public class ExpenseDecisionLogService {
     }
 
     @Transactional
+    public void recordEconomicResend(Expense e, String actorUuid, String reason) {
+        // Re-send does NOT change status/state, so from == to on both axes.
+        append(e, "ACCOUNTING", actorUuid, "ECONOMIC_RESEND",
+               e.getStatus(), e.getStatus(), e.getState(), e.getState(), e.getAiRuleId(), reason);
+    }
+
+    @Transactional
     public void recordLegacyOverride(Expense e, String actorUuid) {
         append(e, "HR", actorUuid, "LEGACY_OVERRIDE",
                e.getStatus(), "VALIDATED", null, null, e.getAiRuleId(), null);

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseEconomicResendService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseEconomicResendService.java
@@ -1,6 +1,7 @@
 package dk.trustworks.intranet.expenseservice.services;
 
 import dk.trustworks.intranet.dto.ExpenseFile;
+import dk.trustworks.intranet.expenseservice.dto.ExpenseResendPrecheckDTO;
 import dk.trustworks.intranet.expenseservice.model.Expense;
 import dk.trustworks.intranet.expenseservice.model.UserAccount;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -42,6 +43,22 @@ public class ExpenseEconomicResendService {
         if (!isPosted(e)) throw new BadRequestException("not posted yet");
         if (UserAccount.findById(e.getUseruuid()) == null) throw new BadRequestException("no e-conomic account");
         return e;
+    }
+
+    @Transactional
+    public ExpenseResendPrecheckDTO precheckOne(String uuid) {
+        Expense e = Expense.findById(uuid);
+        if (e == null) return new ExpenseResendPrecheckDTO(uuid, false, "not found", false, "MISSING");
+        if ("DELETED".equals(e.getStatus())) return new ExpenseResendPrecheckDTO(uuid, false, "deleted", false, "MISSING");
+        if (!isPosted(e)) return new ExpenseResendPrecheckDTO(uuid, false, "not posted yet", false, "MISSING");
+        if (UserAccount.findById(e.getUseruuid()) == null)
+            return new ExpenseResendPrecheckDTO(uuid, false, "no e-conomic account", false, "MISSING");
+
+        if (economicsService.verifyVoucherExists(e))
+            return new ExpenseResendPrecheckDTO(uuid, true, null, true, "DRAFT");
+        if (economicsService.voucherBookedInLedger(e))
+            return new ExpenseResendPrecheckDTO(uuid, true, null, true, "BOOKED");
+        return new ExpenseResendPrecheckDTO(uuid, true, null, false, "MISSING");
     }
 
     @Transactional

--- a/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseEconomicResendService.java
+++ b/src/main/java/dk/trustworks/intranet/expenseservice/services/ExpenseEconomicResendService.java
@@ -1,0 +1,79 @@
+package dk.trustworks.intranet.expenseservice.services;
+
+import dk.trustworks.intranet.dto.ExpenseFile;
+import dk.trustworks.intranet.expenseservice.model.Expense;
+import dk.trustworks.intranet.expenseservice.model.UserAccount;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * Manually re-pushes a "lost" expense to the e-conomic journal. Reuses the orphan-retry
+ * idempotency path ({@code markAsOrphaned + incrementRetryCount}) so e-conomic creates a NEW
+ * voucher, then {@link EconomicsService#sendVoucher} persists the new triple + re-attaches the
+ * receipt. The expense's status/state are never changed.
+ */
+@ApplicationScoped
+public class ExpenseEconomicResendService {
+
+    @Inject EconomicsService economicsService;
+    @Inject ExpenseFileService expenseFileService;
+    @Inject ExpenseDecisionLogService decisionLog;
+
+    @ConfigProperty(name = "dk.trustworks.expense.economics-upload.enabled", defaultValue = "true")
+    boolean economicsUploadEnabled;
+
+    /** Posted = already reached e-conomic (has a voucher or an upload-stage status). */
+    boolean isPosted(Expense e) {
+        if (e.getVouchernumber() > 0) return true;
+        String s = e.getStatus();
+        return "UPLOADED".equals(s) || "VOUCHER_CREATED".equals(s)
+                || "VERIFIED_UNBOOKED".equals(s) || "VERIFIED_BOOKED".equals(s);
+    }
+
+    /** Throws BadRequestException with a skip reason when not re-sendable; returns the loaded expense otherwise. */
+    Expense requireResendable(String uuid) {
+        Expense e = Expense.findById(uuid);
+        if (e == null) throw new NotFoundException();
+        if ("DELETED".equals(e.getStatus())) throw new BadRequestException("deleted");
+        if (!isPosted(e)) throw new BadRequestException("not posted yet");
+        if (UserAccount.findById(e.getUseruuid()) == null) throw new BadRequestException("no e-conomic account");
+        return e;
+    }
+
+    @Transactional
+    public void resendOne(String uuid, String actorUuid) {
+        if (!economicsUploadEnabled) {
+            // Validate existence first so unknown uuids still report "not found".
+            if (Expense.findById(uuid) == null) throw new NotFoundException();
+            throw new BadRequestException("e-conomic upload disabled in this environment");
+        }
+        Expense e = requireResendable(uuid);
+        UserAccount ua = UserAccount.findById(e.getUseruuid());
+
+        ExpenseFile file;
+        try {
+            file = expenseFileService.getFileById(uuid);
+        } catch (Exception ex) {
+            throw new RuntimeException("receipt unavailable: " + ex.getMessage(), ex);
+        }
+
+        int oldVoucher = e.getVouchernumber();
+        // Force a fresh idempotency key (orphan-retry path) so e-conomic creates a NEW voucher.
+        e.markAsOrphaned();
+        e.incrementRetryCount();
+        try {
+            economicsService.sendVoucher(e, file, ua); // persists new triple + re-attaches receipt; no status change
+        } catch (Exception ex) {
+            // RuntimeException ⇒ this @Transactional rolls back (orphan flag / retry bump reverted).
+            throw new RuntimeException("re-send failed: "
+                    + (ex.getMessage() != null ? ex.getMessage() : ex.getClass().getSimpleName()), ex);
+        }
+        e.clearOrphaned();
+        decisionLog.recordEconomicResend(e, actorUuid,
+                "Re-sent to e-conomic: voucher " + oldVoucher + " -> " + e.getVouchernumber());
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/expenseservice/resources/ExpenseEconomicsResendResourceTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/resources/ExpenseEconomicsResendResourceTest.java
@@ -1,8 +1,10 @@
 package dk.trustworks.intranet.expenseservice.resources;
 
+import dk.trustworks.intranet.dto.ExpenseFile;
 import dk.trustworks.intranet.expenseservice.model.Expense;
 import dk.trustworks.intranet.expenseservice.model.UserAccount;
 import dk.trustworks.intranet.expenseservice.services.EconomicsService;
+import dk.trustworks.intranet.expenseservice.services.ExpenseFileService;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -21,6 +23,7 @@ import static org.mockito.Mockito.when;
 class ExpenseEconomicsResendResourceTest {
 
     @InjectMock EconomicsService economicsService;
+    @InjectMock ExpenseFileService expenseFileService;
 
     private String seedPosted() {
         String user = "user-" + UUID.randomUUID();
@@ -50,6 +53,7 @@ class ExpenseEconomicsResendResourceTest {
     void resendReturnsUpdatedCount() throws Exception {
         String uuid = seedPosted();
         when(economicsService.sendVoucher(any(), any(), any())).thenReturn(Response.ok().build());
+        when(expenseFileService.getFileById(any())).thenReturn(new ExpenseFile(uuid, "BASE64"));
 
         given()
           .header("X-Requested-By", "accountant")

--- a/src/test/java/dk/trustworks/intranet/expenseservice/resources/ExpenseEconomicsResendResourceTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/resources/ExpenseEconomicsResendResourceTest.java
@@ -1,0 +1,77 @@
+package dk.trustworks.intranet.expenseservice.resources;
+
+import dk.trustworks.intranet.expenseservice.model.Expense;
+import dk.trustworks.intranet.expenseservice.model.UserAccount;
+import dk.trustworks.intranet.expenseservice.services.EconomicsService;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@QuarkusTest
+class ExpenseEconomicsResendResourceTest {
+
+    @InjectMock EconomicsService economicsService;
+
+    private String seedPosted() {
+        String user = "user-" + UUID.randomUUID();
+        QuarkusTransaction.requiringNew().run(() -> {
+            UserAccount ua = new UserAccount();
+            ua.setUseruuid(user);
+            ua.setEconomics(24649);
+            ua.setUsername("ext_test");
+            ua.persist();
+        });
+        Expense e = new Expense();
+        e.setUuid(UUID.randomUUID().toString());
+        e.setUseruuid(user);
+        e.setAccount("3585");
+        e.setExpensedate(java.time.LocalDate.now());
+        e.setStatus("VERIFIED_UNBOOKED");
+        e.setState("POSTED");
+        e.setVouchernumber(5001);
+        e.setJournalnumber(1);
+        e.setAccountingyear("2025_6_2026");
+        QuarkusTransaction.requiringNew().run(e::persist);
+        return e.getUuid();
+    }
+
+    @Test
+    @TestSecurity(user = "accountant", roles = {"expenses:review"})
+    void resendReturnsUpdatedCount() throws Exception {
+        String uuid = seedPosted();
+        when(economicsService.sendVoucher(any(), any(), any())).thenReturn(Response.ok().build());
+
+        given()
+          .header("X-Requested-By", "accountant")
+          .contentType(MediaType.APPLICATION_JSON)
+          .body("{\"uuids\":[\"" + uuid + "\"]}")
+        .when()
+          .post("/expenses/economics/resend")
+        .then()
+          .statusCode(200)
+          .body("updated", org.hamcrest.Matchers.is(1));
+    }
+
+    @Test
+    @TestSecurity(user = "intruder", roles = {"expenses:read"})
+    void resendForbiddenWithoutReviewScope() {
+        given()
+          .header("X-Requested-By", "intruder")
+          .contentType(MediaType.APPLICATION_JSON)
+          .body("{\"uuids\":[\"any\"]}")
+        .when()
+          .post("/expenses/economics/resend")
+        .then()
+          .statusCode(403);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsServiceIdempotencyKeyTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsServiceIdempotencyKeyTest.java
@@ -1,0 +1,45 @@
+// intranetservices/src/test/java/dk/trustworks/intranet/expenseservice/services/EconomicsServiceIdempotencyKeyTest.java
+package dk.trustworks.intranet.expenseservice.services;
+
+import dk.trustworks.intranet.expenseservice.model.Expense;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class EconomicsServiceIdempotencyKeyTest {
+
+    @Inject EconomicsService economicsService;
+
+    private Expense expense() {
+        Expense e = new Expense();
+        e.setUuid(UUID.randomUUID().toString());
+        e.setUseruuid("user-1");
+        e.setAccount("3585");
+        return e;
+    }
+
+    @Test
+    void standardKeyHasNoRetrySuffix() {
+        Expense e = expense();
+        String key = economicsService.buildIdempotencyKey(e, 1);
+        assertTrue(key.endsWith("-j1"), "standard key ends with -j{journal}: " + key);
+        assertFalse(key.contains("-retry-"), "standard key must not carry a retry suffix: " + key);
+    }
+
+    @Test
+    void orphanedPlusRetryCountProducesFreshRetryKey() {
+        Expense e = expense();
+        e.markAsOrphaned();        // re-send sets this to force a new voucher
+        e.incrementRetryCount();   // -> retryCount = 1
+        e.incrementRetryCount();   // -> retryCount = 2
+        String key = economicsService.buildIdempotencyKey(e, 1);
+        assertTrue(key.endsWith("-j1-retry-2"),
+                "orphaned + retryCount=2 must yield a fresh -retry-2 key so e-conomic creates a new voucher: " + key);
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/ExpenseDecisionLogServiceResendTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/ExpenseDecisionLogServiceResendTest.java
@@ -1,0 +1,38 @@
+// intranetservices/src/test/java/dk/trustworks/intranet/expenseservice/services/ExpenseDecisionLogServiceResendTest.java
+package dk.trustworks.intranet.expenseservice.services;
+
+import dk.trustworks.intranet.expenseservice.model.Expense;
+import dk.trustworks.intranet.expenseservice.model.ExpenseDecisionLog;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@QuarkusTest
+class ExpenseDecisionLogServiceResendTest {
+
+    @Inject ExpenseDecisionLogService logs;
+
+    @Test
+    void recordsEconomicResendRow() {
+        Expense e = new Expense();
+        e.setUuid(UUID.randomUUID().toString());
+        e.setUseruuid("user-1");
+        e.setStatus("VERIFIED_UNBOOKED");
+        e.setState("POSTED");
+
+        logs.recordEconomicResend(e, "accountant-1", "Re-sent to e-conomic: voucher 5001 -> 5042");
+
+        ExpenseDecisionLog row = QuarkusTransaction.requiringNew().call(() ->
+            ExpenseDecisionLog.find("expenseUuid = ?1 and action = ?2", e.getUuid(), "ECONOMIC_RESEND").firstResult());
+        assertNotNull(row, "an ECONOMIC_RESEND row must be written");
+        assertEquals("accountant-1", row.actorUuid);
+        assertEquals("VERIFIED_UNBOOKED", row.toStatus, "status is unchanged by re-send");
+        assertEquals("POSTED", row.toReviewState, "state is unchanged by re-send");
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/ExpenseEconomicResendKillSwitchTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/ExpenseEconomicResendKillSwitchTest.java
@@ -1,0 +1,51 @@
+package dk.trustworks.intranet.expenseservice.services;
+
+import dk.trustworks.intranet.expenseservice.model.Expense;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@QuarkusTest
+@TestProfile(ExpenseEconomicResendKillSwitchTest.UploadDisabled.class)
+class ExpenseEconomicResendKillSwitchTest {
+
+    public static class UploadDisabled implements QuarkusTestProfile {
+        @Override public Map<String, String> getConfigOverrides() {
+            return Map.of("dk.trustworks.expense.economics-upload.enabled", "false");
+        }
+    }
+
+    @Inject ExpenseEconomicResendService service;
+    @InjectMock EconomicsService economicsService;
+
+    @Test
+    void skipsWhenUploadDisabled() throws Exception {
+        Expense e = new Expense();
+        e.setUuid(UUID.randomUUID().toString());
+        e.setUseruuid("user-1");
+        e.setAccount("3585");
+        e.setStatus("VERIFIED_UNBOOKED");
+        e.setState("POSTED");
+        e.setVouchernumber(5001);
+        QuarkusTransaction.requiringNew().run(e::persist);
+
+        BadRequestException ex = assertThrows(BadRequestException.class,
+            () -> service.resendOne(e.getUuid(), "accountant-1"));
+        assertEquals("e-conomic upload disabled in this environment", ex.getMessage());
+        verify(economicsService, never()).sendVoucher(any(), any(), any());
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/ExpenseEconomicResendPrecheckTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/ExpenseEconomicResendPrecheckTest.java
@@ -1,0 +1,83 @@
+package dk.trustworks.intranet.expenseservice.services;
+
+import dk.trustworks.intranet.expenseservice.dto.ExpenseResendPrecheckDTO;
+import dk.trustworks.intranet.expenseservice.model.Expense;
+import dk.trustworks.intranet.expenseservice.model.UserAccount;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@QuarkusTest
+class ExpenseEconomicResendPrecheckTest {
+
+    @Inject ExpenseEconomicResendService service;
+    @InjectMock EconomicsService economicsService;
+
+    private Expense seedPosted() {
+        String user = "user-" + UUID.randomUUID();
+        QuarkusTransaction.requiringNew().run(() -> {
+            UserAccount ua = new UserAccount();
+            ua.setUseruuid(user);
+            ua.setEconomics(24649);
+            ua.setUsername("ext_test");
+            ua.persist();
+        });
+        Expense e = new Expense();
+        e.setUuid(UUID.randomUUID().toString());
+        e.setUseruuid(user);
+        e.setAccount("3585");
+        e.setStatus("VERIFIED_UNBOOKED");
+        e.setState("POSTED");
+        e.setVouchernumber(5001);
+        e.setJournalnumber(1);
+        e.setAccountingyear("2025_6_2026");
+        QuarkusTransaction.requiringNew().run(e::persist);
+        return e;
+    }
+
+    @Test
+    void reportsMissingWhenNeitherDraftNorBooked() {
+        Expense e = seedPosted();
+        when(economicsService.verifyVoucherExists(any())).thenReturn(false);
+        when(economicsService.voucherBookedInLedger(any())).thenReturn(false);
+
+        ExpenseResendPrecheckDTO dto = service.precheckOne(e.getUuid());
+        assertTrue(dto.eligible());
+        assertFalse(dto.voucherExists());
+        assertEquals("MISSING", dto.location());
+    }
+
+    @Test
+    void reportsBookedWhenLedgerHasIt() {
+        Expense e = seedPosted();
+        when(economicsService.verifyVoucherExists(any())).thenReturn(false);
+        when(economicsService.voucherBookedInLedger(any())).thenReturn(true);
+
+        ExpenseResendPrecheckDTO dto = service.precheckOne(e.getUuid());
+        assertTrue(dto.voucherExists());
+        assertEquals("BOOKED", dto.location());
+    }
+
+    @Test
+    void reportsIneligibleForNeverPosted() {
+        Expense e = new Expense();
+        e.setUuid(UUID.randomUUID().toString());
+        e.setUseruuid("user-x");
+        e.setAccount("3585");
+        e.setStatus("CREATED");
+        e.setState("SUBMITTED");
+        QuarkusTransaction.requiringNew().run(e::persist);
+
+        ExpenseResendPrecheckDTO dto = service.precheckOne(e.getUuid());
+        assertFalse(dto.eligible());
+        assertEquals("not posted yet", dto.reason());
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/expenseservice/services/ExpenseEconomicResendServiceTest.java
+++ b/src/test/java/dk/trustworks/intranet/expenseservice/services/ExpenseEconomicResendServiceTest.java
@@ -1,0 +1,108 @@
+package dk.trustworks.intranet.expenseservice.services;
+
+import dk.trustworks.intranet.dto.ExpenseFile;
+import dk.trustworks.intranet.expenseservice.model.Expense;
+import dk.trustworks.intranet.expenseservice.model.ExpenseDecisionLog;
+import dk.trustworks.intranet.expenseservice.model.UserAccount;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+class ExpenseEconomicResendServiceTest {
+
+    @Inject ExpenseEconomicResendService service;
+    @InjectMock EconomicsService economicsService;
+    @InjectMock ExpenseFileService expenseFileService;
+
+    private Expense seedPosted(String useruuid) {
+        Expense e = new Expense();
+        e.setUuid(UUID.randomUUID().toString());
+        e.setUseruuid(useruuid);
+        e.setAmount(250.0);
+        e.setAccount("3585");
+        e.setExpensedate(java.time.LocalDate.now());
+        e.setDatecreated(java.time.LocalDate.now());
+        e.setStatus("VERIFIED_UNBOOKED");  // posted to e-conomic
+        e.setState("POSTED");
+        e.setVouchernumber(5001);
+        e.setJournalnumber(1);
+        e.setAccountingyear("2025_6_2026");
+        QuarkusTransaction.requiringNew().run(e::persist);
+        return e;
+    }
+
+    private void seedUserAccount(String useruuid) {
+        QuarkusTransaction.requiringNew().run(() -> {
+            UserAccount ua = new UserAccount();
+            ua.setUseruuid(useruuid);
+            ua.setEconomics(24649);
+            ua.setUsername("ext_test");
+            ua.persist();
+        });
+    }
+
+    @Test
+    void resendPostsFreshVoucherWithoutChangingStatus() throws Exception {
+        String user = "user-" + UUID.randomUUID();
+        Expense e = seedPosted(user);
+        seedUserAccount(user);
+        when(expenseFileService.getFileById(e.getUuid())).thenReturn(new ExpenseFile(e.getUuid(), "BASE64"));
+        // Assert isOrphaned is TRUE at call time (proves a fresh idempotency key) + simulate the new voucher.
+        when(economicsService.sendVoucher(any(), any(), any())).thenAnswer(inv -> {
+            Expense arg = inv.getArgument(0);
+            assertTrue(Boolean.TRUE.equals(arg.getIsOrphaned()),
+                    "isOrphaned must be true when sendVoucher runs (forces a new voucher)");
+            arg.setVouchernumber(5042);
+            return Response.ok().build();
+        });
+
+        service.resendOne(e.getUuid(), "accountant-1");
+
+        Expense after = QuarkusTransaction.requiringNew().call(() -> Expense.findById(e.getUuid()));
+        assertEquals("VERIFIED_UNBOOKED", after.getStatus(), "status unchanged");
+        assertEquals("POSTED", after.getState(), "state unchanged");
+        assertEquals(5042, after.getVouchernumber(), "voucher relinked to the new voucher");
+        assertFalse(Boolean.TRUE.equals(after.getIsOrphaned()), "orphan flag cleared after success");
+        assertEquals(1, after.getSafeRetryCount(), "retry count incremented once");
+        verify(economicsService, times(1)).sendVoucher(any(), any(), any());
+
+        ExpenseDecisionLog row = QuarkusTransaction.requiringNew().call(() ->
+            ExpenseDecisionLog.find("expenseUuid = ?1 and action = ?2", e.getUuid(), "ECONOMIC_RESEND").firstResult());
+        assertNotNull(row, "audit row written");
+    }
+
+    @Test
+    void skipsExpenseNotYetPosted() throws Exception {
+        String user = "user-" + UUID.randomUUID();
+        Expense e = new Expense();
+        e.setUuid(UUID.randomUUID().toString());
+        e.setUseruuid(user);
+        e.setAccount("3585");
+        e.setExpensedate(java.time.LocalDate.now());
+        e.setStatus("CREATED");   // never posted
+        e.setState("SUBMITTED");
+        QuarkusTransaction.requiringNew().run(e::persist);
+
+        BadRequestException ex = assertThrows(BadRequestException.class,
+            () -> service.resendOne(e.getUuid(), "accountant-1"));
+        assertEquals("not posted yet", ex.getMessage());
+        verify(economicsService, never()).sendVoucher(any(), any(), any());
+    }
+
+    @Test
+    void throwsNotFoundForUnknownUuid() {
+        assertThrows(NotFoundException.class, () -> service.resendOne("does-not-exist", "accountant-1"));
+    }
+}


### PR DESCRIPTION
## Release Summary
- Expenses date-range browsing + manual e-conomic voucher re-send
- POST /expenses/economics/resend + /precheck (expenses:review)
- ExpenseEconomicResendService.resendOne (status-preserving re-post)
- EconomicsService.voucherBookedInLedger (booked-ledger existence check)
- ECONOMIC_RESEND decision-log entry
- Re-send respects the e-conomic upload kill-switch

## Pre-merge checklist
- [x] Staging QA completed
- [x] No outstanding issues on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)