### PR TITLE
Fix: conference fields JSON column boot crash + ECS rollback CI gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,3 +123,42 @@ jobs:
               {"name":"GH_TOKEN","valueFrom":"${{ vars.QUARKUS_SECRETS_ARN }}:GH_TOKEN::"},
               {"name":"VIRKDATA_API_KEY","valueFrom":"${{ vars.QUARKUS_SECRETS_ARN }}:VIRKDATA_API_KEY::"}
             ]
+
+      # Gate: the ECS Express deploy action reports success even when the canary
+      # fails to start and ECS silently rolls back to the previous task definition
+      # (e.g. a Hibernate SessionFactory build failure crashes the container at
+      # boot — which `mvn package` cannot catch). Assert the PRIMARY task is
+      # actually running the image we just pushed; otherwise fail the workflow.
+      - name: Verify deployment landed (no silent rollback)
+        run: |
+          set -euo pipefail
+          CLUSTER="${{ vars.ECS_CLUSTER }}"
+          SERVICE="tw-quarkus-staging"
+          EXPECTED_TAG="${{ github.sha }}"
+          echo "Expecting PRIMARY task to run image tag: $EXPECTED_TAG"
+          for i in $(seq 1 24); do
+            PRIMARY_TD=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" --region "$AWS_REGION" \
+              --query 'services[0].deployments[?status==`PRIMARY`]|[0].taskDefinition' --output text)
+            ROLLOUT=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" --region "$AWS_REGION" \
+              --query 'services[0].deployments[?status==`PRIMARY`]|[0].rolloutState' --output text)
+            IMAGE=$(aws ecs describe-task-definition --task-definition "$PRIMARY_TD" --region "$AWS_REGION" \
+              --query 'taskDefinition.containerDefinitions[0].image' --output text)
+            echo "attempt $i: rolloutState=$ROLLOUT image=$IMAGE"
+            if [ "$ROLLOUT" = "COMPLETED" ]; then
+              case "$IMAGE" in
+                *":$EXPECTED_TAG")
+                  echo "✅ Deployment verified: PRIMARY task is running $EXPECTED_TAG"
+                  exit 0 ;;
+                *)
+                  echo "::error::Deploy rolled back — PRIMARY image is '$IMAGE', expected tag '$EXPECTED_TAG'. The new container failed to start (check CloudWatch /aws/ecs/default/tw-quarkus-staging-* for the boot error)."
+                  exit 1 ;;
+              esac
+            fi
+            if [ "$ROLLOUT" = "FAILED" ]; then
+              echo "::error::ECS rollout FAILED for tag '$EXPECTED_TAG' — task failed to start. Check CloudWatch logs for the boot error."
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out after ~6m waiting for the PRIMARY deployment to settle."
+          exit 1

--- a/src/main/java/dk/trustworks/intranet/knowledgeservice/model/ConferenceParticipant.java
+++ b/src/main/java/dk/trustworks/intranet/knowledgeservice/model/ConferenceParticipant.java
@@ -11,8 +11,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import jakarta.persistence.*;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -38,7 +36,7 @@ public class ConferenceParticipant extends PanacheEntityBase {
     @Column(name = "marketing_consent")
     private boolean marketingConsent;
 
-    @JdbcTypeCode(SqlTypes.JSON)
+    @Convert(converter = ConferenceParticipantFieldsConverter.class)
     @Column(name = "fields")
     private Map<String, Object> fields = new LinkedHashMap<>();
 

--- a/src/main/java/dk/trustworks/intranet/knowledgeservice/model/ConferenceParticipantFieldsConverter.java
+++ b/src/main/java/dk/trustworks/intranet/knowledgeservice/model/ConferenceParticipantFieldsConverter.java
@@ -1,0 +1,54 @@
+package dk.trustworks.intranet.knowledgeservice.model;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * JPA converter for the {@code conference_participants.fields} JSON "bag" column.
+ *
+ * <p>Deliberately uses a self-contained {@link ObjectMapper} and the JPA
+ * {@link AttributeConverter} mechanism rather than {@code @JdbcTypeCode(SqlTypes.JSON)}.
+ * The application registers a custom global Jackson {@code ObjectMapperCustomizer}
+ * ({@code JavaTimeObjectMapperCustomizer}); when a JSON-typed Hibernate column is mapped
+ * with that customizer present, Quarkus refuses to build the SessionFactory at boot
+ * ("uses Quarkus' main formatting facilities for JSON columns ... Detected a customized
+ * ObjectMapper"). Converting to/from a String here sidesteps Hibernate's JSON
+ * FormatMapper entirely, so the persistence unit boots cleanly. The underlying column
+ * stays JSON/LONGTEXT.
+ */
+@Converter
+public class ConferenceParticipantFieldsConverter
+        implements AttributeConverter<Map<String, Object>, String> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final TypeReference<LinkedHashMap<String, Object>> TYPE = new TypeReference<>() {};
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        try {
+            return MAPPER.writeValueAsString(attribute);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to serialize conference participant fields bag", e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            return MAPPER.readValue(dbData, TYPE);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to deserialize conference participant fields bag", e);
+        }
+    }
+}


### PR DESCRIPTION
## Why
The merged feature (#135) **failed to deploy to staging and silently rolled back**. The new container crash-loops at boot:
```
Failed to start quarkus → Unable to build Hibernate SessionFactory
Caused by: IllegalStateException: ... uses Quarkus' main formatting facilities for JSON columns ...
  Detected 'JavaTimeObjectMapperCustomizer' bean (customized ObjectMapper)
```
`@JdbcTypeCode(SqlTypes.JSON)` on `ConferenceParticipant.fields` is the project's first JSON-mapped column; Quarkus won't build the SessionFactory for a JSON column when a custom global Jackson `ObjectMapperCustomizer` exists. `mvn package` can't catch this (runtime-only), and the deploy action reported green while ECS rolled back to the old image.

Data on staging is unaffected: V376 applied cleanly (additive); the old image safely ignores the new columns.

## Fix
1. **`ConferenceParticipantFieldsConverter`** — a self-contained JPA `AttributeConverter<Map<String,Object>,String>` (own Jackson `ObjectMapper`). The entity now uses `@Convert` instead of `@JdbcTypeCode(SqlTypes.JSON)`; the column stays JSON/LONGTEXT but bypasses Hibernate's JSON FormatMapper, so the persistence unit boots.
2. **CI gate (`deploy.yml`)** — a post-deploy step that polls ECS and **fails the workflow** unless the PRIMARY task is running the just-pushed image. Any boot failure → rollback now shows **red**, not green (closes the invisible-rollback gap).

## Verification
- `./mvnw clean test-compile` BUILD SUCCESS; unit tests 6/6 (`ContactFormMapperTest` 4, `ParticipantViewTest` 2).
- Boot can't be verified locally (no Docker; core tables are pre-Flyway baseline so an ephemeral-DB boot isn't possible) — **the new CI gate is the boot verification**: if this deploy rolls back, the workflow fails.

## Follow-up
Mirror the same post-deploy gate into `deploy-production.yml` (same invisible-rollback risk on prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)