### PR TITLE
Production release: flexible conference participant fields (+ JSON boot fix + ECS rollback gates)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -125,3 +125,42 @@ jobs:
               {"name":"GH_TOKEN","valueFrom":"${{ vars.QUARKUS_SECRETS_ARN }}:GH_TOKEN::"},
               {"name":"VIRKDATA_API_KEY","valueFrom":"${{ vars.QUARKUS_SECRETS_ARN }}:VIRKDATA_API_KEY::"}
             ]
+
+      # Gate: the ECS Express deploy action reports success even when the canary
+      # fails to start and ECS silently rolls back to the previous task definition
+      # (e.g. a Hibernate SessionFactory build failure crashes the container at
+      # boot — which `mvn package` cannot catch). Assert the PRIMARY task is
+      # actually running the image we just pushed; otherwise fail the workflow.
+      - name: Verify deployment landed (no silent rollback)
+        run: |
+          set -euo pipefail
+          CLUSTER="${{ vars.ECS_CLUSTER }}"
+          SERVICE="tw-quarkus-production"
+          EXPECTED_TAG="${{ github.sha }}"
+          echo "Expecting PRIMARY task to run image tag: $EXPECTED_TAG"
+          for i in $(seq 1 24); do
+            PRIMARY_TD=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" --region "$AWS_REGION" \
+              --query 'services[0].deployments[?status==`PRIMARY`]|[0].taskDefinition' --output text)
+            ROLLOUT=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" --region "$AWS_REGION" \
+              --query 'services[0].deployments[?status==`PRIMARY`]|[0].rolloutState' --output text)
+            IMAGE=$(aws ecs describe-task-definition --task-definition "$PRIMARY_TD" --region "$AWS_REGION" \
+              --query 'taskDefinition.containerDefinitions[0].image' --output text)
+            echo "attempt $i: rolloutState=$ROLLOUT image=$IMAGE"
+            if [ "$ROLLOUT" = "COMPLETED" ]; then
+              case "$IMAGE" in
+                *":$EXPECTED_TAG")
+                  echo "✅ Deployment verified: PRIMARY task is running $EXPECTED_TAG"
+                  exit 0 ;;
+                *)
+                  echo "::error::Deploy rolled back — PRIMARY image is '$IMAGE', expected tag '$EXPECTED_TAG'. The new container failed to start (check CloudWatch /aws/ecs/default/tw-quarkus-production-* for the boot error)."
+                  exit 1 ;;
+              esac
+            fi
+            if [ "$ROLLOUT" = "FAILED" ]; then
+              echo "::error::ECS rollout FAILED for tag '$EXPECTED_TAG' — task failed to start. Check CloudWatch logs for the boot error."
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out after ~6m waiting for the PRIMARY deployment to settle."
+          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,3 +123,42 @@ jobs:
               {"name":"GH_TOKEN","valueFrom":"${{ vars.QUARKUS_SECRETS_ARN }}:GH_TOKEN::"},
               {"name":"VIRKDATA_API_KEY","valueFrom":"${{ vars.QUARKUS_SECRETS_ARN }}:VIRKDATA_API_KEY::"}
             ]
+
+      # Gate: the ECS Express deploy action reports success even when the canary
+      # fails to start and ECS silently rolls back to the previous task definition
+      # (e.g. a Hibernate SessionFactory build failure crashes the container at
+      # boot — which `mvn package` cannot catch). Assert the PRIMARY task is
+      # actually running the image we just pushed; otherwise fail the workflow.
+      - name: Verify deployment landed (no silent rollback)
+        run: |
+          set -euo pipefail
+          CLUSTER="${{ vars.ECS_CLUSTER }}"
+          SERVICE="tw-quarkus-staging"
+          EXPECTED_TAG="${{ github.sha }}"
+          echo "Expecting PRIMARY task to run image tag: $EXPECTED_TAG"
+          for i in $(seq 1 24); do
+            PRIMARY_TD=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" --region "$AWS_REGION" \
+              --query 'services[0].deployments[?status==`PRIMARY`]|[0].taskDefinition' --output text)
+            ROLLOUT=$(aws ecs describe-services --cluster "$CLUSTER" --services "$SERVICE" --region "$AWS_REGION" \
+              --query 'services[0].deployments[?status==`PRIMARY`]|[0].rolloutState' --output text)
+            IMAGE=$(aws ecs describe-task-definition --task-definition "$PRIMARY_TD" --region "$AWS_REGION" \
+              --query 'taskDefinition.containerDefinitions[0].image' --output text)
+            echo "attempt $i: rolloutState=$ROLLOUT image=$IMAGE"
+            if [ "$ROLLOUT" = "COMPLETED" ]; then
+              case "$IMAGE" in
+                *":$EXPECTED_TAG")
+                  echo "✅ Deployment verified: PRIMARY task is running $EXPECTED_TAG"
+                  exit 0 ;;
+                *)
+                  echo "::error::Deploy rolled back — PRIMARY image is '$IMAGE', expected tag '$EXPECTED_TAG'. The new container failed to start (check CloudWatch /aws/ecs/default/tw-quarkus-staging-* for the boot error)."
+                  exit 1 ;;
+              esac
+            fi
+            if [ "$ROLLOUT" = "FAILED" ]; then
+              echo "::error::ECS rollout FAILED for tag '$EXPECTED_TAG' — task failed to start. Check CloudWatch logs for the boot error."
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out after ~6m waiting for the PRIMARY deployment to settle."
+          exit 1

--- a/src/main/java/dk/trustworks/intranet/aggregates/conference/dto/ParticipantView.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/conference/dto/ParticipantView.java
@@ -1,0 +1,56 @@
+package dk.trustworks.intranet.aggregates.conference.dto;
+
+import dk.trustworks.intranet.knowledgeservice.model.ConferenceParticipant;
+import dk.trustworks.intranet.knowledgeservice.model.ConferencePhase;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Read-side view of a conference participant. `allFields` is the uniform merge of typed
+ * columns and the JSON `fields` bag (typed columns authoritative). This is the single place
+ * the participant "shape" is assembled for the admin UI / export.
+ */
+public record ParticipantView(
+        String uuid,
+        String participantuuid,
+        String conferenceuuid,
+        String name,
+        String company,
+        String titel,
+        String email,
+        String andet,
+        boolean samtykke,
+        boolean marketingConsent,
+        ConferencePhase conferencePhase,
+        LocalDateTime registered,
+        Map<String, Object> fields,
+        Map<String, Object> allFields) {
+
+    public static ParticipantView from(ConferenceParticipant p) {
+        Map<String, Object> bag = p.getFields() != null
+                ? new LinkedHashMap<>(p.getFields())
+                : new LinkedHashMap<>();
+
+        Map<String, Object> all = new LinkedHashMap<>(bag); // bag first; typed columns overwrite below
+        putIfNotNull(all, "name", p.getName());
+        putIfNotNull(all, "company", p.getCompany());
+        putIfNotNull(all, "title", p.getTitel());
+        putIfNotNull(all, "email", p.getEmail());
+        putIfNotNull(all, "message", p.getAndet());
+        all.put("consent", p.isSamtykke());
+        all.put("marketing", p.isMarketingConsent());
+
+        return new ParticipantView(
+                p.getUuid(), p.getParticipantuuid(), p.getConferenceuuid(),
+                p.getName(), p.getCompany(), p.getTitel(), p.getEmail(), p.getAndet(),
+                p.isSamtykke(), p.isMarketingConsent(),
+                p.getConferencePhase(), p.getRegistered(),
+                bag, all);
+    }
+
+    private static void putIfNotNull(Map<String, Object> m, String k, Object v) {
+        if (v != null) m.put(k, v);
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/aggregates/conference/resources/ConferenceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/conference/resources/ConferenceResource.java
@@ -30,6 +30,7 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -348,6 +349,16 @@ public class ConferenceResource {
     public void receiveForm(@PathParam("conferenceuuid") String conferenceuuid, @FormParam("name") String name, @FormParam("company") String company, @FormParam("titel") String titel,
                             @FormParam("email") String email, @FormParam("andet") String andet, @FormParam("samtykke[0]") String samtykke) {
         createParticipant(conferenceuuid, new ConferenceParticipant(name, company, titel, email, andet, "ja".equals(samtykke)));
+    }
+
+    @POST
+    @PermitAll
+    @Path("/{conferenceuuid}/contact")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.TEXT_HTML)
+    public void receiveContactForm(@PathParam("conferenceuuid") String conferenceuuid,
+                                   MultivaluedMap<String, String> form) {
+        createParticipant(conferenceuuid, ContactFormMapper.fromForm(form));
     }
 
     @POST

--- a/src/main/java/dk/trustworks/intranet/aggregates/conference/resources/ConferenceResource.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/conference/resources/ConferenceResource.java
@@ -1,6 +1,7 @@
 package dk.trustworks.intranet.aggregates.conference.resources;
 
 import dk.trustworks.intranet.aggregates.sender.AggregateEventSender;
+import dk.trustworks.intranet.aggregates.conference.dto.ParticipantView;
 import dk.trustworks.intranet.aggregates.conference.dto.ReturningCountDTO;
 import dk.trustworks.intranet.aggregates.conference.events.ChangeParticipantPhaseEvent;
 import dk.trustworks.intranet.aggregates.conference.events.CreateParticipantEvent;
@@ -91,10 +92,9 @@ public class ConferenceResource {
 
     @GET
     @Path("/{conferenceuuid}/participants")
-    public List<ConferenceParticipant> findAllConferenceParticipants(@PathParam("conferenceuuid") String conferenceuuid) {
-        System.out.println("ConferenceResource.findAllConferenceParticipants");
-        System.out.println("conferenceuuid = " + conferenceuuid);
-        return conferenceService.findAllConferenceParticipants(conferenceuuid);
+    public List<ParticipantView> findAllConferenceParticipants(@PathParam("conferenceuuid") String conferenceuuid) {
+        return conferenceService.findAllConferenceParticipants(conferenceuuid)
+                .stream().map(ParticipantView::from).toList();
     }
 
     @GET

--- a/src/main/java/dk/trustworks/intranet/aggregates/conference/resources/ContactFormMapper.java
+++ b/src/main/java/dk/trustworks/intranet/aggregates/conference/resources/ContactFormMapper.java
@@ -1,0 +1,51 @@
+package dk.trustworks.intranet.aggregates.conference.resources;
+
+import dk.trustworks.intranet.knowledgeservice.model.ConferenceParticipant;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Maps a public contact form (English param names) onto a ConferenceParticipant:
+ * known keys become typed columns; everything else lands in the JSON {@code fields} bag.
+ * Pure (no DB / no CDI) so it is unit-testable in isolation.
+ */
+public final class ContactFormMapper {
+
+    static final Set<String> CORE =
+            Set.of("name", "email", "company", "title", "message", "consent", "marketing");
+
+    private ContactFormMapper() { }
+
+    public static ConferenceParticipant fromForm(MultivaluedMap<String, String> form) {
+        ConferenceParticipant p = new ConferenceParticipant();
+        p.setName(first(form, "name"));
+        p.setEmail(first(form, "email"));
+        p.setCompany(first(form, "company"));
+        p.setTitel(first(form, "title"));
+        p.setAndet(first(form, "message"));
+        p.setSamtykke(isChecked(first(form, "consent")));
+        p.setMarketingConsent(isChecked(first(form, "marketing")));
+
+        Map<String, Object> bag = new LinkedHashMap<>();
+        for (String key : form.keySet()) {
+            if (CORE.contains(key)) continue;
+            List<String> values = form.get(key);
+            bag.put(key, values != null && values.size() == 1 ? values.get(0) : values);
+        }
+        p.setFields(bag);
+        return p;
+    }
+
+    static String first(MultivaluedMap<String, String> form, String key) {
+        return form.getFirst(key);
+    }
+
+    static boolean isChecked(String value) {
+        return value != null
+                && Set.of("on", "ja", "true", "1", "yes").contains(value.trim().toLowerCase());
+    }
+}

--- a/src/main/java/dk/trustworks/intranet/knowledgeservice/model/ConferenceParticipant.java
+++ b/src/main/java/dk/trustworks/intranet/knowledgeservice/model/ConferenceParticipant.java
@@ -11,7 +11,11 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import jakarta.persistence.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @Data
 @NoArgsConstructor
@@ -30,6 +34,14 @@ public class ConferenceParticipant extends PanacheEntityBase {
     private String email;
     private String andet;
     private boolean samtykke;
+
+    @Column(name = "marketing_consent")
+    private boolean marketingConsent;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "fields")
+    private Map<String, Object> fields = new LinkedHashMap<>();
+
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "phaseuuid")
     private ConferencePhase conferencePhase;

--- a/src/main/java/dk/trustworks/intranet/knowledgeservice/model/ConferenceParticipant.java
+++ b/src/main/java/dk/trustworks/intranet/knowledgeservice/model/ConferenceParticipant.java
@@ -11,8 +11,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import jakarta.persistence.*;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -38,7 +36,7 @@ public class ConferenceParticipant extends PanacheEntityBase {
     @Column(name = "marketing_consent")
     private boolean marketingConsent;
 
-    @JdbcTypeCode(SqlTypes.JSON)
+    @Convert(converter = ConferenceParticipantFieldsConverter.class)
     @Column(name = "fields")
     private Map<String, Object> fields = new LinkedHashMap<>();
 

--- a/src/main/java/dk/trustworks/intranet/knowledgeservice/model/ConferenceParticipantFieldsConverter.java
+++ b/src/main/java/dk/trustworks/intranet/knowledgeservice/model/ConferenceParticipantFieldsConverter.java
@@ -1,0 +1,54 @@
+package dk.trustworks.intranet.knowledgeservice.model;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * JPA converter for the {@code conference_participants.fields} JSON "bag" column.
+ *
+ * <p>Deliberately uses a self-contained {@link ObjectMapper} and the JPA
+ * {@link AttributeConverter} mechanism rather than {@code @JdbcTypeCode(SqlTypes.JSON)}.
+ * The application registers a custom global Jackson {@code ObjectMapperCustomizer}
+ * ({@code JavaTimeObjectMapperCustomizer}); when a JSON-typed Hibernate column is mapped
+ * with that customizer present, Quarkus refuses to build the SessionFactory at boot
+ * ("uses Quarkus' main formatting facilities for JSON columns ... Detected a customized
+ * ObjectMapper"). Converting to/from a String here sidesteps Hibernate's JSON
+ * FormatMapper entirely, so the persistence unit boots cleanly. The underlying column
+ * stays JSON/LONGTEXT.
+ */
+@Converter
+public class ConferenceParticipantFieldsConverter
+        implements AttributeConverter<Map<String, Object>, String> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final TypeReference<LinkedHashMap<String, Object>> TYPE = new TypeReference<>() {};
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        try {
+            return MAPPER.writeValueAsString(attribute);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to serialize conference participant fields bag", e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            return MAPPER.readValue(dbData, TYPE);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to deserialize conference participant fields bag", e);
+        }
+    }
+}

--- a/src/main/resources/db/migration/V376__Add_marketing_consent_and_fields_to_conference_participants.sql
+++ b/src/main/resources/db/migration/V376__Add_marketing_consent_and_fields_to_conference_participants.sql
@@ -1,0 +1,4 @@
+-- Flexible participant intake: GDPR marketing opt-in (typed) + arbitrary extra fields (JSON bag).
+ALTER TABLE conference_participants
+    ADD COLUMN marketing_consent TINYINT(1) NOT NULL DEFAULT 0 AFTER samtykke,
+    ADD COLUMN fields            JSON       NULL          AFTER andet;

--- a/src/test/java/dk/trustworks/intranet/aggregates/conference/dto/ParticipantViewTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/conference/dto/ParticipantViewTest.java
@@ -1,0 +1,49 @@
+package dk.trustworks.intranet.aggregates.conference.dto;
+
+import dk.trustworks.intranet.knowledgeservice.model.ConferenceParticipant;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParticipantViewTest {
+
+    @Test
+    void mergesTypedColumnsOverBagIntoAllFields() {
+        ConferenceParticipant p = new ConferenceParticipant();
+        p.setName("Ada");
+        p.setCompany("Trustworks");
+        p.setEmail("ada@x.dk");
+        p.setSamtykke(true);
+        p.setMarketingConsent(false);
+        Map<String, Object> bag = new LinkedHashMap<>();
+        bag.put("phone", "+45 99");
+        bag.put("name", "SHOULD_BE_OVERRIDDEN"); // typed column must win
+        p.setFields(bag);
+
+        ParticipantView v = ParticipantView.from(p);
+
+        assertEquals("+45 99", v.allFields().get("phone"));
+        assertEquals("Ada", v.allFields().get("name"), "typed column authoritative over bag");
+        assertEquals(Boolean.TRUE, v.allFields().get("consent"));
+        assertEquals(Boolean.FALSE, v.allFields().get("marketing"));
+        assertEquals("+45 99", v.fields().get("phone"));
+        assertEquals("Ada", v.name());
+        assertFalse(v.marketingConsent());
+    }
+
+    @Test
+    void nullBagYieldsEmptyFieldsAndTypedAllFields() {
+        ConferenceParticipant p = new ConferenceParticipant();
+        p.setEmail("a@b.dk");
+        p.setFields(null);
+
+        ParticipantView v = ParticipantView.from(p);
+
+        assertNotNull(v.fields());
+        assertTrue(v.fields().isEmpty());
+        assertEquals("a@b.dk", v.allFields().get("email"));
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/conference/resources/ConferenceContactResourceTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/conference/resources/ConferenceContactResourceTest.java
@@ -1,0 +1,26 @@
+package dk.trustworks.intranet.aggregates.conference.resources;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+class ConferenceContactResourceTest {
+
+    @Test
+    void contactFormIsAcceptedAnonymously() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("name", "Ada")
+            .formParam("email", "ada@example.dk")
+            .formParam("company", "Trustworks")
+            .formParam("phone", "+45 11 22 33 44")
+            .formParam("consent", "on")
+        .when()
+            .post("/knowledge/conferences/{uuid}/contact", "test-conf-uuid")
+        .then()
+            .statusCode(org.hamcrest.Matchers.anyOf(
+                org.hamcrest.Matchers.is(200), org.hamcrest.Matchers.is(204)));
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/aggregates/conference/resources/ContactFormMapperTest.java
+++ b/src/test/java/dk/trustworks/intranet/aggregates/conference/resources/ContactFormMapperTest.java
@@ -1,0 +1,57 @@
+package dk.trustworks.intranet.aggregates.conference.resources;
+
+import dk.trustworks.intranet.knowledgeservice.model.ConferenceParticipant;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ContactFormMapperTest {
+
+    private static MultivaluedMap<String, String> form(String... kv) {
+        MultivaluedMap<String, String> m = new MultivaluedHashMap<>();
+        for (int i = 0; i < kv.length; i += 2) m.add(kv[i], kv[i + 1]);
+        return m;
+    }
+
+    @Test
+    void mapsCoreParamsToTypedColumns() {
+        ConferenceParticipant p = ContactFormMapper.fromForm(form(
+                "name", "Ada", "email", "ada@x.dk", "company", "Trustworks",
+                "title", "Partner", "message", "Hi", "consent", "on", "marketing", "on"));
+        assertEquals("Ada", p.getName());
+        assertEquals("ada@x.dk", p.getEmail());
+        assertEquals("Trustworks", p.getCompany());
+        assertEquals("Partner", p.getTitel());
+        assertEquals("Hi", p.getAndet());
+        assertTrue(p.isSamtykke());
+        assertTrue(p.isMarketingConsent());
+    }
+
+    @Test
+    void putsUnknownParamsIncludingPhoneInBag() {
+        ConferenceParticipant p = ContactFormMapper.fromForm(form(
+                "email", "a@b.dk", "phone", "+45 11 22 33 44", "branche", "IT"));
+        assertEquals("+45 11 22 33 44", p.getFields().get("phone"));
+        assertEquals("IT", p.getFields().get("branche"));
+        assertFalse(p.getFields().containsKey("email"), "typed key must not leak into bag");
+    }
+
+    @Test
+    void checkboxLeniencyAndDefaults() {
+        assertTrue(ContactFormMapper.fromForm(form("consent", "true")).isSamtykke());
+        assertTrue(ContactFormMapper.fromForm(form("consent", "JA")).isSamtykke());
+        assertTrue(ContactFormMapper.fromForm(form("consent", "1")).isSamtykke());
+        assertFalse(ContactFormMapper.fromForm(form("name", "X")).isSamtykke(), "absent consent -> false");
+        assertFalse(ContactFormMapper.fromForm(form("marketing", "off")).isMarketingConsent());
+    }
+
+    @Test
+    void sparseFormDoesNotThrow() {
+        ConferenceParticipant p = ContactFormMapper.fromForm(form());
+        assertNull(p.getEmail());
+        assertNotNull(p.getFields());
+        assertTrue(p.getFields().isEmpty());
+    }
+}

--- a/src/test/java/dk/trustworks/intranet/knowledgeservice/model/ConferenceParticipantFieldsTest.java
+++ b/src/test/java/dk/trustworks/intranet/knowledgeservice/model/ConferenceParticipantFieldsTest.java
@@ -1,0 +1,37 @@
+package dk.trustworks.intranet.knowledgeservice.model;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class ConferenceParticipantFieldsTest {
+
+    @Test
+    @Transactional
+    void persistsAndReadsBackFieldsAndMarketingConsent() {
+        String uuid = UUID.randomUUID().toString();
+        ConferenceParticipant p = new ConferenceParticipant();
+        p.setUuid(uuid);
+        p.setConferenceuuid("test-conf");
+        p.setEmail("a@b.dk");
+        p.setRegistered(LocalDateTime.now());
+        p.setMarketingConsent(true);
+        Map<String, Object> bag = new LinkedHashMap<>();
+        bag.put("phone", "+45 12 34 56 78");
+        p.setFields(bag);
+        p.persist();
+
+        ConferenceParticipant reloaded = ConferenceParticipant.findById(uuid);
+        assertTrue(reloaded.isMarketingConsent());
+        assertEquals("+45 12 34 56 78", reloaded.getFields().get("phone"));
+    }
+}


### PR DESCRIPTION
Promotes the conference flexible-fields feature from `staging` to production.

## Included
- **Feature** (#135): V376 migration (`marketing_consent` + `fields` JSON bag), `ContactFormMapper`, `@PermitAll /contact` endpoint, `ParticipantView` (`GET /participants` returns typed + `fields` + merged `allFields`). Existing apply endpoints unchanged (backwards compatible).
- **Boot fix** (#136): `fields` uses a JPA `AttributeConverter` instead of `@JdbcTypeCode(SqlTypes.JSON)` — required because the global custom `ObjectMapper` otherwise blocks the Hibernate SessionFactory at boot. Verified booting clean on staging (image `2728a69d`, `started in 29.8s`).
- **CI gates** (#136, #137): post-deploy ECS silent-rollback verification on both staging and production deploys.

## Prod impact
- **V376 runs on the prod DB on first boot** — additive `ALTER TABLE conference_participants ADD COLUMN` (marketing_consent NOT NULL DEFAULT 0, fields JSON NULL). Backwards compatible; old rows get defaults/NULL.
- Schema-coupled with the frontend promotion (trustworks-intranet-v3 `staging → main`) — both promote together.
- This prod deploy is gated: if the new container fails to boot and rolls back, the workflow fails red (the production gate added in #137 is on this branch).

Verified end-to-end on staging: boots clean, data consistent (V376 success, 5,059 rows intact, new cols default/NULL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)